### PR TITLE
Better error message for space after the opening angle bracket of a tag

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -83,7 +83,8 @@
       "unterminated-close-tag": "You forgot to put a > at the end of your </__tag__> tag.",
       "unterminated-comment": "You have a comment that never ends. End the comment with -->",
       "unbound-attribute-value": "The value __value__ isn’t attached to an attribute. Are you missing an = sign?",
-      "invalid-tag-name": "<__tag__> isn’t a valid HTML tag. If you want to create a custom tag, make sure the name has a - in it, like <my-tag>"
+      "invalid-tag-name": "<__tag__> isn’t a valid HTML tag. If you want to create a custom tag, make sure the name has a - in it, like <my-tag>",
+      "space-before-tag-name": "You can’t put any space after the < in an HTML tag. Write <__tag__> instead of < __tag__>."
     },
     "css": {
       "missing-opening-curly": "You should have a { at the end of this line.",

--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -63,4 +63,12 @@ describe('html', () => {
       'mismatched-close-tag'
     )
   );
+
+  it('generates meaningful error for space inside HTML angle bracket', () =>
+    assertFailsValidationWith(
+      html,
+      htmlWithBody('< p>Content</p>'),
+      'space-before-tag-name'
+    )
+  );
 });

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -20,10 +20,25 @@ const errorMap = {
     suppresses: ['lower-case-attribute-name'],
   }),
 
-  INVALID_TAG_NAME: (error) => ({
-    reason: 'invalid-tag-name',
-    payload: {tag: error.openTag.name},
-  }),
+  INVALID_TAG_NAME: (error, source) => {
+    const tagName = error.openTag.name;
+    if (tagName === '') {
+      const tagMatch = /^<\s+([A-Za-z0-9\-]+)/.exec(
+        source.slice(error.openTag.start)
+      );
+      if (tagMatch) {
+        return {
+          reason: 'space-before-tag-name',
+          payload: {tag: tagMatch[1]},
+        };
+      }
+    }
+
+    return {
+      reason: 'invalid-tag-name',
+      payload: {tag: error.openTag.name},
+    };
+  },
 
   UNSUPPORTED_ATTR_NAMESPACE: (error) => ({
     reason: 'invalid-attribute-name',


### PR DESCRIPTION
If you put space right after the opening angle bracket of an HTML tag, e.g. `< p>`, that’s not valid HTML.

From the parser’s standpoint, this looks like a tag whose name is `""`, the empty string. However, we can heuristically detect that this is actually a tag with an erroneous space character before the tag name, and give a more informative error message.