### PR TITLE
Construct debounced function only once

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -38,11 +38,13 @@ function saveCurrentProject(state) {
   return false;
 }
 
-function showErrorsAfterDebounce() {
-  return debounce((dispatch) => {
+const showErrorsAfterDebounce = (() => {
+  const debouncedDispatch = debounce((dispatch) => {
     dispatch({type: 'ERROR_DEBOUNCE_FINISHED'});
   }, 1000);
-}
+
+  return () => debouncedDispatch;
+})();
 
 function validateSource(language, source, enabledLibraries) {
   return (dispatch) => {


### PR DESCRIPTION
Fixes debounce behavior (should continue waiting as long as you are still typing)