### PR TITLE
Show runtime error list docked to the bottom of the preview

### DIFF
--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -1,5 +1,7 @@
 var React = require('react');
 var ErrorSublist = require('./ErrorSublist');
+var classnames = require('classnames');
+var get = require('lodash/get');
 
 var ErrorList = React.createClass({
   propTypes: {
@@ -7,11 +9,14 @@ var ErrorList = React.createClass({
     css: React.PropTypes.array.isRequired,
     javascript: React.PropTypes.array.isRequired,
     onErrorClicked: React.PropTypes.func.isRequired,
+    docked: React.PropTypes.bool,
   },
 
   render: function() {
+    var docked = get(this, 'props.docked', false);
+
     return (
-      <div className="errorList">
+      <div className={classnames('errorList', {'errorList--docked': docked})}>
         <ErrorSublist
           language="html"
           errors={this.props.html}

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var isEmpty = require('lodash/isEmpty');
 
 var ErrorList = require('./ErrorList');
 var Preview = require('./Preview');
@@ -8,30 +9,61 @@ var Output = React.createClass({
     project: React.PropTypes.object.isRequired,
     hasErrors: React.PropTypes.bool.isRequired,
     errors: React.PropTypes.object.isRequired,
+    runtimeErrors: React.PropTypes.array.isRequired,
     onErrorClicked: React.PropTypes.func.isRequired,
     onRuntimeError: React.PropTypes.func.isRequired,
     clearRuntimeErrors: React.PropTypes.func.isRequired,
   },
 
+  _renderErrorList: function(props) {
+    return (
+      <ErrorList
+        {...props}
+        onErrorClicked={this.props.onErrorClicked}
+      />
+    );
+  },
+
+  _renderPreview: function() {
+    return (
+      <Preview
+        project={this.props.project}
+        onRuntimeError={this.props.onRuntimeError}
+        clearRuntimeErrors={this.props.clearRuntimeErrors}
+      />
+    );
+  },
+
   render: function() {
     if (this.props.hasErrors) {
       return (
-        <ErrorList
-          {...this.props.errors}
-          onErrorClicked={this.props.onErrorClicked}
-        />
+        <div className="environment-rightColumn">
+          {this._renderErrorList(this.props.errors)}
+        </div>
       );
     }
-    if (this.props.project) {
-      return (
-        <Preview
-          project={this.props.project}
-          onRuntimeError={this.props.onRuntimeError}
-          clearRuntimeErrors={this.props.clearRuntimeErrors}
-        />
-      );
+
+    if (!this.props.project) {
+      return null;
     }
-    return null;
+
+    var errorList;
+
+    if (!isEmpty(this.props.runtimeErrors)) {
+      errorList = this._renderErrorList({
+        html: [],
+        css: [],
+        javascript: this.props.runtimeErrors,
+        docked: true,
+      });
+    }
+
+    return (
+      <div className="environment-rightColumn">
+        {this._renderPreview()}
+        {errorList}
+      </div>
+    );
   },
 });
 

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -97,6 +97,7 @@ var Workspace = React.createClass({
             hasErrors={
               !isEmpty(flatten(values(this.props.errors)))
             }
+            runtimeErrors={this.props.runtimeErrors}
             onErrorClicked={this._onErrorClicked}
             onRuntimeError={this._onRuntimeError}
             clearRuntimeErrors={this._clearRuntimeErrors}

--- a/src/reducers/runtimeErrors.js
+++ b/src/reducers/runtimeErrors.js
@@ -10,7 +10,10 @@ function runtimeErrors(stateIn, action) {
 
   switch (action.type) {
     case 'RUNTIME_ERROR_ADDED':
-      return state.push(Immutable.fromJS(action.payload.error));
+      return state.push(Immutable.fromJS(action.payload.error)).
+        sortBy(function(error) {
+          return error.get('row');
+        });
 
     case 'RUNTIME_ERRORS_CLEARED':
       return emptyList;

--- a/static/application.css
+++ b/static/application.css
@@ -52,6 +52,12 @@ body {
   clear: left;
 }
 
+.environment-rightColumn {
+  float: right;
+  width: 50%;
+  position: relative;
+}
+
 .editor {
   box-sizing: border-box;
   border-right: 2px solid gray;
@@ -65,8 +71,6 @@ body {
 }
 
 .preview {
-  float: right;
-  width: 50%;
   height: 100%;
   position: relative;
 }
@@ -93,11 +97,18 @@ body {
 }
 
 .errorList {
-  float: right;
-  width: 50%;
   height: 100%;
+  width: 100%;
   position: relative;
   overflow: scroll;
+}
+
+.errorList--docked {
+  position: absolute;
+  height: auto;
+  overflow: hidden;
+  bottom: 2rem;
+  border-top: 3px solid darkgray;
 }
 
 .errorList-errorSublist-header {

--- a/static/application.css
+++ b/static/application.css
@@ -5,6 +5,10 @@ body {
 .toolbar {
   border-bottom: 1px solid darkgray;
   overflow: hidden;
+  position: absolute;
+  width: 100%;
+  z-index: 20;
+  background-color: white;
 }
 
 .toolbar-showHide {
@@ -49,7 +53,9 @@ body {
 }
 
 .environment {
-  clear: left;
+  box-sizing: border-box;
+  height: 100%;
+  padding-top: 2rem;
 }
 
 .environment-rightColumn {
@@ -107,7 +113,7 @@ body {
   position: absolute;
   height: auto;
   overflow: hidden;
-  bottom: 2rem;
+  bottom: 0;
   border-top: 3px solid darkgray;
 }
 


### PR DESCRIPTION
If a runtime error occurs, we don’t want to completely cover the preview like we do for a compilation error. Instead, slide up a list of errors docked to the bottom of the preview column.

Also changes the toolbar/menu to be absolutely positioned, which is better for the layout.