### PR TITLE
Explicitly add a font-family declaration for editors

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -249,6 +249,7 @@ body {
 .editors {
   display: flex;
   flex-direction: column;
+  font-family: 'Inconsolata';
 }
 
 .editors-editorContainer {


### PR DESCRIPTION
To signal to the browser that it needs to load that font