### PR TITLE
Disable the tag-close check in htmllint

### DIFF
--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -31,6 +31,13 @@ describe('html', () => {
     )
   );
 
+  it('allows void tags without explicit close', () =>
+    assertPassesValidation(
+      html,
+      htmlWithBody('<img src="test.jpg">')
+    )
+  );
+
   it('gives error message for missing structure and unclosed p tag', () =>
     assertFailsValidationWith(
       html,
@@ -44,7 +51,7 @@ describe('html', () => {
     assertFailsValidationWith(
       html,
       htmlWithBody('<div>'),
-      'unclosed-tag'
+      'mismatched-close-tag'
     )
   );
 

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -103,7 +103,7 @@ const htmlLintOptions = {
     'tt',
     'strike',
   ],
-  'tag-close': true,
+  'tag-close': false,
   'tag-name-match': true,
   'tag-name-lowercase': true,
   'title-max-length': 0,


### PR DESCRIPTION
Turns out this, rather absurdly, throws an error when e.g. an `<img>` tag doesn’t self-close or have an explicit closing tag.

This means we get slightly less good behavior on actually unclosed tags, but it’s still basically fine.