### PR TITLE
Fix undo behavior

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -7,6 +7,13 @@ import 'brace/mode/css';
 import 'brace/mode/javascript';
 import 'brace/theme/monokai';
 
+function createSessionWithoutWorker(source, language) {
+  const session = ACE.createEditSession(source, null);
+  session.setUseWorker(false);
+  session.setMode(`ace/mode/${language}`);
+  return session;
+}
+
 class Editor extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.projectKey !== this.props.projectKey) {
@@ -49,7 +56,7 @@ class Editor extends React.Component {
   }
 
   _startNewSession(source) {
-    const session = this._createSessionWithoutWorker(source);
+    const session = createSessionWithoutWorker(source, this.props.language);
     session.setUseWrapMode(true);
     session.on('change', () => {
       this.props.onInput(this._editor.getValue());
@@ -58,14 +65,6 @@ class Editor extends React.Component {
     this._editor.setSession(session);
     this._editor.moveCursorTo(0, 0);
     this._editor.resize();
-  }
-
-  _createSessionWithoutWorker(source) {
-    const language = this.props.language;
-    const session = ACE.createEditSession(source, null);
-    session.setUseWorker(false);
-    session.setMode(`ace/mode/${language}`);
-    return session;
   }
 
   _renderLabel() {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -49,10 +49,8 @@ class Editor extends React.Component {
   }
 
   _startNewSession(source) {
-    const language = this.props.language;
-    const session = ACE.createEditSession(source, `ace/mode/${language}`);
+    const session = this._createSessionWithoutWorker(source);
     session.setUseWrapMode(true);
-    session.setUseWorker(false);
     session.on('change', () => {
       this.props.onInput(this._editor.getValue());
     });
@@ -60,6 +58,14 @@ class Editor extends React.Component {
     this._editor.setSession(session);
     this._editor.moveCursorTo(0, 0);
     this._editor.resize();
+  }
+
+  _createSessionWithoutWorker(source) {
+    const language = this.props.language;
+    const session = ACE.createEditSession(source, null);
+    session.setUseWorker(false);
+    session.setMode(`ace/mode/${language}`);
+    return session;
   }
 
   _renderLabel() {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -49,7 +49,8 @@ class Editor extends React.Component {
   }
 
   _startNewSession(source) {
-    const session = new ACE.EditSession(source);
+    const language = this.props.language;
+    const session = ACE.createEditSession(source, `ace/mode/${language}`);
     this._configureSession(session);
     this._editor.setSession(session);
     this._editor.moveCursorTo(0, 0);

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -35,7 +35,7 @@ class Editor extends React.Component {
     if (containerElement) {
       this._editor = ACE.edit(containerElement);
       this._editor.$blockScrolling = Infinity;
-      this._configureSession(this._editor.getSession());
+      this._startNewSession(this.props.source);
       this._disableAutoClosing();
       this._editor.resize();
       this._editor.on('focus', this._editor.resize.bind(this._editor));
@@ -51,21 +51,15 @@ class Editor extends React.Component {
   _startNewSession(source) {
     const language = this.props.language;
     const session = ACE.createEditSession(source, `ace/mode/${language}`);
-    this._configureSession(session);
-    this._editor.setSession(session);
-    this._editor.moveCursorTo(0, 0);
-    this._editor.resize();
-  }
-
-  _configureSession(session) {
-    const language = this.props.language;
     session.setUseWrapMode(true);
     session.setUseWorker(false);
-    session.setMode(`ace/mode/${language}`);
     session.on('change', () => {
       this.props.onInput(this._editor.getValue());
     });
     session.setAnnotations(this.props.errors);
+    this._editor.setSession(session);
+    this._editor.moveCursorTo(0, 0);
+    this._editor.resize();
   }
 
   _renderLabel() {
@@ -84,9 +78,7 @@ class Editor extends React.Component {
       <div
         className="editors-editorContainer-editor"
         ref={this._setupEditor.bind(this)}
-      >
-        {this.props.source}
-      </div>
+      />
     );
   }
 


### PR DESCRIPTION
When the user changes projects or creates a new project, we create a new ACE session. However, using `new ace.EditSession()` gives it a blank undo manager, for some reason. `ace.createEditSession()` does basically the same thing, except it also sets up a real undo manager. Switch to using that.