### PR TITLE
Serve fonts from our assets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,8 @@
     "lodash": "^4.11.2",
     "underscore": "^1.8.3",
     "normalize-css": "normalize.css#^4.1.1",
-    "jquery": "^2.2.3"
+    "jquery": "^2.2.3",
+    "inconsolata-webfont": "^1.0.3",
+    "roboto-webfont-bower": "roboto-webfont#^0.1.1"
   }
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -69,6 +69,15 @@ gulp.task('env', () => {
   }
 });
 
+gulp.task('fonts', () => gulp.
+  src([
+    `${bowerComponents}/inconsolata-webfont/fonts/inconsolata-regular.*`,
+    `${bowerComponents}/roboto-webfont-bower/fonts/` +
+      'Roboto-{Bold,Regular}-webfont.*',
+  ]).
+    pipe(gulp.dest(`${distDir}/fonts`))
+);
+
 gulp.task('css', () => gulp.
   src([
     `${bowerComponents}/normalize-css/normalize.css`,
@@ -87,7 +96,7 @@ gulp.task('js', ['env'], () => {
   return browserifyDone;
 });
 
-gulp.task('build', ['css', 'js']);
+gulp.task('build', ['fonts', 'css', 'js']);
 
 gulp.task('syncFirebase', () => new Promise((resolve, reject) => {
   fs.readFile(`${__dirname}/config/firebase-auth.json`, (err, data) => {
@@ -117,7 +126,7 @@ gulp.task('syncFirebase', () => new Promise((resolve, reject) => {
   });
 }));
 
-gulp.task('dev', ['browserSync', 'css', 'js'], () => {
+gulp.task('dev', ['browserSync', 'fonts', 'css', 'js'], () => {
   gulp.watch(`${stylesheetsDir}/**/*.css`, ['css']);
   gulp.watch(`${srcDir}/**/*.js{,x}`, ['js']);
 });

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -1,5 +1,33 @@
-@import url(https://fonts.googleapis.com/css?family=Roboto:400,700);
-@import url(https://fonts.googleapis.com/css?family=Inconsolata);
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Roboto'),
+    url('/compiled/fonts/Roboto-Regular-webfont.woff') format('woff'),
+    url('/compiled/fonts/Roboto-Regular-webfont.ttf') format('ttf'),
+    url('/compiled/fonts/Roboto-Regular-webfont.eot') format('eot');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  font-style: bold;
+  font-weight: 700;
+  src: local('Roboto'),
+    url('/compiled/fonts/Roboto-Bold-webfont.woff') format('woff'),
+    url('/compiled/fonts/Roboto-Bold-webfont.ttf') format('ttf'),
+    url('/compiled/fonts/Roboto-Bold-webfont.eot') format('eot');
+}
+
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Inconsolata'),
+    url('/compiled/fonts/inconsolata-regular.woff2') format('woff2'),
+    url('/compiled/fonts/inconsolata-regular.woff') format('woff'),
+    url('/compiled/fonts/inconsolata-regular.ttf') format('ttf'),
+    url('/compiled/fonts/inconsolata-regular.eot') format('eot');
+}
 
 html, body {
   min-height: 100%;


### PR DESCRIPTION
Ensure we serve up all the appropriate formats; also serving fonts separately allows the browser to keep them cached basically forever.