### PR TITLE
Set up Bugsnag

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bowser": "^1.0.0",
     "brace": "^0.7.0",
     "browserify": "^13.0.0",
+    "bugsnag-js": "^2.5.0",
     "bulkify": "^1.1.1",
     "classnames": "^2.1.5",
     "css": "^2.2.1",

--- a/src/application.js
+++ b/src/application.js
@@ -1,3 +1,4 @@
+import './util/Bugsnag';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Immutable from 'immutable';

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import createApplicationStore from '../createApplicationStore';
 import Workspace from './Workspace';
+import {includeStoreInBugReports} from '../util/Bugsnag';
 
 class Application extends React.Component {
   constructor() {
     super();
-    this.state = {store: createApplicationStore()};
+    const store = createApplicationStore();
+    this.state = {store};
+    includeStoreInBugReports(store);
   }
 
   render() {

--- a/src/config.js
+++ b/src/config.js
@@ -3,12 +3,15 @@
 const nodeEnv = (process.env.NODE_ENV || 'development');
 
 export default {
+  nodeEnv,
   logReduxActions: () => nodeEnv === 'development',
   stubSVGs: nodeEnv === 'test',
 
   firebaseApp: process.env.FIREBASE_APP || 'blistering-inferno-9896',
 
   feedbackUrl: 'https://gitreports.com/issue/popcodeorg/popcode',
+
+  bugsnagApiKey: '400134511e506b91ae6c24ac962af962',
 
   libraries: {
     jquery: {

--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -1,0 +1,28 @@
+import 'bugsnag-js';
+import config from '../config';
+
+const Bugsnag = window.Bugsnag.noConflict();
+Bugsnag.apiKey = config.bugsnagApiKey;
+Bugsnag.releaseStage = config.nodeEnv;
+
+function includeStoreInBugReports(store) {
+  Bugsnag.beforeNotify = (payload) => {
+    const state = store.getState();
+    if (state.user) {
+      payload.user = state.user.toJS();
+    } else {
+      payload.user = {id: 'anonymous'};
+    }
+
+    const metaData = {};
+    if (state.currentProject && state.currentProject.get('projectKey')) {
+      metaData.currentProject =
+        state.projects.get(state.currentProject.get('projectKey')).toJS();
+    }
+
+    payload.metaData = metaData;
+  };
+}
+
+export default Bugsnag;
+export {includeStoreInBugReports};


### PR DESCRIPTION
Error reporting from the client side. Particularly interesting: we can attach arbitrary payloads to the error, so we send over the current user information as well as the contents of the current project.