### PR TITLE
Prevent preview from ever rendering invalid code

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -133,6 +133,13 @@ function loadCurrentProjectFromStorage() {
 
 function updateProjectSource(projectKey, language, newValue) {
   return (dispatch, getState) => {
+    const currentProject = getCurrentProject(getState());
+    dispatch(validateSource(
+      language,
+      newValue,
+      currentProject.get('enabledLibraries')
+    ));
+
     dispatch({
       type: 'PROJECT_SOURCE_EDITED',
       meta: {timestamp: Date.now()},
@@ -143,15 +150,7 @@ function updateProjectSource(projectKey, language, newValue) {
       },
     });
 
-    const state = getState();
-    saveCurrentProject(state);
-
-    const currentProject = getCurrentProject(state);
-    dispatch(validateSource(
-      language,
-      newValue,
-      currentProject.get('enabledLibraries')
-    ));
+    saveCurrentProject(getState());
   };
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -54,13 +54,6 @@ const showErrorsAfterDebounce = (() => {
 
 function validateSource(language, source, enabledLibraries) {
   return (dispatch, getState) => {
-    dispatch({
-      type: 'VALIDATING_SOURCE',
-      payload: {
-        language,
-      },
-    });
-
     const validate = validations[language];
     validate(source, enabledLibraries.toJS()).then((errors) => {
       const currentSource = getCurrentProject(getState()).

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -24,7 +24,8 @@ class Editor extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.projectKey !== this.props.projectKey) {
       this._startNewSession(nextProps.source);
-    } else if (nextProps.source !== this._editor.getValue()) {
+    } else if (nextProps.source !== this.props.source &&
+        nextProps.source !== this._editor.getValue()) {
       this._editor.setValue(nextProps.source);
     }
 

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -34,10 +34,10 @@ function ErrorList(props) {
 }
 
 ErrorList.propTypes = {
-  css: React.PropTypes.array.isRequired,
+  css: React.PropTypes.object.isRequired,
   docked: React.PropTypes.bool,
-  html: React.PropTypes.array.isRequired,
-  javascript: React.PropTypes.array.isRequired,
+  html: React.PropTypes.object.isRequired,
+  javascript: React.PropTypes.object.isRequired,
   onErrorClick: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/ErrorSublist.jsx
+++ b/src/components/ErrorSublist.jsx
@@ -5,11 +5,11 @@ import i18n from 'i18next-client';
 import ErrorItem from './ErrorItem';
 
 function ErrorSublist(props) {
-  if (props.errors.length === 0) {
+  if (props.errors.state === 'passed') {
     return false;
   }
 
-  const errors = map(props.errors, (error) => (
+  const errors = map(props.errors.items, (error) => (
     <ErrorItem
       {...error}
       key={[error.reason, error.row]}
@@ -22,7 +22,7 @@ function ErrorSublist(props) {
 
   const errorMessage = i18n.t(
     'errors.notice',
-    {amount: props.errors.length, language: props.language}
+    {amount: props.errors.items.length, language: props.language}
   );
 
   return (
@@ -38,7 +38,7 @@ function ErrorSublist(props) {
 }
 
 ErrorSublist.propTypes = {
-  errors: React.PropTypes.array.isRequired,
+  errors: React.PropTypes.object.isRequired,
   language: React.PropTypes.oneOf(['html', 'css', 'javascript']).isRequired,
   onErrorClick: React.PropTypes.func.isRequired,
 };

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -28,7 +28,7 @@ class Output extends React.Component {
   }
 
   _renderRuntimeErrorList() {
-    if (!isEmpty(this.props.runtimeErrors) && !this.props.delayErrorDisplay) {
+    if (!isEmpty(this.props.runtimeErrors)) {
       return this._renderErrorList({
         html: {items: [], state: 'passed'},
         css: {items: [], state: 'passed'},
@@ -44,15 +44,15 @@ class Output extends React.Component {
   }
 
   render() {
-    if (this.props.hasErrors) {
-      if (this.props.delayErrorDisplay) {
-        return (
-          <div className="environment-column output">
-            <div className="output-delayedErrorOverlay" />
-          </div>
-        );
-      }
+    if (this.props.validationState === 'validating') {
+      return (
+        <div className="environment-column output">
+          <div className="output-delayedErrorOverlay" />
+        </div>
+      );
+    }
 
+    if (this.props.validationState === 'failed') {
       return (
         <div className="environment-column output">
           {this._renderErrorList(this.props.errors)}
@@ -70,11 +70,10 @@ class Output extends React.Component {
 }
 
 Output.propTypes = {
-  delayErrorDisplay: React.PropTypes.bool.isRequired,
   errors: React.PropTypes.object.isRequired,
-  hasErrors: React.PropTypes.bool.isRequired,
   project: React.PropTypes.object,
   runtimeErrors: React.PropTypes.array.isRequired,
+  validationState: React.PropTypes.string,
   onClearRuntimeErrors: React.PropTypes.func.isRequired,
   onErrorClick: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -30,9 +30,12 @@ class Output extends React.Component {
   _renderRuntimeErrorList() {
     if (!isEmpty(this.props.runtimeErrors) && !this.props.delayErrorDisplay) {
       return this._renderErrorList({
-        html: [],
-        css: [],
-        javascript: this.props.runtimeErrors,
+        html: {items: [], state: 'passed'},
+        css: {items: [], state: 'passed'},
+        javascript: {
+          items: this.props.runtimeErrors,
+          state: this.props.runtimeErrors.length ? 'failed' : 'passed',
+        },
         docked: true,
       });
     }

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import values from 'lodash/values';
-import flatten from 'lodash/flatten';
-import isEmpty from 'lodash/isEmpty';
 import bindAll from 'lodash/bindAll';
 import includes from 'lodash/includes';
 import partial from 'lodash/partial';
 import sortBy from 'lodash/sortBy';
+import map from 'lodash/map';
 import i18n from 'i18next-client';
 import qs from 'qs';
 import appFirebase from '../services/appFirebase';
@@ -109,10 +108,11 @@ class Workspace extends React.Component {
 
   _allErrorsFor(language) {
     if (language === 'javascript') {
-      return this.props.errors.javascript.concat(this.props.runtimeErrors);
+      return this.props.errors.javascript.items.
+        concat(this.props.runtimeErrors);
     }
 
-    return this.props.errors[language];
+    return this.props.errors[language].items;
   }
 
   _handleComponentMinimized(componentName) {
@@ -176,7 +176,7 @@ class Workspace extends React.Component {
         delayErrorDisplay={this.props.delayErrorDisplay}
         errors={this.props.errors}
         hasErrors={
-          !isEmpty(flatten(values(this.props.errors)))
+          includes(map(values(this.props.errors), 'state'), 'failed')
         }
         project={this.props.currentProject}
         runtimeErrors={this.props.runtimeErrors}

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -171,15 +171,25 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
+    const errorStates = map(values(this.props.errors), 'state');
+
+    let validationState;
+    if (this.props.delayErrorDisplay) {
+      validationState = 'validating';
+    } else if (includes(errorStates, 'failed')) {
+      validationState = 'failed';
+    } else if (includes(errorStates, 'validating')) {
+      validationState = 'validating';
+    } else {
+      validationState = 'passed';
+    }
+
     return (
       <Output
-        delayErrorDisplay={this.props.delayErrorDisplay}
         errors={this.props.errors}
-        hasErrors={
-          includes(map(values(this.props.errors), 'state'), 'failed')
-        }
         project={this.props.currentProject}
         runtimeErrors={this.props.runtimeErrors}
+        validationState={validationState}
         onClearRuntimeErrors={this._handleClearRuntimeErrors}
         onErrorClick={this._handleErrorClick}
         onRuntimeError={this._handleRuntimeError}

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -19,6 +19,12 @@ function buildFailedLanguageErrors(errorList) {
   });
 }
 
+const validatingErrors = new Immutable.Map({
+  html: validatingLanguageErrors,
+  css: validatingLanguageErrors,
+  javascript: validatingLanguageErrors,
+});
+
 const emptyErrors = new Immutable.Map({
   html: passedLanguageErrors,
   css: passedLanguageErrors,
@@ -36,10 +42,13 @@ function errors(stateIn, action) {
       return emptyErrors;
 
     case 'CURRENT_PROJECT_LOADED_FROM_STORAGE':
-      return emptyErrors;
+      return validatingErrors;
 
     case 'CURRENT_PROJECT_CHANGED':
-      return emptyErrors;
+      return validatingErrors;
+
+    case 'PROJECT_SOURCE_EDITED':
+      return state.set(action.payload.language, validatingLanguageErrors);
 
     case 'VALIDATING_SOURCE':
       return state.set(action.payload.language, validatingLanguageErrors);

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -2,10 +2,27 @@ import Immutable from 'immutable';
 
 const emptyList = new Immutable.List();
 
+const passedLanguageErrors = new Immutable.Map({
+  items: emptyList,
+  state: 'passed',
+});
+
+const validatingLanguageErrors = new Immutable.Map({
+  items: emptyList,
+  state: 'validating',
+});
+
+function buildFailedLanguageErrors(errorList) {
+  return Immutable.fromJS({
+    items: errorList,
+    state: 'failed',
+  });
+}
+
 const emptyErrors = new Immutable.Map({
-  html: emptyList,
-  css: emptyList,
-  javascript: emptyList,
+  html: passedLanguageErrors,
+  css: passedLanguageErrors,
+  javascript: passedLanguageErrors,
 });
 
 function errors(stateIn, action) {
@@ -25,13 +42,16 @@ function errors(stateIn, action) {
       return emptyErrors;
 
     case 'VALIDATING_SOURCE':
-      return state.set(action.payload.language, emptyList);
+      return state.set(action.payload.language, validatingLanguageErrors);
 
     case 'VALIDATED_SOURCE':
-      return state.set(
-        action.payload.language,
-        Immutable.fromJS(action.payload.errors)
-      );
+      if (action.payload.errors.length) {
+        return state.set(
+          action.payload.language,
+          buildFailedLanguageErrors(action.payload.errors)
+        );
+      }
+      return state.set(action.payload.language, passedLanguageErrors);
 
     case 'RESET_WORKSPACE':
       return emptyErrors;

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -50,9 +50,6 @@ function errors(stateIn, action) {
     case 'PROJECT_SOURCE_EDITED':
       return state.set(action.payload.language, validatingLanguageErrors);
 
-    case 'VALIDATING_SOURCE':
-      return state.set(action.payload.language, validatingLanguageErrors);
-
     case 'VALIDATED_SOURCE':
       if (action.payload.errors.length) {
         return state.set(


### PR DESCRIPTION
When a project source changes, the first thing that is dispatched is a change to the project state. Previously, this would unconditionally trigger a preview render cycle, since the error store would clear error state when validation began.

Now, we have an explicit idea of error state: `passed`, `failed`, or `validating`. The latter state is invoked as soon as an action results in a change to source code whose validity is not known. The explicit `VALIDATING_SOURCE` action is removed.

As a result, the preview is only rendered when the current source has been positively identified as valid.

This is particularly important for situations in which students have the console open; previously editing JavaScript with the console open would yield a flood of console errors. Also, rendering the preview for invalid code is an unnecessary performance drain while typing.