### PR TITLE
Nicer(?) styling for line numbers in error list

### DIFF
--- a/src/components/ErrorItem.jsx
+++ b/src/components/ErrorItem.jsx
@@ -1,5 +1,4 @@
 var React = require('react');
-var i18n = require('i18next-client');
 var partial = require('lodash/partial');
 
 var ErrorItem = React.createClass({
@@ -11,8 +10,7 @@ var ErrorItem = React.createClass({
   },
 
   render: function() {
-    var lineNumber =
-      i18n.t('errors.line-number', {number: this.props.row + 1});
+    var lineNumber = this.props.row + 1;
 
     return (
       <li

--- a/static/application.css
+++ b/static/application.css
@@ -139,3 +139,14 @@ body {
   background-color: #ffe6e6;
   cursor: pointer;
 }
+
+.errorList-error-line {
+  background-color: #802020;
+  color: white;
+  font-weight: bold;
+  font-size: 0.8em;
+  padding: 0.2em 0.5em;
+  border-radius: 25%;
+  display: inline-block;
+  margin-right: 0.5em;
+}


### PR DESCRIPTION
Instead of showing “Line X:”, put it in a little box with rounded corners.