### PR TITLE
Use slowparse for HTML problem detection

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -105,7 +105,8 @@
           {"ignoreUrls": true}
         ],
         "new-cap": [
-            2
+            2,
+            {"capIsNewExceptions": ["Slowparse.HTML"]}
         ],
         "new-parens": [
             2

--- a/README.md
+++ b/README.md
@@ -39,21 +39,6 @@ enforced style decisions are arbitrary, under the philosophy that giving
 students one right way to do it eliminates ambiguity and aids the learning
 process.
 
-#### A weird thing about HTML validation ####
-
-One strange fact about the universe is that, as far as I can tell, no
-JavaScript package exists that will tell you whether an HTML string is
-well-formed or not. So, while the editor will give plenty of feedback on
-various things about your HTML, one thing the student won’t get feedback on is
-if the HTML is totally broken. This is a problem, especially because totally
-broken HTML will probably yield some confusing second-order error.
-
-The best thing I can think of at the moment is to use the [Nu HTML
-Validator](https://github.com/validator/validator) on the server-side to do
-basic syntax checking and validation. However I would also really like to avoid
-having to go to the server (what server?) for anything, ever. In general, this
-topic merits further investigation.
-
 ### Feature roadmap ###
 
 Check out the [Trello board](https://trello.com/b/ONaFg6wh/popcode).
@@ -64,8 +49,8 @@ Popcode uses **React** to render views, **Flux** to manage application state,
 **Ace** as the code editor, and **Browserify** to package the client-side
 application.
 
-Right now, it includes **htmllint**, **css**, **PrettyCSS**, and **jshint** for
-style checking.
+Right now, it includes **slowparse**, **htmllint**, **css**, **PrettyCSS**,
+and **jshint** for error checking.
 
 The Ace editor has a built-in system for error checking, but it's really hard
 to extend, so I've disabled it. Right now the editor just synchronously runs

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Check out the [Trello board](https://trello.com/b/ONaFg6wh/popcode).
 
 ## Technical details ##
 
-Popcode uses **React** to render views, **Flux** to manage application state,
+Popcode uses **React** to render views, **Redux** to manage application state,
 **Ace** as the code editor, and **Browserify** to package the client-side
 application.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "reactify": "^1.1.1",
     "redux": "^3.0.5",
     "redux-logger": "^2.3.1",
-    "redux-thunk": "^1.0.0"
+    "redux-thunk": "^1.0.0",
+    "slowparse": "^1.1.4"
   },
   "engines": {
     "node": "4.2.x"

--- a/src/validations/html.js
+++ b/src/validations/html.js
@@ -4,15 +4,16 @@ var validateWithHtmllint = require('./html/htmllint.js');
 var validateWithSlowparse = require('./html/slowparse.js');
 
 function filterErrors(errors) {
-  var indexedErrors = lodash(errors).indexBy('reason');
+  var groupedErrors = lodash(errors).groupBy('reason');
 
-  var suppressedTypes = indexedErrors.
+  var suppressedTypes = groupedErrors.
     values().
+    flatten().
     map('suppresses').
     flatten().
     value();
 
-  return indexedErrors.omit(suppressedTypes).values().value();
+  return groupedErrors.omit(suppressedTypes).values().flatten().value();
 }
 
 module.exports = function(source) {

--- a/src/validations/html.js
+++ b/src/validations/html.js
@@ -1,10 +1,13 @@
 var Promise = require('es6-promise').Promise;
 var lodash = require('lodash');
 var validateWithHtmllint = require('./html/htmllint.js');
+var validateWithSlowparse = require('./html/slowparse.js');
 
 module.exports = function(source) {
-  return Promise.all([validateWithHtmllint(source)]).
-    then(function(results) {
-      return lodash.flatten(results);
-    });
+  return Promise.all([
+    validateWithSlowparse(source),
+    validateWithHtmllint(source),
+  ]).then(function(results) {
+    return lodash.flatten(results);
+  });
 };

--- a/src/validations/html.js
+++ b/src/validations/html.js
@@ -3,11 +3,24 @@ var lodash = require('lodash');
 var validateWithHtmllint = require('./html/htmllint.js');
 var validateWithSlowparse = require('./html/slowparse.js');
 
+function filterErrors(errors) {
+  var indexedErrors = lodash(errors).indexBy('reason');
+
+  var suppressedTypes = indexedErrors.
+    values().
+    map('suppresses').
+    flatten().
+    value();
+
+  return indexedErrors.omit(suppressedTypes).values().value();
+}
+
 module.exports = function(source) {
   return Promise.all([
     validateWithSlowparse(source),
     validateWithHtmllint(source),
   ]).then(function(results) {
-    return lodash.flatten(results);
+    var filteredErrors = filterErrors(lodash.flatten(results));
+    return lodash.sortBy(filteredErrors, 'row');
   });
 };

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -1,100 +1,101 @@
 var i18n = require('i18next-client');
 var htmllint = require('htmllint');
+var lodash = require('lodash');
 
 var humanErrors = {
   E001: function(error) {
     switch (error.data.attribute.toLowerCase()) {
       case 'align':
-        return i18n.t('errors.html.banned-attributes.align');
+        return generateAnnotation('banned-attributes.align');
       case 'background':
-        return i18n.t('errors.html.banned-attributes.background');
+        return generateAnnotation('banned-attributes.background');
       case 'bgcolor':
-        return i18n.t('errors.html.banned-attributes.bgcolor');
+        return generateAnnotation('banned-attributes.bgcolor');
       case 'border':
       case 'frameborder':
-        return i18n.t(
-          'errors.html.banned-attributes.frameborder',
+        return generateAnnotation(
+          'banned-attributes.frameborder',
           {attribute: error.data.attribute}
         );
       case 'marginwidth':
-        return i18n.t('errors.html.banned-attributes.marginwidth');
+        return generateAnnotation('banned-attributes.marginwidth');
       case 'marginheight':
-        return i18n.t('errors.html.banned-attributes.marginheight');
+        return generateAnnotation('banned-attributes.marginheight');
       case 'scrolling':
-        return i18n.t('errors.html.banned-attributes.scrolling');
+        return generateAnnotation('banned-attributes.scrolling');
       case 'width':
-        return i18n.t('errors.html.banned-attributes.width');
+        return generateAnnotation('banned-attributes.width');
     }
   },
 
   E002: function() {
-    return i18n.t('errors.html.lower-case');
+    return generateAnnotation('lower-case');
   },
 
   E005: function(error) {
-    return i18n.t(
-      'errors.html.attribute-quotes',
+    return generateAnnotation(
+      'attribute-quotes',
       {attribute: error.data.attribute}
     );
   },
 
   E006: function() {
-    return i18n.t('errors.html.attribute-value');
+    return generateAnnotation('attribute-value');
   },
 
   E007: function() {
-    return i18n.t('errors.html.doctype');
+    return generateAnnotation('doctype');
   },
 
   E008: function() {
-    return i18n.t('errors.html.doctype');
+    return generateAnnotation('doctype');
   },
 
   E012: function(error) {
-    return i18n.t('errors.html.duplicated-id', {id: error.data.id});
+    return generateAnnotation('duplicated-id', {id: error.data.id});
   },
 
   E014: function() {
-    return i18n.t('errors.html.img-src');
+    return generateAnnotation('img-src');
   },
 
   E016: function(error) {
     switch (error.data.tag.toLowerCase()) {
       case 'b':
-        return i18n.t('errors.html.deprecated-tag.b');
+        return generateAnnotation('deprecated-tag.b');
       case 'big':
-        return i18n.t('errors.html.deprecated-tag.big');
+        return generateAnnotation('deprecated-tag.big');
       case 'center':
-        return i18n.t('errors.html.deprecated-tag.center');
+        return generateAnnotation('deprecated-tag.center');
       case 'font':
-        return i18n.t('errors.html.deprecated-tag.font');
+        return generateAnnotation('deprecated-tag.font');
       case 'i':
-        return i18n.t('errors.html.deprecated-tag.i');
+        return generateAnnotation('deprecated-tag.i');
       case 'strike':
-        return i18n.t('errors.html.deprecated-tag.strike');
+        return generateAnnotation('deprecated-tag.strike');
       case 'tt':
-        return i18n.t('errors.html.deprecated-tag.tt');
+        return generateAnnotation('deprecated-tag.tt');
     }
   },
 
   E017: function() {
-    return i18n.t('errors.html.lower-case-tag-name');
+    return generateAnnotation('lower-case-tag-name');
   },
 
   E027: function() {
-    return i18n.t('errors.html.missing-title');
+    return generateAnnotation('missing-title');
   },
 
   E028: function() {
-    return i18n.t('errors.html.duplicated-title');
+    return generateAnnotation('duplicated-title');
   },
 
   E030: function() {
-    return i18n.t('errors.html.opened-tag');
+    return generateAnnotation('opened-tag');
   },
 
   E036: function() {
-    return i18n.t('errors.html.indentation');
+    return generateAnnotation('indentation');
   },
 };
 
@@ -138,15 +139,24 @@ var htmlLintOptions = {
   'title-no-dup': true,
 };
 
+function generateAnnotation(reason, properties, suppresses) {
+  var message = i18n.t('errors.html.' + reason, properties);
+  return {
+    raw: message,
+    text: message,
+    reason: reason,
+    suppresses: suppresses,
+  };
+}
+
 function convertErrorToAnnotation(error) {
   if (humanErrors.hasOwnProperty(error.code)) {
-    var message = humanErrors[error.code](error);
-    return {
+    var annotation = humanErrors[error.code](error);
+
+    return lodash.assign(annotation, {
       row: error.line - 1, column: error.column - 1,
-      raw: message,
-      text: message,
       type: 'error',
-    };
+    });
   }
 }
 

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -89,14 +89,6 @@ var humanErrors = {
   E028: function() {
     return generateAnnotation('duplicated-title');
   },
-
-  E030: function() {
-    return generateAnnotation('opened-tag');
-  },
-
-  E036: function() {
-    return generateAnnotation('indentation');
-  },
 };
 
 var htmlLintOptions = {

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -29,7 +29,7 @@ var humanErrors = {
   },
 
   E002: function() {
-    return generateAnnotation('lower-case');
+    return generateAnnotation('lower-case-attribute-name');
   },
 
   E005: function(error) {

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -24,7 +24,8 @@ var humanErrors = {
   INVALID_ATTR_NAME: function(error) {
     return generateAnnotation(
       'invalid-attribute-name',
-      {attribute: error.attribute.name.value}
+      {attribute: error.attribute.name.value},
+      ['lower-case-attribute-name']
     );
   },
 
@@ -38,14 +39,16 @@ var humanErrors = {
   UNSUPPORTED_ATTR_NAMESPACE: function(error) {
     return generateAnnotation(
       'invalid-attribute-name',
-      {attribute: error.attribute.name.value}
+      {attribute: error.attribute.name.value},
+      ['lower-case-attribute-name']
     );
   },
 
   MULTIPLE_ATTR_NAMESPACES: function(error) {
     return generateAnnotation(
       'invalid-attribute-name',
-      {attribute: error.attribute.name.value}
+      {attribute: error.attribute.name.value},
+      ['lower-case-attribute-name']
     );
   },
 
@@ -106,7 +109,8 @@ var humanErrors = {
   UNBOUND_ATTRIBUTE_VALUE: function(error) {
     return generateAnnotation(
       'unbound-attribute-value',
-      {value: error.value}
+      {value: error.value},
+      ['attribute-value', 'lower-case-attribute-name']
     );
   },
 };

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -1,120 +1,137 @@
 var i18n = require('i18next-client');
 var Slowparse = require('slowparse/src');
+var lodash = require('lodash');
 
 var humanErrors = {
   ATTRIBUTE_IN_CLOSING_TAG: function(error) {
-    return i18n.t(
-      'errors.html.attribute-in-closing-tag',
+    return generateAnnotation(
+      'attribute-in-closing-tag',
       {tag: error.closeTag.name}
     );
   },
 
   CLOSE_TAG_FOR_VOID_ELEMENT: function(error) {
-    return i18n.t(
-      'errors.html.close-tag-for-void-element',
+    return generateAnnotation(
+      'close-tag-for-void-element',
       {tag: error.closeTag.name}
     );
   },
 
   HTML_CODE_IN_CSS_BLOCK: function() {
-    return i18n.t('errors.html.html-in-css-block');
+    return generateAnnotation('html-in-css-block');
   },
 
   INVALID_ATTR_NAME: function(error) {
-    return i18n.t(
-      'errors.html.invalid-attribute-name',
+    return generateAnnotation(
+      'invalid-attribute-name',
       {attribute: error.attribute.name.value}
     );
   },
 
+  INVALID_TAG_NAME: function(error) {
+    return generateAnnotation(
+      'invalid-tag-name',
+      {tag: error.openTag.name}
+    );
+  },
+
   UNSUPPORTED_ATTR_NAMESPACE: function(error) {
-    return i18n.t(
-      'errors.html.invalid-attribute-name',
+    return generateAnnotation(
+      'invalid-attribute-name',
       {attribute: error.attribute.name.value}
     );
   },
 
   MULTIPLE_ATTR_NAMESPACES: function(error) {
-    return i18n.t(
-      'errors.html.invalid-attribute-name',
+    return generateAnnotation(
+      'invalid-attribute-name',
       {attribute: error.attribute.name.value}
     );
   },
 
   MISMATCHED_CLOSE_TAG: function(error) {
-    return i18n.t(
-      'errors.html.mismatched-close-tag',
+    return generateAnnotation(
+      'mismatched-close-tag',
       {open: error.openTag.name, close: error.closeTag.name}
     );
   },
 
   SELF_CLOSING_NON_VOID_ELEMENT: function(error) {
-    return i18n.t(
-      'errors.html.self-closing-non-void-element',
+    return generateAnnotation(
+      'self-closing-non-void-element',
       {tag: error.name}
     );
   },
 
   UNCLOSED_TAG: function(error) {
-    return i18n.t(
-      'errors.html.unclosed-tag',
+    return generateAnnotation(
+      'unclosed-tag',
       {tag: error.openTag.name}
     );
   },
 
   UNEXPECTED_CLOSE_TAG: function(error) {
-    return i18n.t(
-      'errors.html.unexpected-close-tag',
+    return generateAnnotation(
+      'unexpected-close-tag',
       {tag: error.closeTag.name}
     );
   },
 
   UNTERMINATED_ATTR_VALUE: function(error) {
-    return i18n.t(
-      'errors.html.unterminated-attribute-value',
+    return generateAnnotation(
+      'unterminated-attribute-value',
       {attribute: error.attribute.name.value, tag: error.openTag.name}
     );
   },
 
   UNTERMINATED_OPEN_TAG: function(error) {
-    return i18n.t(
-      'errors.html.unterminated-open-tag',
-      {tag: error.openTag.name}
+    return generateAnnotation(
+      'unterminated-open-tag',
+      {tag: error.openTag.name},
+      ['attribute-value', 'lower-case']
     );
   },
 
   UNTERMINATED_CLOSE_TAG: function(error) {
-    return i18n.t(
-      'errors.html.unterminated-close-tag',
+    return generateAnnotation(
+      'unterminated-close-tag',
       {tag: error.closeTag.name}
     );
   },
 
   UNTERMINATED_COMMENT: function() {
-    return i18n.t('errors.html.unterminated-comment');
+    return generateAnnotation('unterminated-comment');
   },
 
   UNBOUND_ATTRIBUTE_VALUE: function(error) {
-    return i18n.t(
-      'errors.html.unbound-attribute-value',
+    return generateAnnotation(
+      'unbound-attribute-value',
       {value: error.value}
     );
   },
 };
 
+function generateAnnotation(reason, properties, suppresses) {
+  var message = i18n.t('errors.html.' + reason, properties);
+  return {
+    raw: message,
+    text: message,
+    reason: reason,
+    suppresses: suppresses,
+  };
+}
+
 function convertErrorToAnnotation(source, error) {
   if (humanErrors.hasOwnProperty(error.type)) {
-    var message = humanErrors[error.type](error);
+    var annotation = humanErrors[error.type](error);
     var lines = source.slice(0, error.cursor).split('\n');
     var row = lines.length - 1;
     var column = lines[row].length - 1;
 
-    return {
+    return lodash.assign(annotation, {
       row: row, column: column,
-      raw: message,
-      text: message,
       type: 'error',
-    };
+    });
   }
 }
 

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -1,0 +1,131 @@
+var i18n = require('i18next-client');
+var Slowparse = require('slowparse/src');
+
+var humanErrors = {
+  ATTRIBUTE_IN_CLOSING_TAG: function(error) {
+    return i18n.t(
+      'errors.html.attribute-in-closing-tag',
+      {tag: error.closeTag.name}
+    );
+  },
+
+  CLOSE_TAG_FOR_VOID_ELEMENT: function(error) {
+    return i18n.t(
+      'errors.html.close-tag-for-void-element',
+      {tag: error.closeTag.name}
+    );
+  },
+
+  HTML_CODE_IN_CSS_BLOCK: function() {
+    return i18n.t('errors.html.html-in-css-block');
+  },
+
+  INVALID_ATTR_NAME: function(error) {
+    return i18n.t(
+      'errors.html.invalid-attribute-name',
+      {attribute: error.attribute.name.value}
+    );
+  },
+
+  UNSUPPORTED_ATTR_NAMESPACE: function(error) {
+    return i18n.t(
+      'errors.html.invalid-attribute-name',
+      {attribute: error.attribute.name.value}
+    );
+  },
+
+  MULTIPLE_ATTR_NAMESPACES: function(error) {
+    return i18n.t(
+      'errors.html.invalid-attribute-name',
+      {attribute: error.attribute.name.value}
+    );
+  },
+
+  MISMATCHED_CLOSE_TAG: function(error) {
+    return i18n.t(
+      'errors.html.mismatched-close-tag',
+      {open: error.openTag.name, close: error.closeTag.name}
+    );
+  },
+
+  SELF_CLOSING_NON_VOID_ELEMENT: function(error) {
+    return i18n.t(
+      'errors.html.self-closing-non-void-element',
+      {tag: error.name}
+    );
+  },
+
+  UNCLOSED_TAG: function(error) {
+    return i18n.t(
+      'errors.html.unclosed-tag',
+      {tag: error.openTag.name}
+    );
+  },
+
+  UNEXPECTED_CLOSE_TAG: function(error) {
+    return i18n.t(
+      'errors.html.unexpected-close-tag',
+      {tag: error.closeTag.name}
+    );
+  },
+
+  UNTERMINATED_ATTR_VALUE: function(error) {
+    return i18n.t(
+      'errors.html.unterminated-attribute-value',
+      {attribute: error.attribute.name.value, tag: error.openTag.name}
+    );
+  },
+
+  UNTERMINATED_OPEN_TAG: function(error) {
+    return i18n.t(
+      'errors.html.unterminated-open-tag',
+      {tag: error.openTag.name}
+    );
+  },
+
+  UNTERMINATED_CLOSE_TAG: function(error) {
+    return i18n.t(
+      'errors.html.unterminated-close-tag',
+      {tag: error.closeTag.name}
+    );
+  },
+
+  UNTERMINATED_COMMENT: function() {
+    return i18n.t('errors.html.unterminated-comment');
+  },
+
+  UNBOUND_ATTRIBUTE_VALUE: function(error) {
+    return i18n.t(
+      'errors.html.unbound-attribute-value',
+      {value: error.value}
+    );
+  },
+};
+
+function convertErrorToAnnotation(source, error) {
+  if (humanErrors.hasOwnProperty(error.type)) {
+    var message = humanErrors[error.type](error);
+    var lines = source.slice(0, error.cursor).split('\n');
+    var row = lines.length - 1;
+    var column = lines[row].length - 1;
+
+    return {
+      row: row, column: column,
+      raw: message,
+      text: message,
+      type: 'error',
+    };
+  }
+}
+
+module.exports = function(source) {
+  var error = Slowparse.HTML(document, source).error;
+  if (error !== null) {
+    var annotation = convertErrorToAnnotation(source, error);
+    if (annotation !== undefined) {
+      return Promise.resolve([annotation]);
+    }
+  }
+
+  return Promise.resolve([]);
+};

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -55,8 +55,6 @@
       "lower-case-tag-name": "Use lower case for tag names",
       "missing-title": "Put a <title> tag inside your <head> tag",
       "duplicated-title": "You have more than one <title> tag in your document; you should only have one",
-      "opened-tag": "You have an opening tag somewhere in the HTML that doesn't have a closing tag to match it.",
-      "indentation": "Lines should be indented with four spaces.\nUse the 'tab' key to increase indentation and the 'delete' key to decrease indentation.",
       "attribute-in-closing-tag": "You have an attribute in your closing </__tag__> tag. Attributes always belong in the opening <__tag__> tag.",
       "close-tag-for-void-element": "You don’t need a closing </__tag__> tag. The <__tag__> tag closes itself.",
       "html-in-css-block": "It looks like you typed some HTML code inside a <style> tag. Remember that only CSS code can go inside a <style> tag.",

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -56,7 +56,20 @@
       "missing-title": "Put a <title> tag inside your <head> tag",
       "duplicated-title": "You have more than one <title> tag in your document; you should only have one",
       "opened-tag": "You have an opening tag somewhere in the HTML that doesn't have a closing tag to match it.",
-      "indentation": "Lines should be indented with four spaces.\nUse the 'tab' key to increase indentation and the 'delete' key to decrease indentation."
+      "indentation": "Lines should be indented with four spaces.\nUse the 'tab' key to increase indentation and the 'delete' key to decrease indentation.",
+      "attribute-in-closing-tag": "You have an attribute in your closing </__tag__> tag. Attributes always belong in the opening <__tag__> tag.",
+      "close-tag-for-void-element": "You don’t need a closing </__tag__> tag. The <__tag__> tag closes itself.",
+      "html-in-css-block": "It looks like you typed some HTML code inside a <style> tag. Remember that only CSS code can go inside a <style> tag.",
+      "invalid-attribute-name": "__attribute__ isn’t allowed as an attribute name.",
+      "mismatched-close-tag": "Your <__open__> tag needs a closing tag, but instead there’s a </__close__> tag where the </__open__> tag should be.",
+      "self-closing-non-void-element": "A <__tag__> tag always needs a closing </__tag__> tag. Writing <__tag__/> is not allowed.",
+      "unclosed-tag": "Your <__tag__> tag needs to be closed by an </__tag__> tag.",
+      "unexpected-close-tag": "You have a closing </__tag__> tag that doesn’t match any opening <__tag__> tag.",
+      "unterminated-attribute-value": "You forgot to put quotation marks after the value of the __attribute__ attribute in the <__tag__> tag.",
+      "unterminated-open-tag": "You forgot to put a > at the end of your <__tag__> tag.",
+      "unterminated-close-tag": "You forgot to put a > at the end of your </__tag__> tag.",
+      "unterminated-comment": "You have a comment that never ends. End the comment with -->",
+      "unbound-attribute-value": "The value __value__ isn’t attached to an attribute. Are you missing an = sign?"
     },
     "javascript": {
       "unmatched": "There is a __openingSymbol__ on this line that needs a closing __closingSymbol__",

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -69,7 +69,8 @@
       "unterminated-open-tag": "You forgot to put a > at the end of your <__tag__> tag.",
       "unterminated-close-tag": "You forgot to put a > at the end of your </__tag__> tag.",
       "unterminated-comment": "You have a comment that never ends. End the comment with -->",
-      "unbound-attribute-value": "The value __value__ isn’t attached to an attribute. Are you missing an = sign?"
+      "unbound-attribute-value": "The value __value__ isn’t attached to an attribute. Are you missing an = sign?",
+      "invalid-tag-name": "<__tag__> isn’t a valid HTML tag. If you want to create a custom tag, make sure the name has a - in it, like <my-tag>"
     },
     "javascript": {
       "unmatched": "There is a __openingSymbol__ on this line that needs a closing __closingSymbol__",

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -37,7 +37,7 @@
         "scrolling": "Don't use the \"scrolling\" attribute. Instead, use the CSS overflow property",
         "width": "Don't use the \"width\" attribute. Instead, use the CSS width property"
       },
-      "lower-case": "Use lower case for attribute names",
+      "lower-case-attribute-name": "Use lower case for attribute names",
       "attribute-quotes": "You need to put the value of the __attribute__ attribute in quotation marks\nTry: __attribute__=\"myvalue\"",
       "attribute-value": "Every attribute needs a value.\nTry: myattribute=\"myvalue\"",
       "doctype": "The first line of your HTML should always be:\n<!DOCTYPE html>",


### PR DESCRIPTION
[Slowparse](https://github.com/mozilla/slowparse) is an HTML parsing library that is specifically designed to give good error feedback. Fills a big hole in our current HTML validation game.

Slowparse also does CSS and is probably worth integrating into CSS validation at some point, but current validation for CSS is reasonably comprehensive so it’s not a high priority right now.