### PR TITLE
More robust base64 encoding for popout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "PrettyCSS": "^0.3.10",
+    "base64-js": "^1.0.2",
     "bowser": "^1.0.0",
     "brace": "^0.5.1",
     "brfs": "^1.4.1",
@@ -42,7 +43,8 @@
     "redux": "^3.0.5",
     "redux-logger": "^2.3.1",
     "redux-thunk": "^1.0.0",
-    "slowparse": "^1.1.4"
+    "slowparse": "^1.1.4",
+    "text-encoding": "^0.5.2"
   },
   "engines": {
     "node": "4.2.x"

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,6 +1,8 @@
 var React = require('react');
 var Bowser = require('bowser');
 var lodash = require('lodash');
+var TextEncoder = require('text-encoding').TextEncoder;
+var base64 = require('base64-js');
 
 var generatePreview = require('../util/generatePreview.js');
 
@@ -73,7 +75,9 @@ var Preview = React.createClass({
 
   _popOut: function() {
     var doc = this._generateDocument();
-    var url = 'data:text/html;base64,' + btoa(doc);
+    var uint8array = new TextEncoder('utf-8').encode(doc);
+    var base64encoded = base64.fromByteArray(uint8array);
+    var url = 'data:text/html;base64,' + base64encoded;
     window.open(url, 'preview');
   },
 


### PR DESCRIPTION
Use TextEncoder polyfill and base64 polyfill to get multibyte character-friendly base64 encodings.