### PR TITLE
Add missing `this` binding

### DIFF
--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -91,7 +91,7 @@ assign(PreviewGenerator.prototype, {
       if (javascript !== undefined) {
         this._attachJavascriptLibrary(javascript);
       }
-    });
+    }.bind(this));
   },
 
   _attachCssLibrary: function(css) {


### PR DESCRIPTION
Fixes preview generation when library enabled