### PR TITLE
Use babel-jest rather than jest-babel-preprocessor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+before_install:
+  npm install -g npm@'>=3.3.12'
 deploy:
   provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ addons:
     packages:
       - g++-4.8
 before_install:
-  npm install -g npm@'>=3.8.0'
-after_install:
-  npm prune
+  - npm install -g npm@'>=3.8.0'
+  - npm prune
 deploy:
   provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ node_js:
 - '4.2.3'
 env:
   - CXX=g++-4.8 LOG_REDUX_ACTIONS=false
+cache:
+  apt: true
+  directories:
+    - node_modules
 script:
 - npm test
 - ./node_modules/.bin/gulp build --production
@@ -13,7 +17,7 @@ addons:
     packages:
       - g++-4.8
 before_install:
-  npm install -g npm@'>=3.3.12'
+  npm install -g npm@'>=3.8.0'
 deploy:
   provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
       - g++-4.8
 before_install:
   npm install -g npm@'>=3.8.0'
+after_install:
+  npm prune
 deploy:
   provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "watchtests": "./node_modules/.bin/jest --watch"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/jest-babel-preprocessor/preprocessor.js",
     "unmockedModulePathPatterns": [
       "./node_modules/immutable",
       "./node_modules/es6-promise",
@@ -75,6 +74,7 @@
   "devDependencies": {
     "babel-core": "^6.5.2",
     "babel-eslint": "^5.0.0",
+    "babel-jest": "^9.0.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
@@ -93,8 +93,7 @@
     "gulp-util": "^3.0.7",
     "immutable-devtools": "0.0.6",
     "jasmine-pit": "^2.0.2",
-    "jest-babel-preprocessor": "^0.3.0",
-    "jest-cli": "^0.8.0",
+    "jest-cli": "^0.9.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "eslint": "^2.1.0",
     "eslint-plugin-react": "^3.16.1",
     "eslint_d": "^2.4.0",
-    "estraverse-fb": "^1.3.1",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint": "^2.1.0",
     "eslint-plugin-react": "^3.16.1",
     "eslint_d": "^2.4.0",
+    "estraverse-fb": "^1.3.1",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
       "./node_modules/es6-promise",
       "./node_modules/keymirror",
       "./node_modules/lodash"
+    ],
+    "modulePathIgnorePatterns": [
+      "/node_modules/.*/package.json",
+      "/node_modules/fbjs/lib/.*\\.js",
+      "/node_modules/react/lib/.*\\.js"
     ]
   },
   "devDependencies": {

--- a/src/reducers/__tests__/currentProject-test.js
+++ b/src/reducers/__tests__/currentProject-test.js
@@ -8,7 +8,7 @@ import Immutable from 'immutable';
 const blankProject = require.requireActual('../../__test__/blank').project;
 
 describe('currentProject', () => {
-  const currentProject = require('../currentProject');
+  const currentProject = require('../currentProject').default;
 
   describe('unknown action', () => {
     const action = {type: 'BOGUS'};

--- a/src/reducers/__tests__/errors-test.js
+++ b/src/reducers/__tests__/errors-test.js
@@ -6,7 +6,7 @@ jest.dontMock('../errors');
 import Immutable from 'immutable';
 
 describe('errors', () => {
-  const errors = require('../errors');
+  const errors = require('../errors').default;
 
   describe('unknown action', () => {
     const action = {type: 'BOGUS'};

--- a/src/reducers/__tests__/projects-test.js
+++ b/src/reducers/__tests__/projects-test.js
@@ -6,7 +6,7 @@ jest.dontMock('../projects');
 import Immutable from 'immutable';
 
 describe('projects', () => {
-  const projects = require('../projects');
+  const projects = require('../projects').default;
 
   describe('unknown action', () => {
     const action = {type: 'BOGUS'};


### PR DESCRIPTION
This is the officially supported jest plugin for ES2015, and works better for module mocking.

Unfortunately `jasmine-pit` doesn’t seem to respect `this` in the latest version of `jest`, so I had to change a bunch of stuff to use lexical variables instead.