### PR TITLE
Replace alert() in preview with non-blocking sweetalert

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ This will start a local static server, and open it in your browser. The first
 pageload will be rather slow as it compiles the bundle; after you change files,
 assets are recompiled incrementally and your browser automatically reloads.
 
+When you're done, lint and make sure tests pass before opening a pull request:
+
+```bash
+$ npm test
+```
+
 ## License ##
 
 Popcode is distributed under the MIT license. See the attached LICENSE file

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "roboto-webfont-bower": "roboto-webfont#^0.1.1",
     "fontawesome": "^4.6.3",
     "mustache.js": "mustache#^2.2.1",
-    "handlebars": "^4.0.5"
+    "handlebars": "^4.0.5",
+    "sweetalert": "^1.1.3"
   }
 }

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -13,7 +13,7 @@ class Preview extends React.Component {
     bindAll(this, '_handlePopOutClick');
   }
 
-  _generateDocument() {
+  _generateDocument(nonBlockingAlerts = false) {
     if (!this.props.isValid) {
       return '';
     }
@@ -26,7 +26,12 @@ class Preview extends React.Component {
 
     return generatePreview(
       project,
-      {targetBaseTop: true, propagateErrorsToParent: true, breakLoops: true}
+      {
+        targetBaseTop: true,
+        propagateErrorsToParent: true,
+        breakLoops: true,
+        nonBlockingAlerts,
+      }
     ).documentElement.outerHTML;
   }
 
@@ -56,7 +61,7 @@ class Preview extends React.Component {
           onClick={this._handlePopOutClick}
         />
         <PreviewFrame
-          src={this._generateDocument()}
+          src={this._generateDocument(true)}
           onFrameWillRefresh={this.props.onClearRuntimeErrors}
           onRuntimeError={this.props.onRuntimeError}
         />

--- a/src/config/previewFrameLibraries.js
+++ b/src/config/previewFrameLibraries.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const previewFrameLibraries = {
+  sweetalert: {
+    name: 'sweetalert',
+    javascript: fs.readFileSync(
+      path.join(__dirname,
+        '../../bower_components/sweetalert/dist/sweetalert.min.js'
+        )
+    ),
+    css: fs.readFileSync(
+      path.join(__dirname,
+        '../../bower_components/sweetalert/dist/sweetalert.css'
+        )
+      ),
+  },
+
+};
+
+export default previewFrameLibraries;


### PR DESCRIPTION
* Added new module that mimics the structure of the existing libraries file for things that should be injected to the preview by Popcode developers, not the user.
* I had to bower install to get the project to start when checking out a fresh copy, so I added that step
* Didn't do anything test-wise since it doesn't look like there are any existing javascript validation tests

The sweetalert functionality is...fairly meh. Since it doesn't block, if there are multiple alerts, then it just renders the last one as a preview. And we can't replace prompt with it. We could do a lot more by patching it down the line, but it would take some dev effort to have the user writing synchronous, blocking code and us transforming it to be asynchronous with this stuff.
