### PR TITLE
Prevent invalid fractional and negative values

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -97,6 +97,8 @@
       "invalid-token": "This line doesn't look like valid CSS.",
       "invalid-token-in-selector": "The __token__ on this line doesn’t belong here.",
       "invalid-value": "__error__ isn't a meaningful value for this property. Double-check what values you can use here.",
+      "invalid-negative-value": "This property can’t have a negative value.",
+      "invalid-fractional-value": "This property needs a whole number for a value.",
       "missing-semicolon": "Looks like you’re missing a semicolon at the end of this line.",
       "require-value": "Put a value for __error__ after the colon.",
       "selector-expected": "Use a comma to separate multiple tag names, classes, or IDs.",

--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -62,6 +62,22 @@ describe('css', () => {
     )
   );
 
+  it('gives a good error when an invalid negative value is given', () =>
+    assertFailsValidationWith(
+      css,
+      'p { padding-left: -2px; }',
+      'invalid-negative-value'
+    )
+  );
+
+  it('gives a good error when invalid fractional value is given', () =>
+    assertFailsValidationWith(
+      css,
+      'p { z-index: 2.4; }',
+      'invalid-fractional-value'
+    )
+  );
+
   context('missing semicolon', () => {
     const stylesheet = `
       p {

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -75,6 +75,16 @@ const errorMap = {
     payload: {error: error.token.content},
   }),
 
+  'require-positive-value': (error) => ({
+    reason: 'invalid-negative-value',
+    payload: {error: error.token.content},
+  }),
+
+  'require-integer': (error) => ({
+    reason: 'invalid-fractional-value',
+    payload: {error: error.token.content},
+  }),
+
   'selector-expected': () => ({reason: 'selector-expected'}),
 
   'unknown-property': (error) => ({


### PR DESCRIPTION
E.g.:

```css
div {
  padding: -2px;
  z-index: 2.1;
}
```

Is invalid, because `padding` has to be nonnegative, and z-index has to be an integer. PrettyCSS already warns about this, so we just add mappings and translations.