### PR TITLE
Don’t show Pop when submenu is active

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -161,6 +161,10 @@ class Dashboard extends React.Component {
   }
 
   _renderPop() {
+    if (this.props.activeSubmenu) {
+      return null;
+    }
+
     return (
       <div className="dashboard-popContainer">
         {this._renderPopSvg('neutral', 'passed')}


### PR DESCRIPTION
For long submenus (e.g. a long project list), Pop covers the list. Going behind the list wouldn’t look great either. So, just don’t show Pop when there is an active submenu.