### PR TITLE
Don't autoclose HTML tags

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -15,8 +15,6 @@ class Editor extends React.Component {
       this._editor.setValue(nextProps.source);
     }
 
-    //this disables autoclosing of HTML tags
-    this._editor.setBehavioursEnabled(false);
     this._editor.getSession().setAnnotations(nextProps.errors);
   }
 
@@ -37,9 +35,14 @@ class Editor extends React.Component {
     if (containerElement) {
       this._editor = ACE.edit(containerElement);
       this._configureSession(this._editor.getSession());
+      this._disableAutoClosing();
     } else {
       this._editor.destroy();
     }
+  }
+
+  _disableAutoClosing() {
+    this._editor.setBehavioursEnabled(false);
   }
 
   _startNewSession(source) {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -15,6 +15,8 @@ class Editor extends React.Component {
       this._editor.setValue(nextProps.source);
     }
 
+    //this disables autoclosing of HTML tags
+    this._editor.setBehavioursEnabled(false);
     this._editor.getSession().setAnnotations(nextProps.errors);
   }
 


### PR DESCRIPTION
Unfortunately, this will also disable smart indenting of HTML
(but it won't disable smart indenting of CSS or JS).

There is no fine-grained way of doing this in the version of
brace that we're using. We have to enable/disable ALL behaviours