### PR TITLE
Friendly translations for runtime errors

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -91,6 +91,29 @@
       },
       "declare-variable": "You haven't declared __variable__.\nTry: var __variable__;",
       "duplicated-declaration": "You already declared __variable__ somewhere else."
+    },
+    "javascriptRuntime": {
+      "not-a-function_with-name": "You tried to call __name__() as a function, but __name__ is not a function.",
+
+      "not-a-function_with-name-type": "You tried to call __name__() as a function, but __name__ is a __type__, not a function.",
+
+      "not-a-function_with-name-value": "You tried to call __name__() as a function, but __name__ is __value__, which is not a function.",
+
+      "undefined-not-a-function_with-name": "You tried to call __name__() as a function, but __name__ does not have a value.",
+
+      "null-not-a-function_with-name": "You tried to call __name__() as a function, but __name__ is null.",
+
+      "access-property-of-undefined": "You are trying to access a property of something that doesn't have a value.",
+
+      "access-property-of-null": "You are trying to access a property of a null value.",
+
+      "read-property-of-undefined_with-property": "You are trying to access the property __property__ on something that doesn't have a value.",
+
+      "read-property-of-null_with-property": "You are trying to access the property __property__ on a null value.",
+
+      "set-property-of-undefined_with-property": "You are trying to set the property __property__ on something that doesn't have a value.",
+
+      "set-property-of-null_with-property": "You are trying to set the property __property__ on a null value."
     }
   }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -107,6 +107,10 @@
 
       "access-property-of-null": "You are trying to access a property of a null value.",
 
+      "access-property-of-undefined_with-name": "You are trying to access a property of __name__, but __name__ doesn't have a value.",
+
+      "access-property-of-null_with-name": "You are trying to access a property of a __name__, but __name__ is null.",
+
       "read-property-of-undefined_with-property": "You are trying to access the property __property__ on something that doesn't have a value.",
 
       "read-property-of-null_with-property": "You are trying to access the property __property__ on a null value.",

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -5,6 +5,7 @@ var TextEncoder = require('text-encoding').TextEncoder;
 var base64 = require('base64-js');
 
 var generatePreview = require('../util/generatePreview.js');
+var normalizeError = require('../util/normalizeError.js');
 
 var Preview = React.createClass({
   propTypes: {
@@ -53,9 +54,14 @@ var Preview = React.createClass({
       return;
     }
 
+    var ErrorConstructor = window[data.error.name] || Error;
+    var error = new ErrorConstructor(data.error.message);
+
+    var normalizedError = normalizeError(error);
+
     this.props.onRuntimeError({
-      text: data.error.message,
-      raw: data.error.message,
+      text: normalizedError.message,
+      raw: normalizedError.message,
       row: data.error.line - this._runtimeErrorLineOffset() - 1,
       column: data.error.column,
       type: 'error',

--- a/src/util/normalizeError.js
+++ b/src/util/normalizeError.js
@@ -61,6 +61,25 @@ var normalizers = {
       }
     },
   },
+
+  Firefox: {
+    TypeError: function(message) {
+      var match;
+
+      match = /^(\w+) is not a function$/.exec(message);
+      if (match) {
+        return {type: 'not-a-function', params: {name: match[1]}};
+      }
+
+      match = /^([\w\.]+) is (null|undefined)$/.exec(message);
+      if (match) {
+        return {
+          type: 'access-property-of-' + match[2],
+          params: {name: match[1]},
+        };
+      }
+    },
+  },
 };
 
 function attachMessage(normalizedError) {
@@ -88,7 +107,7 @@ function normalizeError(error) {
 
   return {
     type: 'unknown',
-    message: error.name + ': ' + error.message,
+    message: error.message,
   };
 }
 

--- a/src/util/normalizeError.js
+++ b/src/util/normalizeError.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-magic-numbers */
+
+var Bowser = require('bowser');
+var get = require('lodash/get');
+var keys = require('lodash/keys');
+var isEmpty = require('lodash/isEmpty');
+var assign = require('lodash/assign');
+var i18n = require('i18next-client');
+
+var normalizers = {
+  Chrome: {
+    TypeError: function(message) {
+      var match;
+
+      match = /^(\w+) is not a function$/.exec(message);
+      if (match) {
+        return {type: 'not-a-function', params: {name: match[1]}};
+      }
+
+      match = /^Cannot (read|set) property '(.+)' of (null|undefined)$/.
+        exec(message);
+      if (match) {
+        return {
+          type: match[1] + '-property-of-' + match[3],
+          params: {property: match[2]},
+        };
+      }
+    },
+  },
+
+  Safari: {
+    TypeError: function(message) {
+      var match;
+
+      match = /^(\w+) is not a function. \(In '\w+\(\)', '\w+' is (\w+|an instance of (\w+))\)$/.exec(message); // eslint-disable-line max-len
+
+      if (match) {
+        if (match[3]) {
+          return {
+            type: 'not-a-function',
+            params: {name: match[1], type: match[3]},
+          };
+        }
+
+        if (match[2] === 'undefined' || match[2] === 'null') {
+          return {
+            type: match[2] + '-not-a-function',
+            params: {name: match[1]},
+          };
+        }
+
+        return {
+          type: 'not-a-function',
+          params: {name: match[1], value: match[2]},
+        };
+      }
+
+      match = /^(null|undefined) is not an object \(.*\)$/.exec(message);
+      if (match) {
+        return {type: 'access-property-of-' + match[1]};
+      }
+    },
+  },
+};
+
+function attachMessage(normalizedError) {
+  var context;
+  if (!isEmpty(normalizedError.params)) {
+    context = 'with-' + keys(normalizedError.params).sort().join('-');
+  }
+
+  return assign(normalizedError, {
+    message: i18n.t(
+      'errors.javascriptRuntime.' + normalizedError.type,
+      assign({context: context}, normalizedError.params)
+    ),
+  });
+}
+
+function normalizeError(error) {
+  var normalizer = get(normalizers, [Bowser.name, error.name]);
+  if (normalizer !== undefined) {
+    var normalizedError = normalizer(error.message);
+    if (normalizedError !== undefined) {
+      return attachMessage(normalizedError);
+    }
+  }
+
+  return {
+    type: 'unknown',
+    message: error.name + ': ' + error.message,
+  };
+}
+
+module.exports = normalizeError;

--- a/static/application.css
+++ b/static/application.css
@@ -113,7 +113,8 @@ body {
 .errorList--docked {
   position: absolute;
   height: auto;
-  overflow: hidden;
+  max-height: 100%;
+  overflow: scroll;
   bottom: 0;
   border-top: 3px solid darkgray;
   z-index: 1;


### PR DESCRIPTION
Basically just covers TypeErrors caused by:

* Calling something as a function that isn’t a function
* Attempting to access a property of something that’s null or undefined

Obviously that is fairly narrow, but my intuition is that it also covers a solid majority of the actual runtime errors students would see in the wild.

Currently translates errors for Chrome, Safari, and Firefox.