### PR TITLE
Make page-level elements explicitly 100% height

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -1,5 +1,13 @@
+html, body {
+  min-height: 100%;
+}
+
 body {
   font-family: Verdana;
+}
+
+#main, .layout {
+  height: 100%;
 }
 
 .layout {


### PR DESCRIPTION
Needed for Firefox