### PR TITLE
Ensure editors are the same size

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -297,7 +297,7 @@ body {
 
 .editors-editorContainer {
   box-sizing: border-box;
-  flex: 1 1 auto;
+  flex: 0 1 100%;
   border-right: 2px solid var(--color-gray);
   border-bottom: 2px solid var(--color-gray);
   position: relative;


### PR DESCRIPTION
Was using `auto` flex basis before, which means “to fit your content”, which is not appropriate here (the editor should resize to fit its container, not vice versa). Switch to 100% flex basis, and remove flex-grow while we’re at it (since it shouldn’t grow to more than 100%).

Fixes issue where many pageloads yield oddly-sized editors.