### PR TITLE
Fix disappearing projects in list after switching projects

### DIFF
--- a/spec/examples/actions/projects.spec.js
+++ b/spec/examples/actions/projects.spec.js
@@ -5,7 +5,12 @@ import {assert} from 'chai';
 
 import createApplicationStore from '../../../src/createApplicationStore';
 
-import {createProject} from '../../../src/actions/projects';
+import {
+  createProject,
+  changeCurrentProject,
+} from '../../../src/actions/projects';
+
+import {toggleLibrary} from '../../../src/actions';
 
 import {
   getProjectKeys,
@@ -36,6 +41,28 @@ describe('projectActions', () => {
         isPristineProject(getCurrentProject(store.getState())),
         'project should be pristine'
       );
+    });
+  });
+
+  describe('changeCurrentProject', () => {
+    let projectKey;
+
+    beforeEach(() => {
+      store.dispatch(createProject());
+      projectKey = getCurrentProject(store.getState()).projectKey;
+      store.dispatch(toggleLibrary(projectKey, 'jquery'));
+      store.dispatch(createProject());
+      const secondProjectKey = getCurrentProject(store.getState()).projectKey;
+      store.dispatch(toggleLibrary(secondProjectKey, 'jquery'));
+      store.dispatch(changeCurrentProject(projectKey));
+    });
+
+    it('changes to the specified project', () => {
+      assert.equal(projectKey, getCurrentProject(store.getState()).projectKey);
+    });
+
+    it('keeps all projects in list', () => {
+      assert.lengthOf(getProjectKeys(store.getState()), 2);
     });
   });
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,7 +8,7 @@ import Gists from '../services/Gists';
 import appFirebase from '../services/appFirebase';
 import validations from '../validations';
 
-import {createProject} from './projects';
+import {createProject, changeCurrentProject} from './projects';
 import {userTyped} from './ui';
 import {isPristineProject} from '../util/projectUtils';
 
@@ -25,7 +25,7 @@ function getCurrentPersistor(state) {
   return null;
 }
 
-function getCurrentProject(state) {
+export function getCurrentProject(state) {
   const projectKey = state.currentProject.get('projectKey');
   if (projectKey) {
     return state.projects.get(projectKey);
@@ -34,7 +34,7 @@ function getCurrentProject(state) {
   return null;
 }
 
-function saveCurrentProject(state) {
+export function saveCurrentProject(state) {
   const currentProject = getCurrentProject(state);
   const persistor = getCurrentPersistor(state);
 
@@ -68,7 +68,7 @@ function validateSource(language, source, enabledLibraries) {
   };
 }
 
-function validateAllSources(project) {
+export function validateAllSources(project) {
   return (dispatch) => {
     const enabledLibraries = project.get('enabledLibraries');
     project.get('sources').forEach((source, language) => {
@@ -131,19 +131,6 @@ function updateProjectSource(projectKey, language, newValue) {
       newValue,
       currentProject.get('enabledLibraries')
     ));
-  };
-}
-
-function changeCurrentProject(projectKey) {
-  return (dispatch, getState) => {
-    dispatch({
-      type: 'CURRENT_PROJECT_CHANGED',
-      payload: {projectKey},
-    });
-
-    const state = getState();
-    saveCurrentProject(state);
-    dispatch(validateAllSources(getCurrentProject(state)));
   };
 }
 

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -1,4 +1,5 @@
 import {createAction} from 'redux-actions';
+import {validateAllSources, getCurrentProject, saveCurrentProject} from '.';
 
 const createProjectWithKey = createAction(
   'PROJECT_CREATED',
@@ -8,6 +9,19 @@ const createProjectWithKey = createAction(
 export function createProject() {
   return (dispatch) => {
     dispatch(createProjectWithKey(generateProjectKey()));
+  };
+}
+
+export function changeCurrentProject(projectKey) {
+  return (dispatch, getState) => {
+    dispatch({
+      type: 'CURRENT_PROJECT_CHANGED',
+      payload: {projectKey},
+    });
+
+    const state = getState();
+    saveCurrentProject(state);
+    dispatch(validateAllSources(getCurrentProject(state)));
   };
 }
 

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -71,7 +71,7 @@ function projects(stateIn, action) {
 
     case 'CURRENT_PROJECT_CHANGED':
       return state.filter((project, projectKey) => (
-        projectKey === action.payload.projectKey || isPristineProject(project)
+        projectKey === action.payload.projectKey || !isPristineProject(project)
       ));
 
     case 'RESET_WORKSPACE':


### PR DESCRIPTION
Fixes bug where switching projects causes all other projects in the list to disappear. This is because I had reversed one of the conditions in the filter for which projects to retain after a project switch.