### PR TITLE
Error message if browser isn’t supported

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -15,6 +15,10 @@
   "editors": {
     "helpText": "Type in your $t(languages.__language__) code here."
   },
+  "bad-browser": {
+    "message": "Popcode doesn’t work with your version of __name__.",
+    "download": "Click here to download a new version."
+  },
   "languages": {
     "html": "HTML",
     "css": "CSS",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,8 +531,8 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "bowser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.1.1.tgz"
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.4.1.tgz"
     },
     "brace": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "PrettyCSS": "^0.3.11",
     "base64-js": "^1.0.2",
-    "bowser": "^1.0.0",
+    "bowser": "^1.4.1",
     "brace": "^0.8.0",
     "browserify": "^13.0.0",
     "bugsnag-js": "^2.5.0",

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {Provider} from 'react-redux';
+import bowser from 'bowser';
 import createApplicationStore from '../createApplicationStore';
 import Workspace from './Workspace';
+import BrowserError from './BrowserError';
 import {includeStoreInBugReports} from '../util/Bugsnag';
 
 class Application extends React.Component {
@@ -12,7 +14,20 @@ class Application extends React.Component {
     includeStoreInBugReports(store);
   }
 
+  _isUnsupportedBrowser() {
+    return bowser.isUnsupportedBrowser({
+      msie: '10',
+      firefox: '12',
+      chrome: '30',
+      safari: '7.1',
+    }, window.navigator.userAgent);
+  }
+
   render() {
+    if (this._isUnsupportedBrowser()) {
+      return <BrowserError browser={bowser} />;
+    }
+
     return (
       <Provider store={this.state.store}>
         <Workspace />

--- a/src/components/BrowserError.jsx
+++ b/src/components/BrowserError.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import i18n from 'i18next-client';
+
+function getBrowserLink(browser) {
+  if (browser.firefox) {
+    return 'https://www.mozilla.org/en-US/firefox/new/';
+  }
+  if (browser.safari) {
+    return 'https://support.apple.com/downloads/safari';
+  }
+  return 'https://www.google.com/chrome/browser/desktop/';
+}
+
+function BrowserError(props) {
+  const browserName = props.browser.name;
+
+  return (
+    <div id="unsupported-browser">
+      <p>{i18n.t('bad-browser.message', {name: browserName})}</p>
+
+      <p>
+        <a href={getBrowserLink(props.browser)}>
+          {i18n.t('bad-browser.download')}
+        </a>
+      </p>
+    </div>
+  );
+}
+
+BrowserError.propTypes = {
+  browser: React.PropTypes.object.isRequired,
+};
+
+export default BrowserError;

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -426,6 +426,16 @@ body {
   cursor: pointer;
 }
 
+#unsupported-browser {
+  font-size: 1.5rem;
+  margin-top: 5rem;
+  text-align: center;
+
+  & a {
+    color: inherit;
+  }
+}
+
 .u-flexContainer {
   display: flex;
 }


### PR DESCRIPTION
Instead of loading the environment, just show an error message if the user’s browser isn’t supported (specifically, is known to lack a feature Popcode needs).