### PR TITLE
Ensure the existence of <html>, <head> and <body> elements

### DIFF
--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -42,7 +42,8 @@ class PreviewGenerator {
       project.sources.html,
       'text/html'
     );
-    this._previewHead = this.previewDocument.head;
+    this._previewHead = this._ensureElement('head');
+    this._previewBody = this._ensureElement('body');
     this.previewBody = this.previewDocument.body;
 
     this._attachLibraries();
@@ -50,6 +51,24 @@ class PreviewGenerator {
     this._addCss();
     this._addErrorHandling();
     this._addJavascript();
+  }
+
+  _ensureDocumentElement() {
+    let documentElement = this.previewDocument.documentElement;
+    if (!documentElement) {
+      documentElement = this.previewDocument.createElement('html');
+      this.previewDocument.appendChild(documentElement);
+    }
+    return documentElement;
+  }
+
+  _ensureElement(elementName) {
+    let element = this.previewDocument[elementName];
+    if (!element) {
+      element = this.previewDocument.createElement(elementName);
+      this._ensureDocumentElement().appendChild(element);
+    }
+    return element;
   }
 
   _addCss() {


### PR DESCRIPTION
When rendering preview, don’t assume that `document.documentElement`, `document.head`, and `document.body` exist—if the HTML input to the preview is malformed, they may not. So, check to see if they exist, and create them if not.

“But why would we be rendering a preview with malformed HTML?”, you may wonder. As it happens, any time the user types into the editor, the error state of the project is reset. Then validations are run, and then the error state is flipped back on based on validations. This is not great, but best tackled separately.