### PR TITLE
Fixes for incorrect HTML errors

### DIFF
--- a/src/validations/html.js
+++ b/src/validations/html.js
@@ -5,6 +5,7 @@ var flatten = require('lodash/flatten');
 var flatMap = require('lodash/flatMap');
 var sortBy = require('lodash/sortBy');
 var omit = require('lodash/omit');
+var trim = require('lodash/trim');
 var validateWithHtmllint = require('./html/htmllint.js');
 var validateWithSlowparse = require('./html/slowparse.js');
 
@@ -21,7 +22,7 @@ function filterErrors(errors) {
 
 module.exports = function(source) {
   return Promise.all([
-    validateWithSlowparse(source),
+    validateWithSlowparse(trim(source)),
     validateWithHtmllint(source),
   ]).then(function(results) {
     var filteredErrors = filterErrors(flatten(results));

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -44,7 +44,7 @@ var humanErrors = {
   },
 
   E007: function() {
-    return generateAnnotation('doctype');
+    return generateAnnotation('doctype', {}, ['invalid-tag-name']);
   },
 
   E008: function() {


### PR DESCRIPTION
* Don’t report an error if HTML begins with a line of whitespace
* Don’t report an invalid tag error if there is a tag before the DOCTYPE (this is already reported as a DOCTYPE error)