### PR TITLE
Improvements to the build process

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -304,7 +304,7 @@
             2
         ],
         "no-process-env": [
-            2
+            0
         ],
         "no-proto": [
             2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - CXX=g++-4.8 LOG_REDUX_ACTIONS=false
 script:
 - npm test
-- gulp build --production
+- ./node_modules/.bin/gulp build --production
 addons:
   apt:
     sources:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,8 @@
 var gulp = require('gulp');
 var concat = require('gulp-concat');
 var browserSync = require('browser-sync').create();
-var browserify = require('browserify-incremental');
+var browserify = require('browserify');
+var browserifyInc = require('browserify-incremental');
 var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var sourcemaps = require('gulp-sourcemaps');
@@ -21,6 +22,13 @@ var baseDir = 'static';
 var distDir = baseDir + '/compiled';
 var stylesheetsDir = srcDir + '/css';
 
+var browserifyImpl;
+if (gulp.env.production) {
+  browserifyImpl = browserify;
+} else {
+  browserifyImpl = browserifyInc;
+}
+
 var browserifyDone = Promise.resolve();
 
 var browserifyOpts = {
@@ -30,7 +38,7 @@ var browserifyOpts = {
 };
 
 var buildBrowserifyCompiler = memoize(function(filename) {
-  return browserify(assign(
+  return browserifyImpl(assign(
     {},
     browserifyOpts,
     {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,8 +31,12 @@ var browserifyOpts = {
 
 var buildBrowserifyCompiler = memoize(function(filename) {
   return browserify(assign(
+    {},
     browserifyOpts,
-    {entries: ['src/' + filename]}
+    {
+      entries: ['src/' + filename],
+      fullPaths: !gulp.env.production,
+    }
   ));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var cssnano = require('gulp-cssnano');
 var gutil = require('gulp-util');
 var assign = require('lodash/assign');
 var memoize = require('lodash/memoize');
-var reactify = require('reactify');
+var babelify = require('babelify');
 var brfs = require('brfs');
 var envify = require('envify');
 
@@ -25,7 +25,7 @@ var browserifyDone = Promise.resolve();
 
 var browserifyOpts = {
   extensions: ['.jsx'],
-  transform: [reactify, brfs, envify],
+  transform: [babelify, brfs, envify],
   debug: true,
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 var gulp = require('gulp');
 var concat = require('gulp-concat');
 var browserSync = require('browser-sync').create();
@@ -49,6 +51,12 @@ function buildBrowserifyStream(filename) {
   });
 }
 
+gulp.task('env', function() {
+  if (gulp.env.production) {
+    process.env.NODE_ENV = 'production';
+  }
+});
+
 gulp.task('css', function() {
   return gulp.src(stylesheetsDir + '/**/*.css').
     pipe(concat('application.css')).
@@ -59,7 +67,7 @@ gulp.task('css', function() {
     pipe(browserSync.reload({stream: true}));
 });
 
-gulp.task('js', function() {
+gulp.task('js', ['env'], function() {
   browserifyDone = buildBrowserifyStream('application.js');
   return browserifyDone;
 });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-dom": "^0.14.7",
     "react-immutable-proptypes": "^1.5.0",
     "react-redux": "^4.4.0",
-    "reactify": "^1.1.1",
     "redux": "^3.3.0",
     "redux-logger": "^2.5.0",
     "redux-thunk": "^1.0.0",
@@ -71,6 +70,8 @@
     ]
   },
   "devDependencies": {
+    "babel-preset-react": "^6.5.0",
+    "babelify": "^7.2.0",
     "browser-sync": "^2.11.1",
     "browserify-incremental": "^3.0.1",
     "disc": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -54,13 +54,6 @@
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx --plugin react src",
     "watchtests": "./node_modules/.bin/jest --watch"
   },
-  "browserify": {
-    "transform": [
-      "reactify",
-      "brfs",
-      "envify"
-    ]
-  },
   "jest": {
     "unmockedModulePathPatterns": [
       "./node_modules/immutable",

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,4 @@
 /* global process */
-/* eslint no-process-env: 0 */
 
 module.exports = {
   logReduxActions: function() {


### PR DESCRIPTION
* Sets `NODE_ENV` to production when building in Travis
* Browserify bundle function is reusable, returns a promise which can just be return value of gulp task
* Switch to Babel for JSX compilation
* Output full paths for Browserify bundle in development for disc compatibility
* Don’t use browserify-incremental when building for production