### PR TITLE
Confirm before exporting anonymous gist

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -11,7 +11,8 @@
       "libraries": "Libraries",
       "export-gist": "Export Gist",
       "send-feedback": "Send Feedback"
-    }
+    },
+    "anonymous-gist-export": "Are you sure you want to export this gist anonymously? If you sign in before exporting, the gist will be added to your GitHub account."
   },
   "editors": {
     "helpText": "Type in your $t(languages.__language__) code here."

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -111,6 +111,13 @@ class Dashboard extends React.Component {
   }
 
   _handleExportGist() {
+    if (!this.props.currentUser.authenticated) {
+      // eslint-disable-next-line no-alert
+      if (!confirm(i18n.t('dashboard.anonymous-gist-export'))) {
+        return;
+      }
+    }
+
     const newWindow = open('about:blank', 'gist');
 
     Gists.createFromProject(this.props.currentProject, this.props.currentUser).


### PR DESCRIPTION
When a student is signed in, Popcode will export their gist to GitHub under their account. This is better. Prompt before exporting a gist anonymously.