### PR TITLE
Immediately add a timestamp to imported project

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -268,6 +268,7 @@ function importProjectFromGist(projectKey, gistData) {
         join('\n\n'),
     },
     enabledLibraries: [],
+    updatedAt: Date.now(),
   };
 
   return {


### PR DESCRIPTION
Otherwise we‘ll blow it away if you subsequently log in without modifying anything.