### PR TITLE
Don’t pass bind argument to lodash map

### DIFF
--- a/src/components/LibraryPicker.jsx
+++ b/src/components/LibraryPicker.jsx
@@ -25,7 +25,7 @@ var LibraryPicker = React.createClass({
           onLibraryToggled={partial(this.props.onLibraryToggled, key)}
         />
       );
-    }, this);
+    }.bind(this));
 
     return <ul className="toolbar-menu">{libraries}</ul>;
   },


### PR DESCRIPTION
This is no longer supported in lodash 4