### PR TITLE
Deal with unexpected end of input

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -117,6 +117,7 @@
       "declare-variable": "You haven't declared __variable__.\nTry: var __variable__;",
       "duplicated-declaration": "You already declared __variable__ somewhere else.",
       "unexpected": "You typed a \"__character__\" here, but that’s not allowed in JavaScript.",
+      "end-of-input": "Looks like you’re missing something at the end of this line.",
       "tokenize-error": "This line doesn’t look like valid JavaScript.",
       "bad-invocation": "You’re trying to call something that isn’t a function."
     },

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -53,6 +53,8 @@ const errorMap = {
     });
   },
 
+  'Unexpected end of input': () => ({reason: 'end-of-input'}),
+
   'Unexpected token ILLEGAL': () => ({reason: 'tokenize-error'}),
 };
 
@@ -78,9 +80,7 @@ class EsprimaValidator extends Validator {
       try {
         const tokens = esprima.tokenize(this._source, {loc: true});
         const token = findTokenForError(error, tokens);
-        if (token) {
-          return [{error, token}];
-        }
+        return [{error, token}];
       } catch (tokenizeError) {
         return [{error: tokenizeError}];
       }

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -4,7 +4,7 @@ import castArray from 'lodash/castArray';
 import clone from 'lodash/clone';
 import compact from 'lodash/compact';
 import get from 'lodash/get';
-import {JSHINT} from 'jshint';
+import {JSHINT as jshint} from 'jshint';
 import libraries from '../../config/libraries';
 
 const jshintrc = {
@@ -125,8 +125,13 @@ class JsHintValidator extends Validator {
   }
 
   _getRawErrors() {
-    JSHINT(this._source, this._jshintOptions); // eslint-disable-line new-cap
-    const data = JSHINT.data();
+    try {
+      jshint(this._source, this._jshintOptions);
+    } catch (e) {
+      return [];
+    }
+
+    const data = jshint.data();
     return compact(castArray(data.errors));
   }
 


### PR DESCRIPTION
* Unexpected end of input can result in an uncaught error from jshint; catch it
* Also catch the "Unexpected end of input" error from esprima and surface it
* While you’re in there, just import jshint using `as` so it’s not upcase