### PR TITLE
Catch and report runtime errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 env:
   DEBUG_REDUX: false
 script:
-- npm run lint
 - npm test
 - npm run build
 env:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ]
   },
   "devDependencies": {
-    "budo": "^6.1.0",
+    "budo": "^8.0.3",
     "eslint": "^1.4.1",
     "eslint-plugin-react": "^3.3.2",
     "eslint_d": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -49,10 +49,11 @@
   },
   "scripts": {
     "start": "./node_modules/.bin/static ./static -a 0.0.0.0 -p ${PORT:-8080}",
+    "pretest": "npm run lint",
     "test": "./node_modules/.bin/jest",
     "build": "./node_modules/.bin/browserify --extension .jsx src/application.js -o static/compiled/bundle.js",
     "devserver": "./node_modules/.bin/budo src/application.js --serve compiled/bundle.js --port 8080 --dir ./static --live --cwd ./static --index static/index.html -- --extension .jsx -o static/compiled/bundle.js",
-    "lint": "./node_modules/.bin/eslint --ext .js,.jsx --plugin react src || true",
+    "lint": "./node_modules/.bin/eslint --ext .js,.jsx --plugin react src",
     "postinstall": "npm run build",
     "watchtests": "./node_modules/.bin/jest --watch"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "PrettyCSS": "^0.3.10",
+    "bowser": "^1.0.0",
     "brace": "^0.5.1",
     "brfs": "^1.4.1",
     "browserify": "^10.2.6",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -139,3 +139,10 @@ exports.loadAllProjects = function() {
     });
   };
 };
+
+exports.addRuntimeError = function(error) {
+  return {
+    type: 'RUNTIME_ERROR_ADDED',
+    payload: {error: error},
+  };
+};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -146,3 +146,9 @@ exports.addRuntimeError = function(error) {
     payload: {error: error},
   };
 };
+
+exports.clearRuntimeErrors = function() {
+  return {
+    type: 'RUNTIME_ERRORS_CLEARED',
+  };
+};

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -9,6 +9,7 @@ var Output = React.createClass({
     hasErrors: React.PropTypes.bool.isRequired,
     errors: React.PropTypes.object.isRequired,
     onErrorClicked: React.PropTypes.func.isRequired,
+    onRuntimeError: React.PropTypes.func.isRequired,
   },
 
   render: function() {
@@ -22,7 +23,10 @@ var Output = React.createClass({
     }
     if (this.props.project) {
       return (
-        <Preview project={this.props.project} />
+        <Preview
+          project={this.props.project}
+          onRuntimeError={this.props.onRuntimeError}
+        />
       );
     }
     return null;

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -10,6 +10,7 @@ var Output = React.createClass({
     errors: React.PropTypes.object.isRequired,
     onErrorClicked: React.PropTypes.func.isRequired,
     onRuntimeError: React.PropTypes.func.isRequired,
+    clearRuntimeErrors: React.PropTypes.func.isRequired,
   },
 
   render: function() {
@@ -26,6 +27,7 @@ var Output = React.createClass({
         <Preview
           project={this.props.project}
           onRuntimeError={this.props.onRuntimeError}
+          clearRuntimeErrors={this.props.clearRuntimeErrors}
         />
       );
     }

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -150,7 +150,7 @@ var Preview = React.createClass({
   },
 
   _buildFrameNode: function() {
-    if (Bowser.safari) {
+    if (Bowser.safari || Bowser.msie) {
       return <iframe className="preview-frame" ref={this._addFrameContents} />;
     }
 

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -114,13 +114,13 @@ var Preview = React.createClass({
     var firstSourceLine = this._generateDocument().
       split('\n').indexOf(sourceDelimiter) + 1;
 
-    var error = lodash.assign(
-      {},
-      data.error,
-      {line: data.error.line - firstSourceLine}
-    );
-
-    this.props.onRuntimeError(error);
+    this.props.onRuntimeError({
+      text: data.error.message,
+      raw: data.error.message,
+      row: data.error.line - firstSourceLine - 1,
+      column: data.error.column,
+      type: 'error',
+    });
   },
 
   _popOut: function() {

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,5 +1,6 @@
 var React = require('react');
 var Bowser = require('bowser');
+var lodash = require('lodash');
 
 var generatePreview = require('../util/generatePreview.js');
 
@@ -7,10 +8,17 @@ var Preview = React.createClass({
   propTypes: {
     project: React.PropTypes.object.isRequired,
     onRuntimeError: React.PropTypes.func.isRequired,
+    clearRuntimeErrors: React.PropTypes.func.isRequired,
   },
 
   componentDidMount: function() {
     window.addEventListener('message', this._onMessage);
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    if (!lodash.isEqual(nextProps.project, this.props.project)) {
+      this.props.clearRuntimeErrors();
+    }
   },
 
   componentWillUnmount: function() {

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -70,6 +70,10 @@ var Workspace = React.createClass({
     this.props.dispatch(actions.changeCurrentProject(project.projectKey));
   },
 
+  _onRuntimeError: function(error) {
+    this.props.dispatch(actions.addRuntimeError(error));
+  },
+
   render: function() {
     var environment;
     if (this.props.currentProject !== undefined) {
@@ -82,6 +86,7 @@ var Workspace = React.createClass({
               Boolean(lodash(this.props.errors).values().flatten().size())
             }
             onErrorClicked={this._onErrorClicked}
+            onRuntimeError={this._onRuntimeError}
           />
 
           <Editor

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -22,6 +22,7 @@ function mapStateToProps(state) {
     allProjects: lodash.values(state.projects.toJS()),
     currentProject: currentProjectJS,
     errors: state.errors.toJS(),
+    runtimeErrors: state.runtimeErrors.toJS(),
   };
 }
 
@@ -31,11 +32,16 @@ var Workspace = React.createClass({
     allProjects: React.PropTypes.array,
     currentProject: React.PropTypes.object,
     errors: React.PropTypes.object,
+    runtimeErrors: React.PropTypes.array,
   },
 
   componentWillMount: function() {
     this.props.dispatch(actions.loadCurrentProjectFromStorage());
     this.props.dispatch(actions.loadAllProjects());
+  },
+
+  _allJavaScriptErrors: function() {
+    return this.props.errors.javascript.concat(this.props.runtimeErrors);
   },
 
   _onErrorClicked: function(language, line, column) {
@@ -111,7 +117,7 @@ var Workspace = React.createClass({
             ref="javascriptEditor"
             projectKey={this.props.currentProject.projectKey}
             source={this.props.currentProject.sources.javascript}
-            errors={this.props.errors.javascript}
+            errors={this._allJavaScriptErrors()}
             onInput={this._onEditorInput.bind(this, 'javascript')}
             language="javascript"
           />

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -80,6 +80,10 @@ var Workspace = React.createClass({
     this.props.dispatch(actions.addRuntimeError(error));
   },
 
+  _clearRuntimeErrors: function() {
+    this.props.dispatch(actions.clearRuntimeErrors());
+  },
+
   render: function() {
     var environment;
     if (this.props.currentProject !== undefined) {
@@ -93,6 +97,7 @@ var Workspace = React.createClass({
             }
             onErrorClicked={this._onErrorClicked}
             onRuntimeError={this._onRuntimeError}
+            clearRuntimeErrors={this._clearRuntimeErrors}
           />
 
           <Editor

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,13 @@ var combineReducers = require('redux').combineReducers;
 var projects = require('./projects');
 var currentProject = require('./currentProject');
 var errors = require('./errors');
+var runtimeErrors = require('./runtimeErrors');
 
 var reducers = combineReducers({
   projects: projects,
   currentProject: currentProject,
   errors: errors,
+  runtimeErrors: runtimeErrors,
 });
 
 module.exports = reducers;

--- a/src/reducers/runtimeErrors.js
+++ b/src/reducers/runtimeErrors.js
@@ -12,6 +12,9 @@ function runtimeErrors(stateIn, action) {
     case 'RUNTIME_ERROR_ADDED':
       return state.push(Immutable.fromJS(action.payload.error));
 
+    case 'RUNTIME_ERRORS_CLEARED':
+      return emptyList;
+
     default:
       return state;
   }

--- a/src/reducers/runtimeErrors.js
+++ b/src/reducers/runtimeErrors.js
@@ -1,0 +1,20 @@
+var Immutable = require('immutable');
+
+var emptyList = new Immutable.List();
+
+function runtimeErrors(stateIn, action) {
+  var state = stateIn;
+  if (state === undefined) {
+    state = emptyList;
+  }
+
+  switch (action.type) {
+    case 'RUNTIME_ERROR_ADDED':
+      return state.push(Immutable.fromJS(action.payload.error));
+
+    default:
+      return state;
+  }
+}
+
+module.exports = runtimeErrors;

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -1,0 +1,111 @@
+var lodash = require('lodash');
+var DOMParser = window.DOMParser;
+var parser = new DOMParser();
+
+var libraries = require('../config').libraries;
+
+var sourceDelimiter = '/*__POPCODESTART__*/';
+
+function generatePreview(project) {
+  return new PreviewGenerator(project).previewDocument;
+}
+
+generatePreview.sourceDelimiter = sourceDelimiter;
+
+function PreviewGenerator(project) {
+  this._project = project;
+  this.previewDocument = parser.parseFromString(
+    project.sources.html,
+    'text/html'
+  );
+  this._previewHead = this.previewDocument.head;
+  this.previewBody = this.previewDocument.body;
+
+  this._attachLibraries();
+
+  this._addCss();
+  this._addErrorHandling();
+  this._addJavascript();
+}
+
+var errorHandlerScript = '(' + (function() {
+  window.onerror = function(fullMessage, _file, line, column, error) {
+    var name, message;
+    if (error) {
+      name = error.name;
+      message = error.message;
+    } else {
+      var components = fullMessage.split(': ', 2);
+      if (components.length === 2) {
+        name = components[0];
+        message = components[1];
+      } else {
+        name = 'Error';
+        message = fullMessage;
+      }
+    }
+
+    window.parent.postMessage(JSON.stringify({
+      type: 'org.popcode.error',
+      error: {
+        name: name,
+        message: message,
+        line: line,
+        column: column,
+      },
+    }), '*');
+  };
+}.toString()) + '());';
+
+lodash.assign(PreviewGenerator.prototype, {
+  _addCss: function() {
+    var styleTag = this.previewDocument.createElement('style');
+    styleTag.innerHTML = this._project.sources.css;
+    this._previewHead.appendChild(styleTag);
+  },
+
+  _addJavascript: function() {
+    var scriptTag = this.previewDocument.createElement('script');
+    scriptTag.innerHTML = '\n' +
+      sourceDelimiter + '\n' +
+      this._project.sources.javascript;
+    this.previewBody.appendChild(scriptTag);
+
+    return this.previewDocument.documentElement.outerHTML;
+  },
+
+  _addErrorHandling: function() {
+    var scriptTag = this.previewDocument.createElement('script');
+    scriptTag.innerHTML = errorHandlerScript;
+    this.previewBody.appendChild(scriptTag);
+  },
+
+  _attachLibraries: function() {
+    this._project.enabledLibraries.forEach(function(libraryKey) {
+      var library = libraries[libraryKey];
+      var css = library.css;
+      var javascript = library.javascript;
+      if (css !== undefined) {
+        this._attachCssLibrary(css);
+      }
+      if (javascript !== undefined) {
+        this._attachJavascriptLibrary(javascript);
+      }
+    });
+  },
+
+  _attachCssLibrary: function(css) {
+    var linkTag = this.previewDocument.createElement('link');
+    linkTag.rel = 'stylesheet';
+    linkTag.href = css;
+    this._previewHead.appendChild(linkTag);
+  },
+
+  _attachJavascriptLibrary: function(javascript) {
+    var scriptTag = this.previewDocument.createElement('script');
+    scriptTag.src = javascript;
+    this.previewBody.appendChild(scriptTag);
+  },
+});
+
+module.exports = generatePreview;


### PR DESCRIPTION
Runtime errors in JavaScript code are now propagated back to the environment via a postmessage. Currently runtime errors are only displayed as annotations in the editor; they don’t populate the error list because in the case of a runtime error we don’t want to replace the whole preview window. Instead, I’ll follow up with functionality to slide up an error list at the bottom of the preview in the case of a runtime error.

Another followup is to “translate” runtime errors into student-friendly messages. Unfortunately as far as I know there’s no better option here than simply making a bunch of regular expressions to map the matrix of error types + commonly used browsers.