### PR TITLE
Suppress lower-case-attribute-name error

### DIFF
--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -66,7 +66,7 @@ const humanErrors = {
   UNTERMINATED_OPEN_TAG: (error) => generateAnnotation(
     'unterminated-open-tag',
     {tag: error.openTag.name},
-    ['attribute-value', 'lower-case']
+    ['attribute-value', 'lower-case', 'lower-case-attribute-name']
   ),
 
   UNTERMINATED_CLOSE_TAG: (error) => generateAnnotation(


### PR DESCRIPTION
When there's an unterminated open tag, the next tag is
interpreted as an attribute name. This triggers an
additional HTML lint error because "<" is not a lower
case character.

We're suppressing this error to make it less
confusing for students.