### PR TITLE
Specify encoding in data URL for pop out

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -83,7 +83,7 @@ var Preview = React.createClass({
     var doc = this._generateDocument();
     var uint8array = new TextEncoder('utf-8').encode(doc);
     var base64encoded = base64.fromByteArray(uint8array);
-    var url = 'data:text/html;base64,' + base64encoded;
+    var url = 'data:text/html;charset=utf-8;base64,' + base64encoded;
     window.open(url, 'preview');
   },
 


### PR DESCRIPTION
Fixes bug where browser assumes a different encoding and renders multibyte characters incorrectly.