### PR TITLE
Stricter React linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -495,9 +495,31 @@
             2,
             "never"
         ],
+        "react/jsx-equals-spacing": [
+          2,
+          "never"
+        ],
+        "react/jsx-first-prop-new-line": [
+          2,
+          "multiline"
+        ],
+        "react/jsx-handler-names": [
+          2,
+          {"eventHandlerPrefix": "_handle"}
+        ],
+        "react/jsx-indent": [
+          2,
+          2
+        ],
         "react/jsx-indent-props": [
             2,
             2
+        ],
+        "react/jsx-key": [
+          2
+        ],
+        "react/jsx-no-bind": [
+          2
         ],
         "react/jsx-no-duplicate-props": [
             2
@@ -505,11 +527,25 @@
         "react/jsx-no-undef": [
             2
         ],
+        "react/jsx-sort-props": [
+          2,
+          {
+            "callbacksLast": true,
+            "shorthandFirst": true
+          }
+        ],
+        "react/jsx-space-before-closing": [
+          2,
+          "always"
+        ],
         "react/jsx-uses-react": [
             2
         ],
         "react/jsx-uses-vars": [
             2
+        ],
+        "react/no-deprecated": [
+          2
         ],
         "react/no-did-mount-set-state": [
             2
@@ -523,12 +559,21 @@
         "react/no-multi-comp": [
             2
         ],
+        "react/no-set-state": [
+          2
+        ],
+        "react/no-string-refs": [
+          2
+        ],
         "react/no-unknown-property": [
             2
         ],
         "react/prefer-es6-class": [
           2,
           "always"
+        ],
+        "react/prefer-stateless-function": [
+          2
         ],
         "react/prop-types": [
             2
@@ -539,11 +584,20 @@
         "react/require-extension": [
             2
         ],
+        "react/require-render-return": [
+          2
+        ],
         "react/self-closing-comp": [
           2
         ],
         "react/sort-comp": [
           2
+        ],
+        "react/sort-prop-types": [
+          2,
+          {
+            "callbacksLast": true
+          }
         ],
         "react/wrap-multilines": [
           2

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -15,7 +15,7 @@ class Application extends React.Component {
   render() {
     return (
       <Provider store={this.state.store}>
-        <Workspace/>
+        <Workspace />
       </Provider>
     );
   }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import i18n from 'i18next-client';
+import bindAll from 'lodash/bindAll';
 import partial from 'lodash/partial';
 import classnames from 'classnames';
 import Gists from '../services/Gists';
@@ -7,6 +8,11 @@ import ProjectList from './ProjectList';
 import LibraryPicker from './LibraryPicker';
 
 class Dashboard extends React.Component {
+  constructor() {
+    super();
+    bindAll(this, '_handleNewProject', '_handleExportGist');
+  }
+
   _renderLoginState() {
     const currentUser = this.props.currentUser;
 
@@ -66,7 +72,7 @@ class Dashboard extends React.Component {
       newProjectButton = (
         <div
           className="dashboard-menu-item dashboard-menu-item--grid"
-          onClick={this._newProject.bind(this)}
+          onClick={this._handleNewProject}
         >
           {i18n.t('dashboard.menu.new-project')}
         </div>
@@ -83,7 +89,7 @@ class Dashboard extends React.Component {
         {this._renderSubmenuToggleButton('libraryPicker', 'libraries')}
         <div
           className="dashboard-menu-item dashboard-menu-item--grid"
-          onClick={this._exportGist.bind(this)}
+          onClick={this._handleExportGist}
         >
           {i18n.t('dashboard.menu.export-gist')}
         </div>
@@ -91,11 +97,11 @@ class Dashboard extends React.Component {
     );
   }
 
-  _newProject() {
+  _handleNewProject() {
     this.props.onNewProject();
   }
 
-  _exportGist() {
+  _handleExportGist() {
     const newWindow = open('about:blank', 'gist');
 
     Gists.createFromProject(this.props.currentProject, this.props.currentUser).
@@ -117,8 +123,8 @@ class Dashboard extends React.Component {
   _renderProjects() {
     return (
       <ProjectList
-        projects={this.props.allProjects}
         currentProject={this.props.currentProject}
+        projects={this.props.allProjects}
         onProjectSelected={this.props.onProjectSelected}
       />
     );
@@ -153,16 +159,16 @@ class Dashboard extends React.Component {
 }
 
 Dashboard.propTypes = {
-  currentUser: React.PropTypes.object.isRequired,
-  currentProject: React.PropTypes.object,
-  allProjects: React.PropTypes.array.isRequired,
   activeSubmenu: React.PropTypes.string,
-  onStartLogIn: React.PropTypes.func.isRequired,
+  allProjects: React.PropTypes.array.isRequired,
+  currentProject: React.PropTypes.object,
+  currentUser: React.PropTypes.object.isRequired,
+  onLibraryToggled: React.PropTypes.func.isRequired,
   onLogOut: React.PropTypes.func.isRequired,
   onNewProject: React.PropTypes.func.isRequired,
   onProjectSelected: React.PropTypes.func.isRequired,
+  onStartLogIn: React.PropTypes.func.isRequired,
   onSubmenuToggled: React.PropTypes.func.isRequired,
-  onLibraryToggled: React.PropTypes.func.isRequired,
 };
 
 export default Dashboard;

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ACE from 'brace';
 import i18n from 'i18next-client';
+import bindAll from 'lodash/bindAll';
 
 import 'brace/mode/html';
 import 'brace/mode/css';
@@ -15,6 +16,11 @@ function createSessionWithoutWorker(source, language) {
 }
 
 class Editor extends React.Component {
+  constructor() {
+    super();
+    bindAll(this, '_resizeEditor', '_setupEditor');
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.projectKey !== this.props.projectKey) {
       this._startNewSession(nextProps.source);
@@ -38,14 +44,18 @@ class Editor extends React.Component {
     this._editor.focus();
   }
 
+  _resizeEditor() {
+    this._editor.resize();
+  }
+
   _setupEditor(containerElement) {
     if (containerElement) {
       this._editor = ACE.edit(containerElement);
       this._editor.$blockScrolling = Infinity;
       this._startNewSession(this.props.source);
       this._disableAutoClosing();
-      this._editor.resize();
-      this._editor.on('focus', this._editor.resize.bind(this._editor));
+      this._resizeEditor();
+      this._editor.on('focus', this._resizeEditor);
     } else {
       this._editor.destroy();
     }
@@ -82,7 +92,7 @@ class Editor extends React.Component {
     return (
       <div
         className="editors-editorContainer-editor"
-        ref={this._setupEditor.bind(this)}
+        ref={this._setupEditor}
       />
     );
   }
@@ -98,10 +108,10 @@ class Editor extends React.Component {
 }
 
 Editor.propTypes = {
-  projectKey: React.PropTypes.string.isRequired,
-  source: React.PropTypes.string.isRequired,
   errors: React.PropTypes.array.isRequired,
   language: React.PropTypes.string.isRequired,
+  projectKey: React.PropTypes.string.isRequired,
+  source: React.PropTypes.string.isRequired,
   onInput: React.PropTypes.func.isRequired,
   onMinimize: React.PropTypes.func.isRequired,
 };

--- a/src/components/ErrorItem.jsx
+++ b/src/components/ErrorItem.jsx
@@ -1,32 +1,28 @@
 import React from 'react';
 import partial from 'lodash/partial';
 
-class ErrorItem extends React.Component {
-  render() {
-    const lineNumber = this.props.row + 1;
-
-    return (
-      <li
-        className="errorList-error"
-        data-error-reason={this.props.reason}
-        onClick={partial(
-          this.props.onClick,
-          this.props.row,
-          this.props.column
-        )}
-      >
-        <span className="errorList-error-line">{lineNumber}</span>
-        <span className="errorList-error-message">{this.props.text}</span>
-      </li>
-    );
-  }
+function ErrorItem(props) {
+  return (
+    <li
+      className="errorList-error"
+      data-error-reason={props.reason}
+      onClick={partial(
+        props.onClick,
+        props.row,
+        props.column
+      )}
+    >
+      <span className="errorList-error-line">{props.row + 1}</span>
+      <span className="errorList-error-message">{props.text}</span>
+    </li>
+  );
 }
 
 ErrorItem.propTypes = {
-  row: React.PropTypes.number.isRequired,
   column: React.PropTypes.number.isRequired,
-  text: React.PropTypes.string.isRequired,
   reason: React.PropTypes.string.isRequired,
+  row: React.PropTypes.number.isRequired,
+  text: React.PropTypes.string.isRequired,
   onClick: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -17,17 +17,17 @@ function ErrorList(props) {
       <ErrorSublist
         errors={props.html}
         language="html"
-        onErrorClicked={props.onErrorClicked}
+        onErrorClick={props.onErrorClick}
       />
       <ErrorSublist
         errors={props.css}
         language="css"
-        onErrorClicked={props.onErrorClicked}
+        onErrorClick={props.onErrorClick}
       />
       <ErrorSublist
         errors={props.javascript}
         language="javascript"
-        onErrorClicked={props.onErrorClicked}
+        onErrorClick={props.onErrorClick}
       />
     </div>
   );
@@ -38,7 +38,7 @@ ErrorList.propTypes = {
   docked: React.PropTypes.bool,
   html: React.PropTypes.array.isRequired,
   javascript: React.PropTypes.array.isRequired,
-  onErrorClicked: React.PropTypes.func.isRequired,
+  onErrorClick: React.PropTypes.func.isRequired,
 };
 
 export default ErrorList;

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -3,44 +3,42 @@ import classnames from 'classnames';
 import get from 'lodash/get';
 import ErrorSublist from './ErrorSublist';
 
-class ErrorList extends React.Component {
-  render() {
-    const docked = get(this, 'props.docked', false);
+function ErrorList(props) {
+  const docked = get(this, 'props.docked', false);
 
-    return (
-      <div className={
-        classnames(
-          'errorList',
-          'output-item',
-          {'errorList--docked': docked, 'output-item--shrink': docked}
-        )}
-      >
-        <ErrorSublist
-          language="html"
-          errors={this.props.html}
-          onErrorClicked={this.props.onErrorClicked}
-        />
-        <ErrorSublist
-          language="css"
-          errors={this.props.css}
-          onErrorClicked={this.props.onErrorClicked}
-        />
-        <ErrorSublist
-          language="javascript"
-          errors={this.props.javascript}
-          onErrorClicked={this.props.onErrorClicked}
-        />
-      </div>
-    );
-  }
+  return (
+    <div
+      className={classnames(
+        'errorList',
+        'output-item',
+        {'errorList--docked': docked, 'output-item--shrink': docked}
+      )}
+    >
+      <ErrorSublist
+        errors={props.html}
+        language="html"
+        onErrorClicked={props.onErrorClicked}
+      />
+      <ErrorSublist
+        errors={props.css}
+        language="css"
+        onErrorClicked={props.onErrorClicked}
+      />
+      <ErrorSublist
+        errors={props.javascript}
+        language="javascript"
+        onErrorClicked={props.onErrorClicked}
+      />
+    </div>
+  );
 }
 
 ErrorList.propTypes = {
-  html: React.PropTypes.array.isRequired,
   css: React.PropTypes.array.isRequired,
+  docked: React.PropTypes.bool,
+  html: React.PropTypes.array.isRequired,
   javascript: React.PropTypes.array.isRequired,
   onErrorClicked: React.PropTypes.func.isRequired,
-  docked: React.PropTypes.bool,
 };
 
 export default ErrorList;

--- a/src/components/ErrorSublist.jsx
+++ b/src/components/ErrorSublist.jsx
@@ -4,44 +4,43 @@ import partial from 'lodash/partial';
 import i18n from 'i18next-client';
 import ErrorItem from './ErrorItem';
 
-class ErrorSublist extends React.Component {
-  render() {
-    if (this.props.errors.length === 0) {
-      return false;
-    }
-
-    const errors = map(this.props.errors, (error) => (
-      <ErrorItem {...error}
-        key={[error.reason, error.row]}
-        onClick={partial(
-          this.props.onErrorClicked,
-          this.props.language
-        )}
-      />
-    ));
-
-    const errorMessage = i18n.t(
-      'errors.notice',
-      {amount: this.props.errors.length, language: this.props.language}
-    );
-
-    return (
-      <div className="errorList-errorSublist">
-        <h2 className="errorList-errorSublist-header">
-          {errorMessage}
-        </h2>
-        <ul className="errorList-errorSublist-list">
-          {errors}
-        </ul>
-      </div>
-    );
+function ErrorSublist(props) {
+  if (props.errors.length === 0) {
+    return false;
   }
+
+  const errors = map(props.errors, (error) => (
+    <ErrorItem
+      {...error}
+      key={[error.reason, error.row]}
+      onClick={partial(
+        props.onErrorClicked,
+        props.language
+      )}
+    />
+  ));
+
+  const errorMessage = i18n.t(
+    'errors.notice',
+    {amount: props.errors.length, language: props.language}
+  );
+
+  return (
+    <div className="errorList-errorSublist">
+      <h2 className="errorList-errorSublist-header">
+        {errorMessage}
+      </h2>
+      <ul className="errorList-errorSublist-list">
+        {errors}
+      </ul>
+    </div>
+  );
 }
 
 ErrorSublist.propTypes = {
   errors: React.PropTypes.array.isRequired,
-  onErrorClicked: React.PropTypes.func.isRequired,
   language: React.PropTypes.oneOf(['html', 'css', 'javascript']).isRequired,
+  onErrorClicked: React.PropTypes.func.isRequired,
 };
 
 export default ErrorSublist;

--- a/src/components/ErrorSublist.jsx
+++ b/src/components/ErrorSublist.jsx
@@ -14,7 +14,7 @@ function ErrorSublist(props) {
       {...error}
       key={[error.reason, error.row]}
       onClick={partial(
-        props.onErrorClicked,
+        props.onErrorClick,
         props.language
       )}
     />
@@ -40,7 +40,7 @@ function ErrorSublist(props) {
 ErrorSublist.propTypes = {
   errors: React.PropTypes.array.isRequired,
   language: React.PropTypes.oneOf(['html', 'css', 'javascript']).isRequired,
-  onErrorClicked: React.PropTypes.func.isRequired,
+  onErrorClick: React.PropTypes.func.isRequired,
 };
 
 export default ErrorSublist;

--- a/src/components/LibraryPicker.jsx
+++ b/src/components/LibraryPicker.jsx
@@ -13,9 +13,9 @@ class LibraryPicker extends React.Component {
   render() {
     const libraryButtons = map(libraries, (library, key) => (
       <LibraryPickerItem
+        enabled={this._isLibraryEnabled(key)}
         key={key}
         library={library}
-        enabled={this._isLibraryEnabled(key)}
         onLibraryToggled={partial(this.props.onLibraryToggled, key)}
       />
     ));

--- a/src/components/LibraryPickerItem.jsx
+++ b/src/components/LibraryPickerItem.jsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import classnames from 'classnames';
 
-class LibraryPickerItem extends React.Component {
-  render() {
-    return (
-      <div className={classnames(
+function LibraryPickerItem(props) {
+  return (
+    <div
+      className={classnames(
         'dashboard-menu-item',
-        {'dashboard-menu-item--active': this.props.enabled}
-      )} onClick={this.props.onLibraryToggled}
-      >
-        {this.props.library.name}
-      </div>
-    );
-  }
+        {'dashboard-menu-item--active': props.enabled}
+      )} onClick={props.onLibraryToggled}
+    >
+      {props.library.name}
+    </div>
+  );
 }
 
 LibraryPickerItem.propTypes = {

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -21,8 +21,8 @@ class Output extends React.Component {
     return (
       <Preview
         project={this.props.project}
-        onRuntimeError={this.props.onRuntimeError}
         onClearRuntimeErrors={this.props.onClearRuntimeErrors}
+        onRuntimeError={this.props.onRuntimeError}
       />
     );
   }
@@ -67,14 +67,14 @@ class Output extends React.Component {
 }
 
 Output.propTypes = {
-  project: React.PropTypes.object,
-  hasErrors: React.PropTypes.bool.isRequired,
-  errors: React.PropTypes.object.isRequired,
-  runtimeErrors: React.PropTypes.array.isRequired,
   delayErrorDisplay: React.PropTypes.bool.isRequired,
+  errors: React.PropTypes.object.isRequired,
+  hasErrors: React.PropTypes.bool.isRequired,
+  project: React.PropTypes.object,
+  runtimeErrors: React.PropTypes.array.isRequired,
+  onClearRuntimeErrors: React.PropTypes.func.isRequired,
   onErrorClick: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
-  onClearRuntimeErrors: React.PropTypes.func.isRequired,
 };
 
 export default Output;

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -8,7 +8,7 @@ class Output extends React.Component {
     return (
       <ErrorList
         {...props}
-        onErrorClicked={this.props.onErrorClicked}
+        onErrorClick={this.props.onErrorClick}
       />
     );
   }
@@ -22,7 +22,7 @@ class Output extends React.Component {
       <Preview
         project={this.props.project}
         onRuntimeError={this.props.onRuntimeError}
-        clearRuntimeErrors={this.props.clearRuntimeErrors}
+        onClearRuntimeErrors={this.props.onClearRuntimeErrors}
       />
     );
   }
@@ -72,9 +72,9 @@ Output.propTypes = {
   errors: React.PropTypes.object.isRequired,
   runtimeErrors: React.PropTypes.array.isRequired,
   delayErrorDisplay: React.PropTypes.bool.isRequired,
-  onErrorClicked: React.PropTypes.func.isRequired,
+  onErrorClick: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
-  clearRuntimeErrors: React.PropTypes.func.isRequired,
+  onClearRuntimeErrors: React.PropTypes.func.isRequired,
 };
 
 export default Output;

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -37,7 +37,7 @@ class Preview extends React.Component {
         <PreviewFrame
           src={this._generateDocument()}
           onRuntimeError={this.props.onRuntimeError}
-          frameWillRefresh={this.props.clearRuntimeErrors}
+          frameWillRefresh={this.props.onClearRuntimeErrors}
         />
       </div>
     );
@@ -47,7 +47,7 @@ class Preview extends React.Component {
 Preview.propTypes = {
   project: React.PropTypes.object.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
-  clearRuntimeErrors: React.PropTypes.func.isRequired,
+  onClearRuntimeErrors: React.PropTypes.func.isRequired,
 };
 
 export default Preview;

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import {TextEncoder} from 'text-encoding';
 import base64 from 'base64-js';
+import bindAll from 'lodash/bindAll';
 
 import PreviewFrame from './PreviewFrame';
 import generatePreview from '../util/generatePreview';
 
 class Preview extends React.Component {
+  constructor() {
+    super();
+    bindAll(this, '_popOut');
+  }
+
   _generateDocument() {
     const project = this.props.project;
 
@@ -17,6 +23,10 @@ class Preview extends React.Component {
       project,
       {targetBaseTop: true, propagateErrorsToParent: true, breakLoops: true}
     ).documentElement.outerHTML;
+  }
+
+  _handlePopOutClick() {
+    this._popOut();
   }
 
   _popOut() {
@@ -32,12 +42,12 @@ class Preview extends React.Component {
       <div className="preview output-item">
         <div
           className="preview-popOutButton"
-          onClick={this._popOut.bind(this)}
+          onClick={this._handlePopOutClick}
         />
         <PreviewFrame
           src={this._generateDocument()}
+          onFrameWillRefresh={this.props.onClearRuntimeErrors}
           onRuntimeError={this.props.onRuntimeError}
-          frameWillRefresh={this.props.onClearRuntimeErrors}
         />
       </div>
     );
@@ -46,8 +56,8 @@ class Preview extends React.Component {
 
 Preview.propTypes = {
   project: React.PropTypes.object.isRequired,
-  onRuntimeError: React.PropTypes.func.isRequired,
   onClearRuntimeErrors: React.PropTypes.func.isRequired,
+  onRuntimeError: React.PropTypes.func.isRequired,
 };
 
 export default Preview;

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -10,7 +10,7 @@ import loopProtect from 'loop-protect';
 class PreviewFrame extends React.Component {
   constructor() {
     super();
-    bindAll(this, '_onMessage');
+    bindAll(this, '_onMessage', '_saveFrame');
   }
 
   componentWillMount() {
@@ -112,15 +112,15 @@ class PreviewFrame extends React.Component {
     return (
       <iframe
         className="preview-frame"
-        ref={this._saveFrame.bind(this)}
+        ref={this._saveFrame}
       />
     );
   }
 }
 
 PreviewFrame.propTypes = {
-  src: React.PropTypes.string.isRequired,
   frameWillRefresh: React.PropTypes.func.isRequired,
+  src: React.PropTypes.string.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -24,7 +24,7 @@ class PreviewFrame extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.src !== this.props.src) {
       this._writeFrameContents(nextProps.src);
-      nextProps.frameWillRefresh();
+      nextProps.onFrameWillRefresh();
     }
   }
 
@@ -119,8 +119,8 @@ class PreviewFrame extends React.Component {
 }
 
 PreviewFrame.propTypes = {
-  frameWillRefresh: React.PropTypes.func.isRequired,
   src: React.PropTypes.string.isRequired,
+  onFrameWillRefresh: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -1,48 +1,47 @@
 import React from 'react';
 import moment from 'moment';
 import classnames from 'classnames';
+import partial from 'lodash';
 import {generateTextPreview} from '../util/generatePreview';
 
 const MAX_LENGTH = 50;
 
-class ProjectList extends React.Component {
-  render() {
-    const projects = this.props.projects.map((project) => {
-      const preview = generateTextPreview(project);
-      const isSelected =
-        project.projectKey === this.props.currentProject.projectKey;
-
-      return (
-        <div
-          key={project.projectKey}
-          className={classnames(
-            'projectPreview',
-            'dashboard-menu-item',
-            {'dashboard-menu-item--active': isSelected}
-          )}
-          onClick={this.props.onProjectSelected.bind(null, project)}
-        >
-          <div className="projectPreview-timestamp">
-            {moment(project.updatedAt).fromNow()}
-          </div>
-          <div className="projectPreview-previewText">
-            {preview.slice(0, MAX_LENGTH)}
-          </div>
-        </div>
-      );
-    });
+function ProjectList(props) {
+  const projects = props.projects.map((project) => {
+    const preview = generateTextPreview(project);
+    const isSelected =
+      project.projectKey === props.currentProject.projectKey;
 
     return (
-      <div className="dashboard-menu dashboard-menu--scrollable">
-        {projects}
+      <div
+        className={classnames(
+          'projectPreview',
+          'dashboard-menu-item',
+          {'dashboard-menu-item--active': isSelected}
+        )}
+        key={project.projectKey}
+        onClick={partial(props.onProjectSelected, project)}
+      >
+        <div className="projectPreview-timestamp">
+          {moment(project.updatedAt).fromNow()}
+        </div>
+        <div className="projectPreview-previewText">
+          {preview.slice(0, MAX_LENGTH)}
+        </div>
       </div>
     );
-  }
+  });
+
+  return (
+    <div className="dashboard-menu dashboard-menu--scrollable">
+      {projects}
+    </div>
+  );
 }
 
 ProjectList.propTypes = {
-  projects: React.PropTypes.array.isRequired,
   currentProject: React.PropTypes.object.isRequired,
+  projects: React.PropTypes.array.isRequired,
   onProjectSelected: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import classnames from 'classnames';
-import partial from 'lodash';
+import partial from 'lodash/partial';
 import {generateTextPreview} from '../util/generatePreview';
 
 const MAX_LENGTH = 50;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -28,7 +28,7 @@ class Sidebar extends React.Component {
     return (
       <div className="sidebar">
         <div className="sidebar-wordmarkContainer">
-          <Isvg src="/images/wordmark-vertical.svg"/>
+          <Isvg src="/images/wordmark-vertical.svg" />
           <div
             className={classnames(
               'sidebar-arrow',

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,8 +9,8 @@ class Sidebar extends React.Component {
     const components = this.props.minimizedComponents.
       map((componentName) => (
         <div
-          key={componentName}
           className="sidebar-minimizedComponent"
+          key={componentName}
           onClick={partial(this.props.onComponentMaximized, componentName)}
         >
           {i18n.t(`workspace.components.${componentName}`)}
@@ -47,8 +47,8 @@ class Sidebar extends React.Component {
 }
 
 Sidebar.propTypes = {
-  minimizedComponents: React.PropTypes.array.isRequired,
   dashboardIsOpen: React.PropTypes.bool.isRequired,
+  minimizedComponents: React.PropTypes.array.isRequired,
   onComponentMaximized: React.PropTypes.func.isRequired,
   onToggleDashboard: React.PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Added a bunch of react-eslint rules, and then patched the code to follow them.

Two particularly good ones:

* Ban the use of `bind()` in callback props (this is a performance issue)
* Use stateless components where practical (could do more, but right now just converted the ones that are nothing more than a `render` function). This is a performance enhancement