### PR TITLE
Back to official PrettyCSS release

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz"
     },
     "PrettyCSS": {
-      "version": "0.3.10-popcode.2",
-      "resolved": "git://github.com/popcodeorg/PrettyCSS.git#80c44114d1a4eea78252aa1371dffc600241337e"
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/PrettyCSS/-/PrettyCSS-0.3.12.tgz"
     },
     "abbrev": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "bugs": "https://trello.com/b/ONaFg6wh/popcode",
   "license": "MIT",
   "dependencies": {
-    "PrettyCSS": "popcodeorg/PrettyCSS#v0.3.10-popcode.2",
+    "PrettyCSS": "^0.3.12",
     "base64-js": "^1.0.2",
     "bowser": "^1.4.1",
     "brace": "^0.8.0",


### PR DESCRIPTION
Flexbox support has been merged and released, so no need to use our
fork.