### PR TITLE
Special case for “mismatched close tag” when open tag is the whole doc

### DIFF
--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -71,4 +71,17 @@ describe('html', () => {
       'space-before-tag-name'
     )
   );
+
+  it('generates meaningful error for extra tag at end of doc', () =>
+    assertFailsValidationWith(
+      html,
+      `<!DOCTYPE html>
+       <html>
+       <head><title>Page Title</title></head>
+       <body></body>
+       </html>
+       </div>`,
+      'unexpected-close-tag'
+    )
+  );
 });

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -52,10 +52,21 @@ const errorMap = {
     suppresses: ['lower-case-attribute-name'],
   }),
 
-  MISMATCHED_CLOSE_TAG: (error) => ({
-    reason: 'mismatched-close-tag',
-    payload: {open: error.openTag.name, close: error.closeTag.name},
-  }),
+  MISMATCHED_CLOSE_TAG: (error) => {
+    const openTagName = error.openTag.name;
+    const closeTagName = error.closeTag.name;
+    if (openTagName === '#document-fragment') {
+      return {
+        reason: 'unexpected-close-tag',
+        payload: {tag: closeTagName},
+      };
+    }
+
+    return {
+      reason: 'mismatched-close-tag',
+      payload: {open: openTagName, close: closeTagName},
+    };
+  },
 
   SELF_CLOSING_NON_VOID_ELEMENT: (error) => ({
     reason: 'self-closing-non-void-element',


### PR DESCRIPTION
Slowparse will report a “mismatched close tag” when a stray closing tag sits at the very bottom of the entire document, e.g.:

```html
<!DOCTYPE html>
<html>
<head><title>Page Title</title></head>
<body></body>
</html>
</div>
```

The opening tag is reported as `#document-fragment`, so we can simply detect this and report it as an `unexpected-close-tag` instead.