### PR TITLE
Background color for error list

### DIFF
--- a/static/application.css
+++ b/static/application.css
@@ -107,6 +107,7 @@ body {
   width: 100%;
   position: relative;
   overflow: scroll;
+  background: white;
 }
 
 .errorList--docked {
@@ -115,6 +116,7 @@ body {
   overflow: hidden;
   bottom: 0;
   border-top: 3px solid darkgray;
+  z-index: 1;
 }
 
 .errorList-errorSublist-header {


### PR DESCRIPTION
So that it completely covers page (although the page should really shrink to fit)