### PR TITLE
Smarter editor resizing

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -43,6 +43,10 @@ class Editor extends React.Component {
       this._editor.setValue(nextProps.source);
     }
 
+    if (nextProps.percentageOfHeight !== this.props.percentageOfHeight) {
+      requestAnimationFrame(this._resizeEditor);
+    }
+
     this._editor.getSession().setAnnotations(nextProps.errors);
   }
 
@@ -126,6 +130,7 @@ class Editor extends React.Component {
 Editor.propTypes = {
   errors: React.PropTypes.array.isRequired,
   language: React.PropTypes.string.isRequired,
+  percentageOfHeight: React.PropTypes.number.isRequired,
   projectKey: React.PropTypes.string.isRequired,
   source: React.PropTypes.string.isRequired,
   onInput: React.PropTypes.func.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -213,6 +213,7 @@ class Workspace extends React.Component {
           errors={this._allErrorsFor(language)}
           key={language}
           language={language}
+          percentageOfHeight={1 / editors.length}
           projectKey={this.props.currentProject.projectKey}
           ref={partial(this._handleEditorMountedOrUnmounted, language)}
           source={this.props.currentProject.sources[language]}


### PR DESCRIPTION
The ACE editor needs to be explicitly told when its container has changed in size. Previously we have been relying on a pretty clunky mechanism of just firing a resize when you focus the editor; however, this leads to noticeably bad behavior in a couple of cases:

* When the entire browser window is resized
* When you minimize or maximize one of the language editors

In both of these cases, the editor is visibly the wrong size until you actually focus it.

This update fixes both problems by adding a window resize event handler, and also making the editor component aware when its proportion of the overall editor column has changed, so that in both cases it can resize the editor itself.