### PR TITLE
Basic support for flexbox

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz"
     },
     "PrettyCSS": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/PrettyCSS/-/PrettyCSS-0.3.11.tgz"
+      "version": "0.3.10-popcode.1",
+      "resolved": "git://github.com/popcodeorg/PrettyCSS.git#cb63676363405b0dadaa4e42376ab86ce5dafc58"
     },
     "abbrev": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bugs": "https://trello.com/b/ONaFg6wh/popcode",
   "license": "MIT",
   "dependencies": {
-    "PrettyCSS": "^0.3.11",
+    "PrettyCSS": "popcodeorg/PrettyCSS#v0.3.10-popcode.1",
     "base64-js": "^1.0.2",
     "bowser": "^1.4.1",
     "brace": "^0.8.0",

--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha */
+
+import '../../helper';
+import {
+  assertPassesValidation,
+  assertFailsValidationWith,
+} from '../../assertions/validations';
+
+import css from '../../../src/validations/css';
+
+function assertPassesCssValidation(source) {
+  return assertPassesValidation(css, source);
+}
+
+function assertFailsCssValidationWith(source, ...errors) {
+  return assertFailsValidationWith(css, source, ...errors);
+}
+
+describe('css', () => {
+  it('allows valid flexbox', () =>
+    assertPassesCssValidation(`
+      .flex-container { display: flex; }
+      .flex-item { flex: 1 0 auto; }
+    `)
+  );
+
+  it('fails with bogus flex value', () =>
+    assertFailsCssValidationWith(
+      '.flex-item { flex: bogus; }',
+      'invalid-value'
+    )
+  );
+});
+


### PR DESCRIPTION
Points to a fork of PrettyCSS that I just patched to support Flexbox.

Currently only supports:

```css
display: flex;
flex-grow: 1;
flex-shrink: 0;
flex-basis: auto;
flex: 1 0 auto;
```