### PR TITLE
Disallow blocking prompt in preview

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -30,7 +30,7 @@ class Preview extends React.Component {
         targetBaseTop: isLivePreview,
         propagateErrorsToParent: isLivePreview,
         breakLoops: isLivePreview,
-        nonBlockingAlerts: isLivePreview,
+        nonBlockingAlertsAndPrompts: isLivePreview,
       }
     ).documentElement.outerHTML;
   }

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -39,15 +39,20 @@ const errorHandlerScript = `(${(() => {
   };
 }).toString()}());`;
 
-const alertReplacementScript = `(${(() => {
+const alertAndPromptReplacementScript = `(${(() => {
   const _swal = window.swal;
 
-  Object.defineProperty(window, // eslint-disable-line prefer-reflect
-    'alert', {
+  Object.defineProperties(window, { // eslint-disable-line prefer-reflect
+    alert: {
       value: (message) => {
         _swal(message);
       },
-    });
+    },
+    prompt: {
+      value: (message, defaultValue = '') => defaultValue,
+    },
+  });
+
   delete window.swal; // eslint-disable-line prefer-reflect
 }).toString()}());`;
 
@@ -62,7 +67,7 @@ class PreviewGenerator {
     this.previewBody = this._ensureElement('body');
 
     this.previewText = (this.previewBody.innerText || '').trim();
-    this._attachLibraries(options.nonBlockingAlerts);
+    this._attachLibraries(options.nonBlockingAlertsAndPrompts);
 
     if (options.targetBaseTop) {
       this._addBase();
@@ -72,8 +77,8 @@ class PreviewGenerator {
       this._addErrorHandling();
     }
 
-    if (options.nonBlockingAlerts) {
-      this._addAlertHandling();
+    if (options.nonBlockingAlertsAndPrompts) {
+      this._addAlertAndPromptHandling();
     }
 
     this._addJavascript(pick(options, 'breakLoops'));
@@ -137,9 +142,9 @@ class PreviewGenerator {
     this.previewBody.appendChild(scriptTag);
   }
 
-  _addAlertHandling() {
+  _addAlertAndPromptHandling() {
     const scriptTag = this.previewDocument.createElement('script');
-    scriptTag.innerHTML = alertReplacementScript;
+    scriptTag.innerHTML = alertAndPromptReplacementScript;
     this.previewBody.appendChild(scriptTag);
   }
 


### PR DESCRIPTION
Not sure if you wanted to do anything fancier than this, it just ignores whatever is passed in, doesn't block, and returns the second parameter, or the empty string. This way users can continue to write code after prompts and do string methods, coerce types, etc, without getting errors (I'm sure there are cases where this is not true).