### PR TITLE
Fix uncaught error on invalid CSS input; add real error

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -24,5 +24,6 @@
   },
   "src/validations/*.js": {"type": "validation"},
   "src/static/*": {"type": "static"},
-  "src/css/application.css": {"type": "stylesheet"}
+  "src/css/application.css": {"type": "stylesheet"},
+  "locales/*.json": {"type": "locale"}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -78,6 +78,7 @@
       "invalid-tag-name": "<__tag__> isn’t a valid HTML tag. If you want to create a custom tag, make sure the name has a - in it, like <my-tag>"
     },
     "css": {
+      "missing-opening-curly": "You should have a { at the end of this line.",
       "missing-closing-curly": "You have a starting { but no ending } to go with it.",
       "property-missing-colon": "Put a colon (:) between the property and the value.\nTry: color: red",
       "selector-missing": "Start every block of CSS with a selector, such as an element name or class name.\nTry: p {\n  color: red;\n}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -78,7 +78,7 @@
       "invalid-tag-name": "<__tag__> isn’t a valid HTML tag. If you want to create a custom tag, make sure the name has a - in it, like <my-tag>"
     },
     "css": {
-      "missing-curly": "You have a starting { but no ending } to go with it.",
+      "missing-closing-curly": "You have a starting { but no ending } to go with it.",
       "property-missing-colon": "Put a colon (:) between the property and the value.\nTry: color: red",
       "selector-missing": "Start every block of CSS with a selector, such as an element name or class name.\nTry: p {\n  color: red;\n}",
       "block-expected": "Start a block using { after your selector.\nTry: __error__ {",

--- a/src/validations/Validator.js
+++ b/src/validations/Validator.js
@@ -33,7 +33,7 @@ class Validator {
     if (!error) {
       if (config.warnOnDroppedErrors) {
         // eslint-disable-next-line no-console
-        console.warn('Dropped error', this._language, rawError);
+        console.warn(this.constructor.name, 'dropped error', rawError);
       }
 
       return null;

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -2,6 +2,8 @@ import Validator from '../Validator';
 import css from 'css';
 
 const errorMap = {
+  'missing \'{\'': () => ({reason: 'missing-opening-curly'}),
+
   'missing \'}\'': () => ({reason: 'missing-closing-curly'}),
 
   'property missing \':\'': () => ({

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -2,11 +2,11 @@ import Validator from '../Validator';
 import css from 'css';
 
 const errorMap = {
-  'missing \'}\'': () => ({reason: 'missing-curly'}),
+  'missing \'}\'': () => ({reason: 'missing-closing-curly'}),
 
   'property missing \':\'': () => ({
     reason: 'property-missing-colon',
-    suppresses: ['invalid-token', 'missing-curly'],
+    suppresses: ['invalid-token', 'missing-closing-curly'],
   }),
 
   'selector missing': () => ({

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -54,8 +54,12 @@ class PrettyCssValidator extends Validator {
   }
 
   _getRawErrors() {
-    const result = prettyCSS.parse(this._source);
-    return result.errors.concat(result.warnings);
+    try {
+      const result = prettyCSS.parse(this._source);
+      return result.errors.concat(result.warnings);
+    } catch (_e) {
+      return [];
+    }
   }
 
   _keyForError(error) {


### PR DESCRIPTION
* CSS input that ends with a comma causes PrettyCSS to throw an uncaught error. Catch uncaught errors.
* The same input generates a usable lint error from `css`. Map it.