### PR TITLE
Catch slowparse errors

### DIFF
--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -37,4 +37,12 @@ describe('html', () => {
       'banned-attributes.align'
     )
   );
+
+  it('gives error message for missing structure and unclosed p tag', () =>
+    assertFailsHtmlValidationWith(
+      '<p>T',
+      'unclosed-tag',
+      'doctype'
+    )
+  );
 });

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -88,7 +88,12 @@ class SlowparseValidator extends Validator {
   }
 
   _getRawErrors() {
-    const error = Slowparse.HTML(document, this._source).error;
+    let error;
+    try {
+      error = Slowparse.HTML(document, this._source).error;
+    } catch (e) {
+      error = null;
+    }
 
     if (error !== null) {
       return [error];


### PR DESCRIPTION
E.g. the string "<p>T" in the HTML input causes Slowparse to throw an uncaught error.