### PR TITLE
Catch uncaught errors in htmllint

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "envify": "^3.4.0",
     "firebase": "^2.4.1",
     "github-api": "^0.11.2",
-    "htmllint": "^0.2.4",
+    "htmllint": "^0.3.0",
     "i18next-client": "^1.10.2",
     "immutable": "^3.7.5",
     "jshint": "^2.9.1",

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -147,4 +147,4 @@ export default (source) => htmllint(source, htmlLintOptions).then((errors) => {
     }
   });
   return annotations;
-});
+}).catch(() => []);


### PR DESCRIPTION
E.g., the input `<a>text</p>` will cause the `htmllint` promise to throw an uncaught promise error, which appears to be an internal bug.

If this happens, just return an empty list of errors (slowparse will catch it).