### PR TITLE
Fix sticky runtime errors

### DIFF
--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -20,6 +20,7 @@ class Output extends React.Component {
 
     return (
       <Preview
+        isValid={this.props.validationState === 'passed'}
         project={this.props.project}
         onClearRuntimeErrors={this.props.onClearRuntimeErrors}
         onRuntimeError={this.props.onRuntimeError}
@@ -43,25 +44,22 @@ class Output extends React.Component {
     return null;
   }
 
-  render() {
+  _renderErrors() {
     if (this.props.validationState === 'validating') {
-      return (
-        <div className="environment-column output">
-          <div className="output-delayedErrorOverlay" />
-        </div>
-      );
+      return <div className="output-delayedErrorOverlay" />;
     }
 
     if (this.props.validationState === 'failed') {
-      return (
-        <div className="environment-column output">
-          {this._renderErrorList(this.props.errors)}
-        </div>
-      );
+      return this._renderErrorList(this.props.errors);
     }
 
+    return null;
+  }
+
+  render() {
     return (
       <div className="environment-column output">
+        {this._renderErrors()}
         {this._renderPreview()}
         {this._renderRuntimeErrorList()}
       </div>

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {TextEncoder} from 'text-encoding';
 import base64 from 'base64-js';
 import bindAll from 'lodash/bindAll';
+import classnames from 'classnames';
 
 import PreviewFrame from './PreviewFrame';
 import generatePreview from '../util/generatePreview';
@@ -13,6 +14,10 @@ class Preview extends React.Component {
   }
 
   _generateDocument() {
+    if (!this.props.isValid) {
+      return '';
+    }
+
     const project = this.props.project;
 
     if (project === undefined) {
@@ -39,7 +44,13 @@ class Preview extends React.Component {
 
   render() {
     return (
-      <div className="preview output-item">
+      <div
+        className={classnames(
+          'preview',
+          'output-item',
+          {'u-hidden': !this.props.isValid}
+        )}
+      >
         <div
           className="preview-popOutButton"
           onClick={this._handlePopOutClick}
@@ -55,6 +66,7 @@ class Preview extends React.Component {
 }
 
 Preview.propTypes = {
+  isValid: React.PropTypes.bool.isRequired,
   project: React.PropTypes.object.isRequired,
   onClearRuntimeErrors: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -24,7 +24,6 @@ class PreviewFrame extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.src !== this.props.src) {
       this._writeFrameContents(nextProps.src);
-      nextProps.onFrameWillRefresh();
     }
   }
 
@@ -52,6 +51,8 @@ class PreviewFrame extends React.Component {
     this.frame.contentWindow.loopProtect = loopProtect;
     frameDocument.write(src);
     frameDocument.close();
+
+    this.props.onFrameWillRefresh();
   }
 
   _runtimeErrorLineOffset() {

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -10,11 +10,11 @@ import loopProtect from 'loop-protect';
 class PreviewFrame extends React.Component {
   constructor() {
     super();
-    bindAll(this, '_onMessage', '_saveFrame');
+    bindAll(this, '_onMessage', '_saveFrame', '_handleInfiniteLoop');
   }
 
   componentWillMount() {
-    loopProtect.hit = this._onInfiniteLoop.bind(this);
+    loopProtect.hit = this._handleInfiniteLoop;
   }
 
   componentDidMount() {
@@ -96,7 +96,7 @@ class PreviewFrame extends React.Component {
     });
   }
 
-  _onInfiniteLoop(line) {
+  _handleInfiniteLoop(line) {
     const message = i18n.t('errors.javascriptRuntime.infinite-loop');
     this.props.onRuntimeError({
       reason: 'infinite-loop',

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -356,3 +356,7 @@ body {
 .u-flexItem--fill {
   flex: 1 0 100%;
 }
+
+.u-hidden {
+  display: none;
+}


### PR DESCRIPTION
Previously a runtime error would continue to be displayed even after being resolved. This is because the `PreviewFrame` only sent an `onFrameWillRefresh` event when it received new props; *not* when it initially mounted/was rendered. However, because of the three-phase error state, each keystroke resulted in the `PreviewFrame` at least briefly unmounting while validation was underway. So, the frame never updated; it was always torn down and rebuilt.

Two changes, either of which alone would solve the problem, but both of which seem like good changes to the code:

* `PreviewFrame` emits a frame refresh signal any time it flushes the contents of the frame (including when it is first mounted). This seems semantically correct
* `Preview` now always renders the `PreviewFrame`, but it knows whether the current source is known to be valid. If it’s not, the `PreviewFrame` is hidden and its source is set to an empty string. This is almost certainly more performant than constantly tearing down and rebuilding the frame