### PR TITLE
Update exported gist with import URL

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -5,7 +5,6 @@ import find from 'lodash/find';
 import filter from 'lodash/filter';
 import values from 'lodash/values';
 import map from 'lodash/map';
-import moment from 'moment';
 import FirebasePersistor from '../persistors/FirebasePersistor';
 import Gists from '../services/Gists';
 import appFirebase from '../services/appFirebase';
@@ -269,7 +268,6 @@ function importProjectFromGist(projectKey, gistData) {
         join('\n\n'),
     },
     enabledLibraries: [],
-    updatedAt: moment(gistData.updated_at).toDate().getTime(),
   };
 
   return {


### PR DESCRIPTION
When we export a gist, immediately update the description to contain an import URL for the gist. We have to do this with an update because the import URL contains an ID, and we don’t know the ID until we create it.

Unfortunately it’s not possible to update anonymously, so this functionality only works if you’re logged in.