### PR TITLE
Import from gist

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "keymirror": "^0.1.1",
     "lodash": "^4.2.1",
     "moment": "^2.11.2",
+    "qs": "^6.1.0",
     "react": "^0.14.7",
     "react-addons-update": "^0.14.7",
     "react-dom": "^0.14.7",

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -5,6 +5,7 @@ import flatten from 'lodash/flatten';
 import isEmpty from 'lodash/isEmpty';
 import bindAll from 'lodash/bindAll';
 import i18n from 'i18next-client';
+import qs from 'qs';
 
 import {
   addRuntimeError,
@@ -13,7 +14,7 @@ import {
   createProject,
   updateProjectSource,
   toggleLibrary,
-  listenForAuth,
+  bootstrap,
 } from '../actions';
 
 import Editor from './Editor';
@@ -47,15 +48,21 @@ class Workspace extends React.Component {
   }
 
   componentWillMount() {
-    this.props.dispatch(listenForAuth());
+    let gistId;
+    if (location.search) {
+      const query = qs.parse(location.search.slice(1));
+      gistId = query.gist;
+    }
+    history.replaceState({}, '', location.pathname);
+    this.props.dispatch(bootstrap({gistId}));
   }
 
   componentDidMount() {
-    window.addEventListener('beforeunload', this._confirmUnload);
+    addEventListener('beforeunload', this._confirmUnload);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('beforeunload', this._confirmUnload);
+    removeEventListener('beforeunload', this._confirmUnload);
   }
 
   _confirmUnload(event) {

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -61,6 +61,17 @@ function projects(stateIn, action) {
         newProject.set('projectKey', action.payload.projectKey)
       );
 
+    case 'PROJECT_IMPORTED':
+      return state.set(
+        action.payload.project.projectKey,
+        Immutable.fromJS(action.payload.project)
+      );
+
+    case 'CURRENT_PROJECT_CHANGED':
+      return state.filter((project, projectKey) => (
+        projectKey === action.payload.projectKey || project.has('updatedAt')
+      ));
+
     case 'RESET_WORKSPACE':
       return emptyMap;
 

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -56,6 +56,20 @@ const Gists = {
       );
     });
   },
+
+  loadFromId(gistId, user) {
+    return new Promise((resolve, reject) => {
+      const github = clientForUser(user);
+      const gist = github.getGist(gistId);
+      gist.read((err, gistData) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(gistData);
+        }
+      });
+    });
+  },
 };
 
 export default Gists;


### PR DESCRIPTION
When the `Workspace` bootstraps, it checks the query string for a `gist` parameter. If it finds one, this is passed to the `bootstrap` action, which will load the gist as the current project if an ID is present.

Also adds a nice bit of logic to the `projects` reducer which ensures we won’t hold on to an untouched project when switching away from it.