### PR TITLE
Catch unexpected token errors

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -94,6 +94,7 @@
     "javascript": {
       "unexpected-string": "JavaScript doesn’t expect a string where you wrote __value__. Remember that variable and function names aren’t surrounded in quotes.",
       "unexpected-number": "JavaScript doesn’t expect a number where you wrote __value__. Remember that variable and function names have to start with a letter.",
+      "unexpected-identifier": "JavaScript doesn’t expect a variable or property name where you wrote \"__name__\".",
       "unexpected-token": "JavaScript doesn’t expect a __token__ where you wrote one here.",
       "invalid-left-hand-string": "You wrote __value__ to the left of the = sign here, but that’s not a valid variable name. Remember that variable names aren’t surrounded by quotes.",
       "invalid-left-hand-number": "You wrote __value__ to the left of the = sign here, but that’s not a valid variable name. Remember that variable names have to start with a letter.",

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -25,6 +25,11 @@ const errorMap = {
     ],
   }),
 
+  'Unexpected identifier': ({token}) => ({
+    reason: 'unexpected-identifier',
+    payload: {name: token.value},
+  }),
+
   'Invalid left-hand side in assignment': ({token}) => {
     let message;
     switch (token.type) {


### PR DESCRIPTION
Handles things like:

```javascript
var o = {a: 1 b: 2};

var a b;
```