### PR TITLE
Distinguish between missing opening curly and bogus character in selector

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -95,6 +95,7 @@
       "extra-tokens-after-value": "The __token__ at the end of this line doesn’t belong there.",
       "illegal-token-after-combinator": "After a + or > in a selector, you need to specify the name of another element, class, or ID",
       "invalid-token": "This line doesn't look like valid CSS.",
+      "invalid-token-in-selector": "The __token__ on this line doesn’t belong here.",
       "invalid-value": "__error__ isn't a meaningful value for this property. Double-check what values you can use here.",
       "missing-semicolon": "Looks like you’re missing a semicolon at the end of this line.",
       "require-value": "Put a value for __error__ after the colon.",

--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -35,6 +35,33 @@ describe('css', () => {
     )
   );
 
+  it('gives a useful error when there is no opening curly brace', () =>
+    assertFailsValidationWith(
+      css,
+      `p
+        display: block;`,
+      'block-expected'
+    )
+  );
+
+  it('gives a useful error with no opening curly brace and whitespace', () =>
+    assertFailsValidationWith(
+      css,
+      `p
+        display: block;
+      `,
+      'block-expected'
+    )
+  );
+
+  it('gives a useful error when a bogus character is in selector', () =>
+    assertFailsValidationWith(
+      css,
+      'p; div { display: block; }',
+      'invalid-token-in-selector'
+    )
+  );
+
   context('missing semicolon', () => {
     const stylesheet = `
       p {

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -11,10 +11,23 @@ function isIncorrectlyRejectedRadialGradientValue(value) {
 }
 
 const errorMap = {
-  'block-expected': (error) => ({
-    reason: 'block-expected',
-    payload: {error: error.token.content},
-  }),
+  'block-expected': (error) => {
+    const tokenType = error.token.type;
+    const token = error.token.content;
+
+    if (tokenType === 'IDENT' || tokenType === 'S') {
+      return {
+        reason: 'block-expected',
+        payload: {error: token},
+        suppresses: ['missing-opening-curly'],
+      };
+    }
+
+    return {
+      reason: 'invalid-token-in-selector',
+      payload: {token},
+    };
+  },
 
   'extra-tokens-after-value': (error, source) => {
     const lineNumber = error.token.line;
@@ -78,7 +91,7 @@ class PrettyCssValidator extends Validator {
   _getRawErrors() {
     try {
       const result = prettyCSS.parse(this._source);
-      return result.errors.concat(result.warnings);
+      return result.getProblems();
     } catch (_e) {
       return [];
     }


### PR DESCRIPTION
This is a missing opening curly brace:

```css
p
  display: block;
}
```

This is a typo in the selector:

```css
p; div {
  display: block;
}
```

Both look the same to our parsers, though. We can distinguish between the two by checking what type of token tripped the `block-expected` error in PrettyCSS—if it’s an identifier or whitespace, we can guess that it’s a missing curly; otherwise, we can surmise that it’s an invalid character in the selector.