### PR TITLE
More descriptive error messages when using an undefined library global

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -118,6 +118,7 @@
         "custom-case": "There should be a __goodOperator__ where you wrote __badOperator__"
       },
       "declare-variable": "You haven't declared __variable__.\nTry: var __variable__;",
+      "missing-library": "__variable__ isn’t defined. Did you mean to enable the __library__ library?",
       "duplicated-declaration": "You already declared __variable__ somewhere else.",
       "unexpected": "You typed a \"__character__\" here, but that’s not allowed in JavaScript.",
       "end-of-input": "Looks like you’re missing something at the end of this line.",

--- a/src/config/libraries.js
+++ b/src/config/libraries.js
@@ -7,14 +7,14 @@ const libraries = {
     javascript: fs.readFileSync(
       path.join(__dirname, '../../bower_components/jquery/dist/jquery.min.js')
     ),
-    validations: {javascript: {jquery: {$set: true}}},
+    predefined: ['$', 'jQuery'],
   },
   lodash: {
     name: 'lodash',
     javascript: fs.readFileSync(
       path.join(__dirname, '../../bower_components/lodash/dist/lodash.min.js')
     ),
-    validations: {javascript: {predef: {$push: ['_']}}},
+    predefined: ['_'],
   },
   underscore: {
     name: 'Underscore.js',
@@ -24,14 +24,14 @@ const libraries = {
         '../../bower_components/underscore/underscore-min.js'
       )
     ),
-    validations: {javascript: {predef: {$push: ['_']}}},
+    predefined: ['_'],
   },
   angular: {
     name: 'AngularJS',
     javascript: fs.readFileSync(
       path.join(__dirname, '../../bower_components/angular/angular.min.js')
     ),
-    validations: {javascript: {predef: {$push: ['angular']}}},
+    predefined: ['angular'],
   },
   react: {
     name: 'React',
@@ -43,14 +43,14 @@ const libraries = {
         path.join(__dirname, '../../bower_components/react/react-dom.min.js')
       ),
     ],
-    validations: {javascript: {predef: {$push: ['React']}}},
+    predefined: ['React'],
   },
   ember: {
     name: 'Ember.js',
     javascript: fs.readFileSync(
       path.join(__dirname, '../../bower_components/ember/ember.min.js')
     ),
-    validations: {javascript: {predef: {$push: ['Ember']}}},
+    predefined: ['Ember'],
   },
   bootstrap: {
     name: 'Bootstrap',


### PR DESCRIPTION
E.g. if you try to use `$` but haven’t enabled jQuery, the error message will specifically suggest enabling jQuery, rather than a generic undefined variable message.

![](https://dl.dropboxusercontent.com/u/364501990/2016-06-18_1123.png?raw=1)