### PR TITLE
Improved support for old browsers

### DIFF
--- a/config/browsers.json
+++ b/config/browsers.json
@@ -1,0 +1,6 @@
+{
+  "msie": "11",
+  "firefox": "28",
+  "chrome": "30",
+  "safari": "7.1"
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,6 +12,7 @@ import uglify from 'gulp-uglify';
 import cssnano from 'gulp-cssnano';
 import gutil from 'gulp-util';
 import memoize from 'lodash/memoize';
+import forOwn from 'lodash/forOwn';
 import brfs from 'brfs-babel';
 import babelify from 'babelify';
 import envify from 'envify';
@@ -26,6 +27,17 @@ const baseDir = 'static';
 const distDir = `${baseDir}/compiled`;
 const stylesheetsDir = `${srcDir}/css`;
 const bowerComponents = 'bower_components';
+
+const cssnextBrowsers = [];
+const supportedBrowsers =
+  JSON.parse(fs.readFileSync('./config/browsers.json'));
+forOwn(supportedBrowsers, (version, browser) => {
+  let browserForCssnext = browser;
+  if (browser === 'msie') {
+    browserForCssnext = 'ie';
+  }
+  cssnextBrowsers.push(`${browserForCssnext} >= ${version}`);
+});
 
 let browserifyImpl;
 if (gulp.env.production) {
@@ -88,7 +100,7 @@ gulp.task('css', () => gulp.
   ]).
   pipe(concat('application.css')).
   pipe(sourcemaps.init({loadMaps: true})).
-  pipe(postcss([cssnext()])).
+  pipe(postcss([cssnext({browsers: cssnextBrowsers})])).
   pipe(gutil.env.production ? cssnano() : gutil.noop()).
   pipe(sourcemaps.write('./')).
   pipe(gulp.dest(distDir)).

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,1476 +6,1826 @@
   "dependencies": {
     "JSONStream": {
       "version": "1.1.4",
+      "from": "JSONStream@https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz"
     },
     "PrettyCSS": {
       "version": "0.3.12",
+      "from": "PrettyCSS@https://registry.npmjs.org/PrettyCSS/-/PrettyCSS-0.3.12.tgz",
       "resolved": "https://registry.npmjs.org/PrettyCSS/-/PrettyCSS-0.3.12.tgz"
     },
     "abbrev": {
       "version": "1.0.9",
+      "from": "abbrev@https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
     },
     "accepts": {
       "version": "1.3.3",
+      "from": "accepts@https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
     },
     "acorn": {
       "version": "1.2.2",
+      "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
     },
     "acorn-jsx": {
       "version": "3.0.1",
+      "from": "acorn-jsx@https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
+          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         }
       }
     },
     "after": {
       "version": "0.8.1",
+      "from": "after@https://registry.npmjs.org/after/-/after-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
     },
     "align-text": {
       "version": "0.1.4",
+      "from": "align-text@https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
     },
     "alphanum-sort": {
       "version": "1.0.2",
+      "from": "alphanum-sort@https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
     },
     "amdefine": {
       "version": "1.0.0",
+      "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
+      "from": "ansi-escapes@https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
+      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
+      "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "ansicolors": {
       "version": "0.2.1",
+      "from": "ansicolors@https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
     },
     "anymatch": {
       "version": "1.3.0",
+      "from": "anymatch@https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "archy": {
       "version": "1.0.0",
+      "from": "archy@https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
     },
     "argparse": {
       "version": "1.0.7",
+      "from": "argparse@https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
+      "from": "arr-diff@https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
+      "from": "arr-flatten@https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
+      "from": "array-differ@https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
     "array-filter": {
       "version": "0.0.1",
+      "from": "array-filter@https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
     },
     "array-find": {
       "version": "0.1.1",
+      "from": "array-find@https://registry.npmjs.org/array-find/-/array-find-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-0.1.1.tgz"
     },
     "array-find-index": {
       "version": "1.0.1",
+      "from": "array-find-index@https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-map": {
       "version": "0.0.0",
+      "from": "array-map@https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
     },
     "array-reduce": {
       "version": "0.0.0",
+      "from": "array-reduce@https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
     },
     "array-slice": {
       "version": "0.2.3",
+      "from": "array-slice@https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
     },
     "array-union": {
       "version": "1.0.2",
+      "from": "array-union@https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
     },
     "array-uniq": {
       "version": "1.0.3",
+      "from": "array-uniq@https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
+      "from": "array-unique@https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
+      "from": "arraybuffer.slice@https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
     },
     "arrify": {
       "version": "1.0.1",
+      "from": "arrify@https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
       "version": "2.0.4",
+      "from": "asap@https://registry.npmjs.org/asap/-/asap-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
     },
     "asn1": {
       "version": "0.1.11",
+      "from": "asn1@https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
     },
     "asn1.js": {
       "version": "4.8.0",
+      "from": "asn1.js@https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz"
     },
     "assert": {
       "version": "1.3.0",
+      "from": "assert@https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
     },
     "assert-plus": {
       "version": "0.1.5",
+      "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "assertion-error": {
       "version": "1.0.2",
+      "from": "assertion-error@https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "ast-types": {
       "version": "0.8.15",
+      "from": "ast-types@https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
     },
     "astw": {
       "version": "2.0.0",
+      "from": "astw@https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz"
     },
     "async": {
       "version": "2.0.1",
+      "from": "async@https://registry.npmjs.org/async/-/async-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz"
     },
     "async-each": {
       "version": "1.0.1",
+      "from": "async-each@https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
     },
     "async-each-series": {
       "version": "0.1.1",
+      "from": "async-each-series@https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz"
     },
     "atob": {
       "version": "1.1.3",
+      "from": "atob@https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
     },
     "autoprefixer": {
       "version": "6.4.1",
+      "from": "autoprefixer@https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.4.1.tgz",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.4.1.tgz",
       "dependencies": {
         "postcss": {
           "version": "5.1.2",
+          "from": "postcss@https://registry.npmjs.org/postcss/-/postcss-5.1.2.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.1.2.tgz"
         },
         "supports-color": {
           "version": "3.1.2",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         }
       }
     },
     "aws-sign2": {
       "version": "0.6.0",
+      "from": "aws-sign2@https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.4.1",
+      "from": "aws4@https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
     },
     "axios": {
       "version": "0.10.0",
+      "from": "axios@https://registry.npmjs.org/axios/-/axios-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.10.0.tgz"
     },
     "babel-code-frame": {
       "version": "6.11.0",
+      "from": "babel-code-frame@https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
       "dependencies": {
         "esutils": {
           "version": "2.0.2",
+          "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "js-tokens": {
           "version": "2.0.0",
+          "from": "js-tokens@https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
         }
       }
     },
     "babel-core": {
       "version": "6.14.0",
+      "from": "babel-core@https://registry.npmjs.org/babel-core/-/babel-core-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.14.0.tgz"
     },
     "babel-eslint": {
       "version": "6.1.2",
+      "from": "babel-eslint@https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz"
     },
     "babel-generator": {
       "version": "6.14.0",
+      "from": "babel-generator@https://registry.npmjs.org/babel-generator/-/babel-generator-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.14.0.tgz"
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.9.0",
+      "from": "babel-helper-builder-react-jsx@https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
       "dependencies": {
         "esutils": {
           "version": "2.0.2",
+          "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         }
       }
     },
     "babel-helper-call-delegate": {
       "version": "6.8.0",
+      "from": "babel-helper-call-delegate@https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz"
     },
     "babel-helper-define-map": {
       "version": "6.9.0",
+      "from": "babel-helper-define-map@https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz"
     },
     "babel-helper-function-name": {
       "version": "6.8.0",
+      "from": "babel-helper-function-name@https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz"
     },
     "babel-helper-get-function-arity": {
       "version": "6.8.0",
+      "from": "babel-helper-get-function-arity@https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
     },
     "babel-helper-hoist-variables": {
       "version": "6.8.0",
+      "from": "babel-helper-hoist-variables@https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.8.0",
+      "from": "babel-helper-optimise-call-expression@https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
     },
     "babel-helper-regex": {
       "version": "6.9.0",
+      "from": "babel-helper-regex@https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz"
     },
     "babel-helper-replace-supers": {
       "version": "6.14.0",
+      "from": "babel-helper-replace-supers@https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.14.0.tgz"
     },
     "babel-helpers": {
       "version": "6.8.0",
+      "from": "babel-helpers@https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz"
     },
     "babel-messages": {
       "version": "6.8.0",
+      "from": "babel-messages@https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.8.0",
+      "from": "babel-plugin-check-es2015-constants@https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
     },
     "babel-plugin-static-fs": {
       "version": "1.1.0",
+      "from": "babel-plugin-static-fs@https://registry.npmjs.org/babel-plugin-static-fs/-/babel-plugin-static-fs-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-static-fs/-/babel-plugin-static-fs-1.1.0.tgz"
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-functions@https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
     },
     "babel-plugin-syntax-flow": {
       "version": "6.13.0",
+      "from": "babel-plugin-syntax-flow@https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.13.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.13.0.tgz"
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.13.0",
+      "from": "babel-plugin-syntax-jsx@https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.13.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.13.0.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.15.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.14.0",
+      "from": "babel-plugin-transform-es2015-classes@https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz"
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-destructuring@https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-for-of@https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-function-name@https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-literals@https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-modules-amd@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.14.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.14.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.14.0",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.12.0",
+      "from": "babel-plugin-transform-es2015-modules-umd@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-object-super@https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.11.4",
+      "from": "babel-plugin-transform-es2015-parameters@https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.11.4.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.11.4.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-spread@https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-template-literals@https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.11.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.14.0",
+      "from": "babel-plugin-transform-flow-strip-types@https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.14.0.tgz"
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-react-display-name@https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz"
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.8.0",
+      "from": "babel-plugin-transform-react-jsx@https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.11.0",
+      "from": "babel-plugin-transform-react-jsx-self@https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz"
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.9.0",
+      "from": "babel-plugin-transform-react-jsx-source@https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.14.0",
+      "from": "babel-plugin-transform-regenerator@https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.14.0.tgz"
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.11.3",
+      "from": "babel-plugin-transform-strict-mode@https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz"
     },
     "babel-polyfill": {
       "version": "6.13.0",
+      "from": "babel-polyfill@https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.13.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.13.0.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
+          "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
         }
       }
     },
     "babel-preset-es2015": {
       "version": "6.14.0",
+      "from": "babel-preset-es2015@https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.14.0.tgz"
     },
     "babel-preset-react": {
       "version": "6.11.1",
+      "from": "babel-preset-react@https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.11.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.11.1.tgz"
     },
     "babel-register": {
       "version": "6.14.0",
+      "from": "babel-register@https://registry.npmjs.org/babel-register/-/babel-register-6.14.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.14.0.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
+          "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
         }
       }
     },
     "babel-runtime": {
       "version": "6.11.6",
+      "from": "babel-runtime@https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
+          "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
         }
       }
     },
     "babel-template": {
       "version": "6.15.0",
+      "from": "babel-template@https://registry.npmjs.org/babel-template/-/babel-template-6.15.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.15.0.tgz"
     },
     "babel-traverse": {
       "version": "6.15.0",
+      "from": "babel-traverse@https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.15.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.15.0.tgz"
     },
     "babel-types": {
       "version": "6.15.0",
+      "from": "babel-types@https://registry.npmjs.org/babel-types/-/babel-types-6.15.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.15.0.tgz",
       "dependencies": {
         "esutils": {
           "version": "2.0.2",
+          "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         }
       }
     },
     "babelify": {
       "version": "7.3.0",
+      "from": "babelify@https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "babylon": {
       "version": "6.9.1",
+      "from": "babylon@https://registry.npmjs.org/babylon/-/babylon-6.9.1.tgz",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.9.1.tgz"
     },
     "backo2": {
       "version": "1.0.2",
+      "from": "backo2@https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
     },
     "balanced-match": {
       "version": "0.4.2",
+      "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
       "version": "1.1.1",
+      "from": "base62@https://registry.npmjs.org/base62/-/base62-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.1.tgz"
     },
     "base64-arraybuffer": {
       "version": "0.1.2",
+      "from": "base64-arraybuffer@https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
     },
     "base64-js": {
       "version": "1.1.2",
+      "from": "base64-js@https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
     },
     "base64id": {
       "version": "0.1.0",
+      "from": "base64id@https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
     },
     "batch": {
       "version": "0.5.3",
+      "from": "batch@https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.0",
+      "from": "bcrypt-pbkdf@https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "dependencies": {
         "tweetnacl": {
           "version": "0.14.3",
+          "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
         }
       }
     },
     "beeper": {
       "version": "1.1.0",
+      "from": "beeper@https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "benchmark": {
       "version": "1.0.0",
+      "from": "benchmark@https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
     },
     "better-assert": {
       "version": "1.0.2",
+      "from": "better-assert@https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
     },
     "binary-extensions": {
       "version": "1.6.0",
+      "from": "binary-extensions@https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz"
     },
     "bl": {
       "version": "1.0.3",
+      "from": "bl@https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "blob": {
       "version": "0.0.4",
+      "from": "blob@https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "bluebird": {
       "version": "3.4.6",
+      "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
     },
     "bn.js": {
       "version": "4.11.6",
+      "from": "bn.js@https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
     },
     "body-parser": {
       "version": "1.15.2",
+      "from": "body-parser@https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
       "dependencies": {
         "qs": {
           "version": "6.2.0",
+          "from": "qs@https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         }
       }
     },
     "boom": {
       "version": "2.10.1",
+      "from": "boom@https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "bower": {
       "version": "1.7.9",
+      "from": "bower@https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz"
     },
     "bower-config": {
       "version": "1.4.0",
+      "from": "bower-config@https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz"
     },
     "bowser": {
       "version": "1.4.5",
+      "from": "bowser@https://registry.npmjs.org/bowser/-/bowser-1.4.5.tgz",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.4.5.tgz"
     },
     "boxen": {
       "version": "0.3.1",
+      "from": "boxen@https://registry.npmjs.org/boxen/-/boxen-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.3.1.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         },
         "repeating": {
           "version": "2.0.1",
+          "from": "repeating@https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
         }
       }
     },
     "brace": {
       "version": "0.8.0",
+      "from": "brace@https://registry.npmjs.org/brace/-/brace-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/brace/-/brace-0.8.0.tgz"
     },
     "brace-expansion": {
       "version": "1.1.6",
+      "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "braces": {
       "version": "1.8.5",
+      "from": "braces@https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
     "brfs-babel": {
       "version": "1.0.0",
+      "from": "brfs-babel@https://registry.npmjs.org/brfs-babel/-/brfs-babel-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/brfs-babel/-/brfs-babel-1.0.0.tgz"
     },
     "brorand": {
       "version": "1.0.5",
+      "from": "brorand@https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
     },
     "browser-pack": {
       "version": "6.0.1",
+      "from": "browser-pack@https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.1.tgz",
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.1.tgz"
     },
     "browser-resolve": {
       "version": "1.11.2",
+      "from": "browser-resolve@https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
     },
     "browser-sync": {
       "version": "2.14.3",
+      "from": "browser-sync@https://registry.npmjs.org/browser-sync/-/browser-sync-2.14.3.tgz",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.14.3.tgz"
     },
     "browser-sync-client": {
       "version": "2.4.2",
+      "from": "browser-sync-client@https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.4.2.tgz",
       "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.4.2.tgz"
     },
     "browser-sync-ui": {
       "version": "0.6.0",
+      "from": "browser-sync-ui@https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.0.tgz"
     },
     "browserify": {
       "version": "13.1.0",
+      "from": "browserify@https://registry.npmjs.org/browserify/-/browserify-13.1.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.1.0.tgz"
     },
     "browserify-aes": {
       "version": "1.0.6",
+      "from": "browserify-aes@https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
     },
     "browserify-cache-api": {
       "version": "3.0.1",
+      "from": "browserify-cache-api@https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
+          "from": "async@https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         }
       }
     },
     "browserify-cipher": {
       "version": "1.0.0",
+      "from": "browserify-cipher@https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
     },
     "browserify-des": {
       "version": "1.0.0",
+      "from": "browserify-des@https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
     },
     "browserify-incremental": {
       "version": "3.1.1",
+      "from": "browserify-incremental@https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
+          "from": "JSONStream@https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz"
         },
         "jsonparse": {
           "version": "0.0.5",
+          "from": "jsonparse@https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
         }
       }
     },
     "browserify-rsa": {
       "version": "4.0.1",
+      "from": "browserify-rsa@https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
     },
     "browserify-sign": {
       "version": "4.0.0",
+      "from": "browserify-sign@https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz"
     },
     "browserify-zlib": {
       "version": "0.1.4",
+      "from": "browserify-zlib@https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
       "version": "1.3.6",
+      "from": "browserslist@https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz"
     },
     "bs-recipes": {
       "version": "1.2.3",
+      "from": "bs-recipes@https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.2.3.tgz",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.2.3.tgz"
     },
     "buffer": {
       "version": "4.9.1",
+      "from": "buffer@https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
+      "from": "buffer-shims@https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "buffer-xor": {
       "version": "1.0.3",
+      "from": "buffer-xor@https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
     },
     "bugsnag-js": {
       "version": "3.0.2",
+      "from": "bugsnag-js@https://registry.npmjs.org/bugsnag-js/-/bugsnag-js-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/bugsnag-js/-/bugsnag-js-3.0.2.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
+      "from": "builtin-modules@https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "builtin-status-codes": {
       "version": "2.0.0",
+      "from": "builtin-status-codes@https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
     },
     "bulk-require": {
       "version": "1.0.0",
+      "from": "bulk-require@https://registry.npmjs.org/bulk-require/-/bulk-require-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bulk-require/-/bulk-require-1.0.0.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
+          "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
     },
     "bulkify": {
       "version": "1.4.2",
+      "from": "bulkify@https://registry.npmjs.org/bulkify/-/bulkify-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/bulkify/-/bulkify-1.4.2.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "object-keys": {
           "version": "0.4.0",
+          "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.4.2",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
         },
         "xtend": {
           "version": "2.1.2",
+          "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
         }
       }
     },
     "bytes": {
       "version": "2.4.0",
+      "from": "bytes@https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
     },
     "caller-path": {
       "version": "0.1.0",
+      "from": "caller-path@https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
     },
     "callsite": {
       "version": "1.0.0",
+      "from": "callsite@https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
     },
     "callsite-record": {
       "version": "3.2.1",
+      "from": "callsite-record@https://registry.npmjs.org/callsite-record/-/callsite-record-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/callsite-record/-/callsite-record-3.2.1.tgz"
     },
     "callsites": {
       "version": "0.2.0",
+      "from": "callsites@https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
     },
     "camelcase": {
       "version": "1.2.1",
+      "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
+      "from": "camelcase-keys@https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
+          "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         }
       }
     },
     "camelize": {
       "version": "1.0.0",
+      "from": "camelize@https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz"
     },
     "caniuse-api": {
       "version": "1.5.2",
+      "from": "caniuse-api@https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.2.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.6",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "lodash.memoize": {
           "version": "4.1.2",
+          "from": "lodash.memoize@https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
         },
         "shelljs": {
           "version": "0.7.4",
+          "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.7.4.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.4.tgz"
         }
       }
     },
     "caniuse-db": {
       "version": "1.0.30000528",
+      "from": "caniuse-db@https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000528.tgz",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000528.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
+      "from": "capture-stack-trace@https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
     "cardinal": {
       "version": "0.5.0",
+      "from": "cardinal@https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz"
     },
     "caseless": {
       "version": "0.11.0",
+      "from": "caseless@https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "center-align": {
       "version": "0.1.3",
+      "from": "center-align@https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
     "chai": {
       "version": "3.5.0",
+      "from": "chai@https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chai-as-promised": {
       "version": "5.3.0",
+      "from": "chai-as-promised@https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
+      "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "check-dependencies": {
       "version": "1.0.1",
+      "from": "check-dependencies@https://registry.npmjs.org/check-dependencies/-/check-dependencies-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/check-dependencies/-/check-dependencies-1.0.1.tgz"
     },
     "chokidar": {
       "version": "1.6.0",
+      "from": "chokidar@https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz"
     },
     "cipher-base": {
       "version": "1.0.2",
+      "from": "cipher-base@https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
     },
     "circular-json": {
       "version": "0.3.1",
+      "from": "circular-json@https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
     },
     "clap": {
       "version": "1.1.1",
+      "from": "clap@https://registry.npmjs.org/clap/-/clap-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.1.1.tgz"
     },
     "classnames": {
       "version": "2.2.5",
+      "from": "classnames@https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
     },
     "cli": {
       "version": "1.0.0",
+      "from": "cli@https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.6",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         }
       }
     },
     "cli-color": {
       "version": "0.1.7",
+      "from": "cli-color@https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
       "dependencies": {
         "es5-ext": {
           "version": "0.8.2",
+          "from": "es5-ext@https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz"
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
+      "from": "cli-cursor@https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-spinners": {
       "version": "0.1.2",
+      "from": "cli-spinners@https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz"
     },
     "cli-width": {
       "version": "2.1.0",
+      "from": "cli-width@https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
     },
     "cliui": {
       "version": "3.2.0",
+      "from": "cliui@https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
     },
     "clone": {
       "version": "1.0.2",
+      "from": "clone@https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
+      "from": "clone-stats@https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "co": {
       "version": "4.6.0",
+      "from": "co@https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "coa": {
       "version": "1.0.1",
+      "from": "coa@https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz"
     },
     "code-point-at": {
       "version": "1.0.0",
+      "from": "code-point-at@https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "color": {
       "version": "0.11.3",
+      "from": "color@https://registry.npmjs.org/color/-/color-0.11.3.tgz",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.3.tgz"
     },
     "color-convert": {
       "version": "1.5.0",
+      "from": "color-convert@https://registry.npmjs.org/color-convert/-/color-convert-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.5.0.tgz"
     },
     "color-name": {
       "version": "1.1.1",
+      "from": "color-name@https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
     },
     "color-string": {
       "version": "0.3.0",
+      "from": "color-string@https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
     },
     "colormin": {
       "version": "1.1.2",
+      "from": "colormin@https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz"
     },
     "colors": {
       "version": "1.1.2",
+      "from": "colors@https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
     },
     "combine-lists": {
       "version": "1.0.0",
+      "from": "combine-lists@https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.0.tgz"
     },
     "combine-source-map": {
       "version": "0.7.2",
+      "from": "combine-source-map@https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
+      "from": "combined-stream@https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.9.0",
+      "from": "commander@https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "commoner": {
       "version": "0.10.4",
+      "from": "commoner@https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
+      "from": "component-bind@https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
     },
     "component-emitter": {
       "version": "1.1.2",
+      "from": "component-emitter@https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
     },
     "component-inherit": {
       "version": "0.0.3",
+      "from": "component-inherit@https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
+      "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.2",
+      "from": "concat-stream@https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "concat-with-sourcemaps": {
       "version": "1.0.4",
+      "from": "concat-with-sourcemaps@https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz"
     },
     "configstore": {
       "version": "2.1.0",
+      "from": "configstore@https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "connect": {
       "version": "3.4.1",
+      "from": "connect@https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz"
     },
     "connect-history-api-fallback": {
       "version": "1.3.0",
+      "from": "connect-history-api-fallback@https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
     },
     "console-browserify": {
       "version": "1.1.0",
+      "from": "console-browserify@https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
     },
     "constants-browserify": {
       "version": "1.0.0",
+      "from": "constants-browserify@https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
     },
     "content-type": {
       "version": "1.0.2",
+      "from": "content-type@https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
       "version": "1.1.3",
+      "from": "convert-source-map@https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
     },
     "core-js": {
       "version": "1.2.7",
+      "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
+      "from": "core-util-is@https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "create-ecdh": {
       "version": "4.0.0",
+      "from": "create-ecdh@https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
     },
     "create-error-class": {
       "version": "3.0.2",
+      "from": "create-error-class@https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
     },
     "create-hash": {
       "version": "1.1.2",
+      "from": "create-hash@https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
     },
     "create-hmac": {
       "version": "1.1.4",
+      "from": "create-hmac@https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
     },
     "cross-spawn-async": {
       "version": "2.2.4",
+      "from": "cross-spawn-async@https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "4.0.1",
+          "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
         }
       }
     },
     "cryptiles": {
       "version": "2.0.5",
+      "from": "cryptiles@https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto-browserify": {
       "version": "3.11.0",
+      "from": "crypto-browserify@https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
     },
     "css": {
       "version": "2.2.1",
+      "from": "css@https://registry.npmjs.org/css/-/css-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.43",
+          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         }
       }
     },
     "css-color-function": {
       "version": "1.3.0",
+      "from": "css-color-function@https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.0.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.1.0",
+          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
         },
         "debug": {
           "version": "0.7.4",
+          "from": "debug@https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
         }
       }
     },
     "css-color-names": {
       "version": "0.0.4",
+      "from": "css-color-names@https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz"
     },
     "cssnano": {
       "version": "3.7.4",
+      "from": "cssnano@https://registry.npmjs.org/cssnano/-/cssnano-3.7.4.tgz",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.7.4.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "csso": {
       "version": "2.0.0",
+      "from": "csso@https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz"
     },
     "ctype": {
       "version": "0.5.3",
+      "from": "ctype@https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
     },
     "currently-unhandled": {
       "version": "0.4.1",
+      "from": "currently-unhandled@https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "custom-event": {
       "version": "1.0.0",
+      "from": "custom-event@https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz"
     },
     "d": {
       "version": "0.1.1",
+      "from": "d@https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
       "version": "1.14.0",
+      "from": "dashdash@https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
+      "from": "date-now@https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "dateformat": {
       "version": "1.0.12",
+      "from": "dateformat@https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
       "version": "2.2.0",
+      "from": "debug@https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
+      "from": "decamelize@https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
+      "from": "deep-eql@https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
+          "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
     },
     "deep-extend": {
       "version": "0.4.1",
+      "from": "deep-extend@https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
+      "from": "deep-is@https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "defaults": {
       "version": "1.0.3",
+      "from": "defaults@https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "defined": {
       "version": "1.0.0",
+      "from": "defined@https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
     },
     "del": {
       "version": "2.2.2",
+      "from": "del@https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
+      "from": "delayed-stream@https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "depcheck": {
       "version": "0.6.4",
+      "from": "depcheck@https://registry.npmjs.org/depcheck/-/depcheck-0.6.4.tgz",
       "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.6.4.tgz",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
+          "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         },
         "window-size": {
           "version": "0.2.0",
+          "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
         },
         "yargs": {
           "version": "4.8.1",
+          "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
         },
         "yargs-parser": {
           "version": "2.4.1",
+          "from": "yargs-parser@https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz"
         }
       }
     },
     "depd": {
       "version": "1.1.0",
+      "from": "depd@https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "deprecate": {
       "version": "0.1.0",
+      "from": "deprecate@https://registry.npmjs.org/deprecate/-/deprecate-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-0.1.0.tgz"
     },
     "deprecated": {
       "version": "0.0.1",
+      "from": "deprecated@https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
     },
     "deps-regex": {
       "version": "0.1.4",
+      "from": "deps-regex@https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz"
     },
     "deps-sort": {
       "version": "2.0.0",
+      "from": "deps-sort@https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz"
     },
     "des.js": {
       "version": "1.0.0",
+      "from": "des.js@https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
     },
     "destroy": {
       "version": "1.0.4",
+      "from": "destroy@https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "detect-file": {
       "version": "0.1.0",
+      "from": "detect-file@https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz"
     },
     "detect-indent": {
       "version": "3.0.1",
+      "from": "detect-indent@https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
     },
     "detective": {
       "version": "4.3.1",
+      "from": "detective@https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
     },
     "dev-ip": {
       "version": "1.0.1",
+      "from": "dev-ip@https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz"
     },
     "di": {
       "version": "0.0.1",
+      "from": "di@https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
     },
     "diff": {
       "version": "1.4.0",
+      "from": "diff@https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "diffie-hellman": {
       "version": "5.0.2",
+      "from": "diffie-hellman@https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
     },
     "difflib": {
       "version": "0.2.4",
+      "from": "difflib@https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
       "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz"
     },
     "doctrine": {
       "version": "1.3.0",
+      "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
       "dependencies": {
         "esutils": {
           "version": "2.0.2",
+          "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         }
       }
     },
     "dom-serialize": {
       "version": "2.2.1",
+      "from": "dom-serialize@https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
+      "from": "dom-serializer@https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
+          "from": "domelementtype@https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         }
       }
     },
     "domain-browser": {
       "version": "1.1.7",
+      "from": "domain-browser@https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "domelementtype": {
       "version": "1.3.0",
+      "from": "domelementtype@https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
+      "from": "domhandler@https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.5.1",
+      "from": "domutils@https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "dot-prop": {
       "version": "3.0.0",
+      "from": "dot-prop@https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
     },
     "dreamopt": {
       "version": "0.6.0",
+      "from": "dreamopt@https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz"
     },
     "duplexer2": {
       "version": "0.1.4",
+      "from": "duplexer2@https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
     },
     "easy-extender": {
       "version": "2.3.2",
+      "from": "easy-extender@https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "eazy-logger": {
       "version": "3.0.2",
+      "from": "eazy-logger@https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
+      "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
+      "from": "ee-first@https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "elliptic": {
       "version": "6.3.1",
+      "from": "elliptic@https://registry.npmjs.org/elliptic/-/elliptic-6.3.1.tgz",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.1.tgz"
     },
     "emitter-steward": {
       "version": "1.0.0",
+      "from": "emitter-steward@https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz"
     },
     "encodeurl": {
       "version": "1.0.1",
+      "from": "encodeurl@https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
     },
     "encoding": {
       "version": "0.1.12",
+      "from": "encoding@https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "end-of-stream": {
       "version": "0.1.5",
+      "from": "end-of-stream@https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
     },
     "engine.io": {
       "version": "1.6.11",
+      "from": "engine.io@https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
+          "from": "accepts@https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
         },
         "mime-db": {
           "version": "1.12.0",
+          "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
         },
         "mime-types": {
           "version": "2.0.14",
+          "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
         },
         "negotiator": {
           "version": "0.4.9",
+          "from": "negotiator@https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
         }
       }
     },
     "engine.io-client": {
       "version": "1.6.11",
+      "from": "engine.io-client@https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
       "dependencies": {
         "ws": {
           "version": "1.0.1",
+          "from": "ws@https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
         }
       }
     },
     "engine.io-parser": {
       "version": "1.2.4",
+      "from": "engine.io-parser@https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
+          "from": "has-binary@https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "utf8": {
           "version": "2.1.0",
+          "from": "utf8@https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
         }
       }
     },
     "ent": {
       "version": "2.2.0",
+      "from": "ent@https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
     },
     "entities": {
       "version": "1.1.1",
+      "from": "entities@https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "envify": {
       "version": "3.4.1",
+      "from": "envify@https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
       "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz"
     },
     "error": {
       "version": "4.4.0",
+      "from": "error@https://registry.npmjs.org/error/-/error-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
+      "from": "error-ex@https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "error-stack-parser": {
       "version": "1.3.6",
+      "from": "error-stack-parser@https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
+      "from": "es5-ext@https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
+      "from": "es6-iterator@https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.4",
+      "from": "es6-map@https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
     "es6-promise": {
       "version": "3.2.1",
+      "from": "es6-promise@https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
     },
     "es6-set": {
@@ -1484,352 +1834,432 @@
     },
     "es6-symbol": {
       "version": "3.1.0",
+      "from": "es6-symbol@https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
+      "from": "es6-weak-map@https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
+      "from": "escape-html@https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
+      "from": "escape-string-regexp@https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
       "version": "1.3.3",
+      "from": "escodegen@https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.1.1",
+          "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
         },
         "source-map": {
           "version": "0.1.43",
+          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         }
       }
     },
     "escope": {
       "version": "3.6.0",
+      "from": "escope@https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
+          "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         }
       }
     },
     "eslint": {
       "version": "3.4.0",
+      "from": "eslint@https://registry.npmjs.org/eslint/-/eslint-3.4.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.4.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
+          "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         },
         "esutils": {
           "version": "2.0.2",
+          "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "glob": {
           "version": "7.0.6",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "globals": {
           "version": "9.9.0",
+          "from": "globals@https://registry.npmjs.org/globals/-/globals-9.9.0.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.9.0.tgz"
         },
         "json-stable-stringify": {
           "version": "1.0.1",
+          "from": "json-stable-stringify@https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
         },
         "shelljs": {
           "version": "0.6.1",
+          "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
         },
         "strip-bom": {
           "version": "3.0.0",
+          "from": "strip-bom@https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
         },
         "user-home": {
           "version": "2.0.0",
+          "from": "user-home@https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
         }
       }
     },
     "eslint-plugin-react": {
       "version": "6.2.0",
+      "from": "eslint-plugin-react@https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.2.0.tgz"
     },
     "eslint_d": {
       "version": "4.0.1",
+      "from": "eslint_d@https://registry.npmjs.org/eslint_d/-/eslint_d-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint_d/-/eslint_d-4.0.1.tgz",
       "dependencies": {
         "supports-color": {
           "version": "3.1.2",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         }
       }
     },
     "espree": {
       "version": "3.1.7",
+      "from": "espree@https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
+          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         }
       }
     },
     "esprima": {
       "version": "3.0.0",
+      "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",
+      "from": "esrecurse@https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
+          "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "estraverse": {
       "version": "1.5.1",
+      "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
     },
     "esutils": {
       "version": "1.0.0",
+      "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
     },
     "etag": {
       "version": "1.7.0",
+      "from": "etag@https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
+      "from": "event-emitter@https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "eventemitter3": {
       "version": "1.2.0",
+      "from": "eventemitter3@https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
     },
     "events": {
       "version": "1.1.1",
+      "from": "events@https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
     },
     "evp_bytestokey": {
       "version": "1.0.0",
+      "from": "evp_bytestokey@https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
     },
     "execa": {
       "version": "0.2.2",
+      "from": "execa@https://registry.npmjs.org/execa/-/execa-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.2.2.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "exit": {
       "version": "0.1.2",
+      "from": "exit@https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
+      "from": "exit-hook@https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expand-braces": {
       "version": "0.1.2",
+      "from": "expand-braces@https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "dependencies": {
         "braces": {
           "version": "0.1.5",
+          "from": "braces@https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz"
         },
         "expand-range": {
           "version": "0.1.1",
+          "from": "expand-range@https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz"
         },
         "is-number": {
           "version": "0.1.1",
+          "from": "is-number@https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
         },
         "repeat-string": {
           "version": "0.2.2",
+          "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
         }
       }
     },
     "expand-brackets": {
       "version": "0.1.5",
+      "from": "expand-brackets@https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.2",
+      "from": "expand-range@https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "expand-tilde": {
       "version": "1.2.2",
+      "from": "expand-tilde@https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
     },
     "express": {
       "version": "2.5.11",
+      "from": "express@https://registry.npmjs.org/express/-/express-2.5.11.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
       "dependencies": {
         "connect": {
           "version": "1.9.2",
+          "from": "connect@https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz"
         },
         "mkdirp": {
           "version": "0.3.0",
+          "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         },
         "qs": {
           "version": "0.4.2",
+          "from": "qs@https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
         }
       }
     },
     "extend": {
       "version": "3.0.0",
+      "from": "extend@https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
       "version": "0.3.2",
+      "from": "extglob@https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extract-zip": {
       "version": "1.5.0",
+      "from": "extract-zip@https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.0",
+          "from": "concat-stream@https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz"
         },
         "debug": {
           "version": "0.7.4",
+          "from": "debug@https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
         },
         "minimist": {
           "version": "0.0.8",
+          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
+          "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "extsprintf": {
       "version": "1.0.2",
+      "from": "extsprintf@https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "falafel": {
       "version": "1.2.0",
+      "from": "falafel@https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "fancy-log": {
       "version": "1.2.0",
+      "from": "fancy-log@https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
     "fast-levenshtein": {
       "version": "1.1.4",
+      "from": "fast-levenshtein@https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz"
     },
     "fbjs": {
       "version": "0.8.4",
+      "from": "fbjs@https://registry.npmjs.org/fbjs/-/fbjs-0.8.4.tgz",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.4.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "fd-slicer": {
       "version": "1.0.1",
+      "from": "fd-slicer@https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "figures": {
       "version": "1.7.0",
+      "from": "figures@https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "file-entry-cache": {
       "version": "2.0.0",
+      "from": "file-entry-cache@https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "filename-regex": {
       "version": "2.0.0",
+      "from": "filename-regex@https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
+      "from": "fill-range@https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "filled-array": {
       "version": "1.1.0",
+      "from": "filled-array@https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz"
     },
     "finalhandler": {
       "version": "0.4.1",
+      "from": "finalhandler@https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
     },
     "find-index": {
       "version": "0.1.1",
+      "from": "find-index@https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
+      "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
           "version": "2.1.0",
+          "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "findup-sync": {
       "version": "0.4.2",
+      "from": "findup-sync@https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz"
     },
     "fined": {
       "version": "1.0.1",
+      "from": "fined@https://registry.npmjs.org/fined/-/fined-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.1.tgz",
       "dependencies": {
         "lodash.isarray": {
           "version": "4.0.0",
+          "from": "lodash.isarray@https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz"
         }
       }
@@ -1858,74 +2288,92 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
+      "from": "first-chunk-stream@https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
     },
     "flagged-respawn": {
       "version": "0.3.2",
+      "from": "flagged-respawn@https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
     },
     "flat-cache": {
       "version": "1.2.1",
+      "from": "flat-cache@https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz"
     },
     "flatten": {
       "version": "1.0.2",
+      "from": "flatten@https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
     },
     "follow-redirects": {
       "version": "0.0.7",
+      "from": "follow-redirects@https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz"
     },
     "for-in": {
       "version": "0.1.5",
+      "from": "for-in@https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
     },
     "for-own": {
       "version": "0.1.4",
+      "from": "for-own@https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "foreach": {
       "version": "2.0.5",
+      "from": "foreach@https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
+      "from": "forever-agent@https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.1",
+      "from": "form-data@https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
     },
     "formatio": {
       "version": "1.1.1",
+      "from": "formatio@https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
     "formidable": {
       "version": "1.0.17",
+      "from": "formidable@https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
     },
     "fresh": {
       "version": "0.3.0",
+      "from": "fresh@https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "fs-access": {
       "version": "1.0.0",
+      "from": "fs-access@https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz"
     },
     "fs-exists-sync": {
       "version": "0.1.0",
+      "from": "fs-exists-sync@https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
     },
     "fs-extra": {
       "version": "0.30.0",
+      "from": "fs-extra@https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz"
     },
     "fs.realpath": {
       "version": "1.0.0",
+      "from": "fs.realpath@https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fsevents": {
       "version": "1.0.14",
+      "from": "fsevents@https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
       "dependencies": {
         "abbrev": {
@@ -2414,1098 +2862,1359 @@
     },
     "function-bind": {
       "version": "1.1.0",
+      "from": "function-bind@https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "gaze": {
       "version": "0.5.2",
+      "from": "gaze@https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
+      "from": "generate-function@https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
+      "from": "generate-object-property@https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-caller-file": {
       "version": "1.0.2",
+      "from": "get-caller-file@https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
+      "from": "get-stdin@https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getpass": {
       "version": "0.1.6",
+      "from": "getpass@https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "git-rev-sync": {
       "version": "1.6.0",
+      "from": "git-rev-sync@https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.6.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
+          "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
         "shelljs": {
           "version": "0.6.0",
+          "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
         }
       }
     },
     "github-api": {
       "version": "2.3.0",
+      "from": "github-api@https://registry.npmjs.org/github-api/-/github-api-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/github-api/-/github-api-2.3.0.tgz"
     },
     "giturl": {
       "version": "1.0.0",
+      "from": "giturl@https://registry.npmjs.org/giturl/-/giturl-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/giturl/-/giturl-1.0.0.tgz"
     },
     "glob": {
       "version": "5.0.15",
+      "from": "glob@https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
+      "from": "glob-base@https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
+      "from": "glob-parent@https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
+      "from": "glob-stream@https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "dependencies": {
         "glob": {
           "version": "4.5.3",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
+          "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
+      "from": "glob-watcher@https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
     },
     "glob2base": {
       "version": "0.0.12",
+      "from": "glob2base@https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "global-modules": {
       "version": "0.2.3",
+      "from": "global-modules@https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
     },
     "global-prefix": {
       "version": "0.1.4",
+      "from": "global-prefix@https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz"
     },
     "globals": {
       "version": "8.18.0",
+      "from": "globals@https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
     },
     "globby": {
       "version": "5.0.0",
+      "from": "globby@https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.6",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "globule": {
       "version": "0.1.0",
+      "from": "globule@https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
         "glob": {
           "version": "3.1.21",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
+          "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
           "version": "1.0.2",
+          "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
         },
         "lodash": {
           "version": "1.0.2",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
+          "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
+      "from": "glogg@https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "got": {
       "version": "5.6.0",
+      "from": "got@https://registry.npmjs.org/got/-/got-5.6.0.tgz",
       "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "graceful-fs": {
       "version": "4.1.6",
+      "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
+      "from": "graceful-readlink@https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.8.1",
+      "from": "growl@https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
     },
     "gulp": {
       "version": "3.9.1",
+      "from": "gulp@https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
+          "from": "semver@https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "gulp-concat": {
       "version": "2.6.0",
+      "from": "gulp-concat@https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         }
       }
     },
     "gulp-cssnano": {
       "version": "2.1.2",
+      "from": "gulp-cssnano@https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.2.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "gulp-postcss": {
       "version": "6.1.1",
+      "from": "gulp-postcss@https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-6.1.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-6.1.1.tgz"
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
+      "from": "gulp-sourcemaps@https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "dependencies": {
         "vinyl": {
           "version": "1.2.0",
+          "from": "vinyl@https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
         }
       }
     },
     "gulp-uglify": {
       "version": "2.0.0",
+      "from": "gulp-uglify@https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-2.0.0.tgz"
     },
     "gulp-util": {
       "version": "3.0.7",
+      "from": "gulp-util@https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
+      "from": "gulplog@https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "har-validator": {
       "version": "2.0.6",
+      "from": "har-validator@https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has": {
       "version": "1.0.1",
+      "from": "has@https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
+      "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-binary": {
       "version": "0.1.7",
+      "from": "has-binary@https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "has-color": {
       "version": "0.1.7",
+      "from": "has-color@https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "has-cors": {
       "version": "1.1.0",
+      "from": "has-cors@https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
     },
     "has-flag": {
       "version": "1.0.0",
+      "from": "has-flag@https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
+      "from": "has-gulplog@https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "hash.js": {
       "version": "1.0.3",
+      "from": "hash.js@https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
     },
     "hasha": {
       "version": "2.2.0",
+      "from": "hasha@https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz"
     },
     "hat": {
       "version": "0.0.3",
+      "from": "hat@https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz"
     },
     "hawk": {
       "version": "3.1.3",
+      "from": "hawk@https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "heap": {
       "version": "0.2.6",
+      "from": "heap@https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz"
     },
     "highlight-es": {
       "version": "1.0.0",
+      "from": "highlight-es@https://registry.npmjs.org/highlight-es/-/highlight-es-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/highlight-es/-/highlight-es-1.0.0.tgz"
     },
     "hoek": {
       "version": "2.16.3",
+      "from": "hoek@https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
+      "from": "hoist-non-react-statics@https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
+      "from": "home-or-tmp@https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.5",
+      "from": "hosted-git-info@https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
     },
     "html-comment-regex": {
       "version": "1.1.1",
+      "from": "html-comment-regex@https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
     },
     "htmlescape": {
       "version": "1.1.1",
+      "from": "htmlescape@https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz"
     },
     "htmllint": {
       "version": "0.4.0",
+      "from": "htmllint@https://registry.npmjs.org/htmllint/-/htmllint-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/htmllint/-/htmllint-0.4.0.tgz"
     },
     "htmlparser2": {
       "version": "3.9.1",
+      "from": "htmlparser2@https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.1.tgz"
     },
     "http-errors": {
       "version": "1.5.0",
+      "from": "http-errors@https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
     },
     "http-proxy": {
       "version": "1.14.0",
+      "from": "http-proxy@https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz"
     },
     "http-signature": {
       "version": "0.11.0",
+      "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
     },
     "httpplease": {
       "version": "0.16.4",
+      "from": "httpplease@https://registry.npmjs.org/httpplease/-/httpplease-0.16.4.tgz",
       "resolved": "https://registry.npmjs.org/httpplease/-/httpplease-0.16.4.tgz",
       "dependencies": {
         "xtend": {
           "version": "3.0.0",
+          "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "https-browserify": {
       "version": "0.0.1",
+      "from": "https-browserify@https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
     "i18next-client": {
       "version": "1.11.4",
+      "from": "i18next-client@https://registry.npmjs.org/i18next-client/-/i18next-client-1.11.4.tgz",
       "resolved": "https://registry.npmjs.org/i18next-client/-/i18next-client-1.11.4.tgz"
     },
     "iconv-lite": {
       "version": "0.4.13",
+      "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
       "version": "1.1.6",
+      "from": "ieee754@https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
     },
     "ignore": {
       "version": "3.1.5",
+      "from": "ignore@https://registry.npmjs.org/ignore/-/ignore-3.1.5.tgz",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.5.tgz"
     },
     "immutable": {
       "version": "3.8.1",
+      "from": "immutable@https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
     },
     "immutable-devtools": {
       "version": "0.0.7",
+      "from": "immutable-devtools@https://registry.npmjs.org/immutable-devtools/-/immutable-devtools-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/immutable-devtools/-/immutable-devtools-0.0.7.tgz"
     },
     "imurmurhash": {
       "version": "0.1.4",
+      "from": "imurmurhash@https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
+      "from": "indent-string@https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "dependencies": {
         "repeating": {
           "version": "2.0.1",
+          "from": "repeating@https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
         }
       }
     },
     "indexes-of": {
       "version": "1.0.1",
+      "from": "indexes-of@https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
     },
     "indexof": {
       "version": "0.0.1",
+      "from": "indexof@https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
     },
     "inflight": {
       "version": "1.0.5",
+      "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
     },
     "inherits": {
       "version": "2.0.1",
+      "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
+      "from": "ini@https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-source-map": {
       "version": "0.6.2",
+      "from": "inline-source-map@https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
+      "from": "inquirer@https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz"
     },
     "insert-module-globals": {
       "version": "7.0.1",
+      "from": "insert-module-globals@https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz"
     },
     "interpret": {
       "version": "1.0.1",
+      "from": "interpret@https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
     },
     "invariant": {
       "version": "2.2.1",
+      "from": "invariant@https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
+      "from": "invert-kv@https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "is-absolute": {
       "version": "0.2.5",
+      "from": "is-absolute@https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
       "dependencies": {
         "is-windows": {
           "version": "0.1.1",
+          "from": "is-windows@https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz"
         }
       }
     },
     "is-absolute-url": {
       "version": "2.0.0",
+      "from": "is-absolute-url@https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
+      "from": "is-arrayish@https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
+      "from": "is-binary-path@https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.4",
+      "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
+      "from": "is-builtin-module@https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-ci": {
       "version": "1.0.9",
+      "from": "is-ci@https://registry.npmjs.org/is-ci/-/is-ci-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.9.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
+      "from": "is-dotfile@https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
+      "from": "is-equal-shallow@https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-es2016-keyword": {
       "version": "1.0.0",
+      "from": "is-es2016-keyword@https://registry.npmjs.org/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
+      "from": "is-extendable@https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
+      "from": "is-extglob@https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
+      "from": "is-finite@https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
+      "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
+      "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-my-json-valid": {
       "version": "2.13.1",
+      "from": "is-my-json-valid@https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
     },
     "is-npm": {
       "version": "1.0.0",
+      "from": "is-npm@https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
     },
     "is-number": {
       "version": "2.1.0",
+      "from": "is-number@https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-obj": {
       "version": "1.0.1",
+      "from": "is-obj@https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
+      "from": "is-path-cwd@https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
+      "from": "is-path-in-cwd@https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
+      "from": "is-path-inside@https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-plain-obj": {
       "version": "1.1.0",
+      "from": "is-plain-obj@https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
+      "from": "is-posix-bracket@https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
+      "from": "is-primitive@https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
+      "from": "is-property@https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-redirect": {
       "version": "1.0.0",
+      "from": "is-redirect@https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
     "is-relative": {
       "version": "0.2.1",
+      "from": "is-relative@https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
+      "from": "is-resolvable@https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-retry-allowed": {
       "version": "1.1.0",
+      "from": "is-retry-allowed@https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
+      "from": "is-stream@https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-svg": {
       "version": "2.0.1",
+      "from": "is-svg@https://registry.npmjs.org/is-svg/-/is-svg-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.0.1.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
+      "from": "is-typedarray@https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-unc-path": {
       "version": "0.1.1",
+      "from": "is-unc-path@https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
+      "from": "is-utf8@https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "is-windows": {
       "version": "0.2.0",
+      "from": "is-windows@https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
     },
     "isarray": {
       "version": "1.0.0",
+      "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isbinaryfile": {
       "version": "3.0.1",
+      "from": "isbinaryfile@https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.1.tgz"
     },
     "isexe": {
       "version": "1.1.2",
+      "from": "isexe@https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
       "version": "2.1.0",
+      "from": "isobject@https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
+      "from": "isomorphic-fetch@https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
+      "from": "isstream@https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "0.26.3",
+      "from": "jade@https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
+          "from": "commander@https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "mkdirp": {
           "version": "0.3.0",
+          "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
+      "from": "jodid25519@https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "js-base64": {
       "version": "2.1.9",
+      "from": "js-base64@https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
     },
     "js-string-escape": {
       "version": "1.0.1",
+      "from": "js-string-escape@https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
     },
     "js-tokens": {
       "version": "1.0.3",
+      "from": "js-tokens@https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
     },
     "js-yaml": {
       "version": "3.6.1",
+      "from": "js-yaml@https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
+          "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
         }
       }
     },
     "jsbn": {
       "version": "0.1.0",
+      "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsesc": {
       "version": "0.5.0",
+      "from": "jsesc@https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "jshint": {
       "version": "2.9.3",
+      "from": "jshint@https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
       "dependencies": {
         "entities": {
           "version": "1.0.0",
+          "from": "entities@https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
         },
         "htmlparser2": {
           "version": "3.8.3",
+          "from": "htmlparser2@https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "lodash": {
           "version": "3.7.0",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         },
         "readable-stream": {
           "version": "1.1.14",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
     "json-diff": {
       "version": "0.3.1",
+      "from": "json-diff@https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz"
     },
     "json-schema": {
       "version": "0.2.2",
+      "from": "json-schema@https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stable-stringify": {
       "version": "0.0.1",
+      "from": "json-stable-stringify@https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
+      "from": "json-stringify-safe@https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
       "version": "3.2.6",
+      "from": "json3@https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
     },
     "json5": {
       "version": "0.4.0",
+      "from": "json5@https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonfile": {
       "version": "2.3.1",
+      "from": "jsonfile@https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
+      "from": "jsonify@https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonparse": {
       "version": "1.2.0",
+      "from": "jsonparse@https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
+      "from": "jsonpointer@https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsprim": {
       "version": "1.3.0",
+      "from": "jsprim@https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
     },
     "jstransform": {
       "version": "11.0.3",
+      "from": "jstransform@https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
         },
         "source-map": {
           "version": "0.4.4",
+          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "jsx-ast-utils": {
       "version": "1.3.1",
+      "from": "jsx-ast-utils@https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.1.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "karma": {
       "version": "1.2.0",
+      "from": "karma@https://registry.npmjs.org/karma/-/karma-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.2.0.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
+          "from": "accepts@https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
         },
         "component-emitter": {
           "version": "1.2.0",
+          "from": "component-emitter@https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
         },
         "core-js": {
           "version": "2.4.1",
+          "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
         },
         "engine.io": {
           "version": "1.6.10",
+          "from": "engine.io@https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
           "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz"
         },
         "engine.io-client": {
           "version": "1.6.9",
+          "from": "engine.io-client@https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
           "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
           "dependencies": {
             "component-emitter": {
               "version": "1.1.2",
+              "from": "component-emitter@https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
             }
           }
         },
         "glob": {
           "version": "7.0.6",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "mime": {
           "version": "1.3.4",
+          "from": "mime@https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "mime-db": {
           "version": "1.12.0",
+          "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
         },
         "mime-types": {
           "version": "2.0.14",
+          "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
         },
         "negotiator": {
           "version": "0.4.9",
+          "from": "negotiator@https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
         },
         "socket.io": {
           "version": "1.4.7",
+          "from": "socket.io@https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz"
         },
         "socket.io-client": {
           "version": "1.4.6",
+          "from": "socket.io-client@https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz"
         },
         "ws": {
           "version": "1.0.1",
+          "from": "ws@https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
         }
       }
     },
     "karma-browserify": {
       "version": "5.1.0",
+      "from": "karma-browserify@https://registry.npmjs.org/karma-browserify/-/karma-browserify-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-5.1.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "karma-chai": {
       "version": "0.1.0",
+      "from": "karma-chai@https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz"
     },
     "karma-chai-as-promised": {
       "version": "0.1.2",
+      "from": "karma-chai-as-promised@https://registry.npmjs.org/karma-chai-as-promised/-/karma-chai-as-promised-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/karma-chai-as-promised/-/karma-chai-as-promised-0.1.2.tgz"
     },
     "karma-chrome-launcher": {
       "version": "2.0.0",
+      "from": "karma-chrome-launcher@https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.0.0.tgz"
     },
     "karma-firefox-launcher": {
       "version": "1.0.0",
+      "from": "karma-firefox-launcher@https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.0.0.tgz"
     },
     "karma-mocha": {
       "version": "1.1.1",
+      "from": "karma-mocha@https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.1.1.tgz"
     },
     "karma-mocha-reporter": {
       "version": "2.1.0",
+      "from": "karma-mocha-reporter@https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.1.0.tgz"
     },
     "karma-phantomjs-launcher": {
       "version": "1.0.2",
+      "from": "karma-phantomjs-launcher@https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.2.tgz"
     },
     "karma-safari-launcher": {
       "version": "1.0.0",
+      "from": "karma-safari-launcher@https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz"
     },
     "karma-sinon-chai": {
       "version": "1.2.3",
+      "from": "karma-sinon-chai@https://registry.npmjs.org/karma-sinon-chai/-/karma-sinon-chai-1.2.3.tgz",
       "resolved": "https://registry.npmjs.org/karma-sinon-chai/-/karma-sinon-chai-1.2.3.tgz"
     },
     "kew": {
       "version": "0.7.0",
+      "from": "kew@https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
     },
     "keymirror": {
       "version": "0.1.1",
+      "from": "keymirror@https://registry.npmjs.org/keymirror/-/keymirror-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/keymirror/-/keymirror-0.1.1.tgz"
     },
     "kind-of": {
       "version": "3.0.4",
+      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
     },
     "klaw": {
       "version": "1.3.0",
+      "from": "klaw@https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
     },
     "labeled-stream-splicer": {
       "version": "2.0.0",
+      "from": "labeled-stream-splicer@https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "latest-version": {
       "version": "2.0.0",
+      "from": "latest-version@https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz"
     },
     "lazy-cache": {
       "version": "1.0.4",
+      "from": "lazy-cache@https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
     "lcid": {
       "version": "1.0.0",
+      "from": "lcid@https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "levn": {
       "version": "0.3.0",
+      "from": "levn@https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
     "lexical-scope": {
       "version": "1.2.0",
+      "from": "lexical-scope@https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz"
     },
     "liftoff": {
       "version": "2.3.0",
+      "from": "liftoff@https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz"
     },
     "limiter": {
       "version": "1.1.0",
+      "from": "limiter@https://registry.npmjs.org/limiter/-/limiter-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.0.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
+      "from": "load-json-file@https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "localtunnel": {
       "version": "1.8.1",
+      "from": "localtunnel@https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.1.tgz",
       "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.1.tgz",
       "dependencies": {
         "yargs": {
           "version": "3.29.0",
+          "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz"
         }
       }
     },
     "lodash": {
       "version": "4.15.0",
+      "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
     },
     "lodash-es": {
       "version": "4.15.0",
+      "from": "lodash-es@https://registry.npmjs.org/lodash-es/-/lodash-es-4.15.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.15.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
+      "from": "lodash._basecopy@https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
+      "from": "lodash._basetostring@https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
     },
     "lodash._basevalues": {
       "version": "3.0.0",
+      "from": "lodash._basevalues@https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
+      "from": "lodash._getnative@https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
+      "from": "lodash._isiterateecall@https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
+      "from": "lodash._reescape@https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
+      "from": "lodash._reevaluate@https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
+      "from": "lodash._reinterpolate@https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
       "version": "3.0.1",
+      "from": "lodash._root@https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
     },
     "lodash.assign": {
       "version": "4.2.0",
+      "from": "lodash.assign@https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
     },
     "lodash.assignwith": {
       "version": "4.2.0",
+      "from": "lodash.assignwith@https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz"
     },
     "lodash.camelcase": {
       "version": "4.3.0",
+      "from": "lodash.camelcase@https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz"
     },
     "lodash.escape": {
       "version": "3.2.0",
+      "from": "lodash.escape@https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
     },
     "lodash.indexof": {
       "version": "4.0.5",
+      "from": "lodash.indexof@https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz",
       "resolved": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz"
     },
     "lodash.isarguments": {
       "version": "3.1.0",
+      "from": "lodash.isarguments@https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
+      "from": "lodash.isarray@https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isempty": {
       "version": "4.4.0",
+      "from": "lodash.isempty@https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz"
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
+      "from": "lodash.isplainobject@https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
     },
     "lodash.isstring": {
       "version": "4.0.1",
+      "from": "lodash.isstring@https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
+      "from": "lodash.keys@https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
+      "from": "lodash.mapvalues@https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz"
     },
     "lodash.memoize": {
       "version": "3.0.4",
+      "from": "lodash.memoize@https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
     },
     "lodash.pick": {
       "version": "4.4.0",
+      "from": "lodash.pick@https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
     },
     "lodash.pickby": {
       "version": "4.6.0",
+      "from": "lodash.pickby@https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
+      "from": "lodash.restparam@https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
+      "from": "lodash.template@https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
+      "from": "lodash.templatesettings@https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "lodash.uniq": {
       "version": "4.5.0",
+      "from": "lodash.uniq@https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
     },
     "log4js": {
       "version": "0.6.38",
+      "from": "log4js@https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "semver": {
           "version": "4.3.6",
+          "from": "semver@https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "lolex": {
       "version": "1.5.1",
+      "from": "lolex@https://registry.npmjs.org/lolex/-/lolex-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.5.1.tgz"
     },
     "longest": {
       "version": "1.0.1",
+      "from": "longest@https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loop-protect": {
@@ -3515,266 +4224,329 @@
     },
     "loose-envify": {
       "version": "1.2.0",
+      "from": "loose-envify@https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
     },
     "loud-rejection": {
       "version": "1.6.0",
+      "from": "loud-rejection@https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
+      "from": "lowercase-keys@https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
     },
     "lru-cache": {
       "version": "2.7.3",
+      "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "macaddress": {
       "version": "0.2.8",
+      "from": "macaddress@https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
     },
     "make-error": {
       "version": "1.2.0",
+      "from": "make-error@https://registry.npmjs.org/make-error/-/make-error-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.2.0.tgz"
     },
     "make-error-cause": {
       "version": "1.2.1",
+      "from": "make-error-cause@https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.1.tgz"
     },
     "map-cache": {
       "version": "0.2.2",
+      "from": "map-cache@https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
+      "from": "map-obj@https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "marked": {
       "version": "0.3.6",
+      "from": "marked@https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
     },
     "math-expression-evaluator": {
       "version": "1.2.14",
+      "from": "math-expression-evaluator@https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
+      "from": "media-typer@https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "meow": {
       "version": "3.7.0",
+      "from": "meow@https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "merge-options": {
       "version": "0.0.64",
+      "from": "merge-options@https://registry.npmjs.org/merge-options/-/merge-options-0.0.64.tgz",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-0.0.64.tgz"
     },
     "micromatch": {
       "version": "2.3.11",
+      "from": "micromatch@https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
     },
     "miller-rabin": {
       "version": "4.0.0",
+      "from": "miller-rabin@https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
     },
     "mime": {
       "version": "1.2.4",
+      "from": "mime@https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
     },
     "mime-db": {
       "version": "1.23.0",
+      "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
     },
     "mime-types": {
       "version": "2.1.11",
+      "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
     },
     "minimalistic-assert": {
       "version": "1.0.0",
+      "from": "minimalistic-assert@https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
     },
     "minimatch": {
       "version": "3.0.3",
+      "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
       "version": "1.2.0",
+      "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
+      "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
+          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "mocha": {
       "version": "2.4.5",
+      "from": "mocha@https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
+          "from": "commander@https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
+          "from": "escape-string-regexp@https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz"
         },
         "graceful-fs": {
           "version": "2.0.3",
+          "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
+          "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         },
         "supports-color": {
           "version": "1.2.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
     },
     "module-deps": {
       "version": "4.0.7",
+      "from": "module-deps@https://registry.npmjs.org/module-deps/-/module-deps-4.0.7.tgz",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.0.7.tgz"
     },
     "moment": {
       "version": "2.14.1",
+      "from": "moment@https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
     },
     "mout": {
       "version": "1.0.0",
+      "from": "mout@https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz"
     },
     "ms": {
       "version": "0.7.1",
+      "from": "ms@https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "msee": {
       "version": "0.1.2",
+      "from": "msee@https://registry.npmjs.org/msee/-/msee-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/msee/-/msee-0.1.2.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
         },
         "chalk": {
           "version": "0.4.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
         },
         "nopt": {
           "version": "2.1.2",
+          "from": "nopt@https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz"
         },
         "object-keys": {
           "version": "0.4.0",
+          "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
         },
         "strip-ansi": {
           "version": "0.1.1",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
         },
         "xtend": {
           "version": "2.1.2",
+          "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
         }
       }
     },
     "multipipe": {
       "version": "0.1.2",
+      "from": "multipipe@https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "dependencies": {
         "duplexer2": {
           "version": "0.0.2",
+          "from": "duplexer2@https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.14",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
     "mute-stream": {
       "version": "0.0.5",
+      "from": "mute-stream@https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "nan": {
       "version": "2.4.0",
+      "from": "nan@https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
     },
     "natives": {
       "version": "1.1.0",
+      "from": "natives@https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
     },
     "natural-compare": {
       "version": "1.4.0",
+      "from": "natural-compare@https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
     },
     "negotiator": {
       "version": "0.6.1",
+      "from": "negotiator@https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
     "node-emoji": {
       "version": "1.3.1",
+      "from": "node-emoji@https://registry.npmjs.org/node-emoji/-/node-emoji-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.3.1.tgz"
     },
     "node-fetch": {
       "version": "1.6.0",
+      "from": "node-fetch@https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.0.tgz"
     },
     "node-status-codes": {
       "version": "1.0.0",
+      "from": "node-status-codes@https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
+      "from": "node-uuid@https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "nopt": {
       "version": "3.0.6",
+      "from": "nopt@https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
+      "from": "normalize-package-data@https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
+      "from": "normalize-path@https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "normalize-range": {
       "version": "0.1.2",
+      "from": "normalize-range@https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
     },
     "normalize-url": {
       "version": "1.6.1",
+      "from": "normalize-url@https://registry.npmjs.org/normalize-url/-/normalize-url-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.6.1.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "npm": {
       "version": "2.15.10",
+      "from": "npm@https://registry.npmjs.org/npm/-/npm-2.15.10.tgz",
       "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.10.tgz",
       "dependencies": {
         "abbrev": {
@@ -4727,1184 +5499,1464 @@
     },
     "npm-check": {
       "version": "5.2.3",
+      "from": "npm-check@https://registry.npmjs.org/npm-check/-/npm-check-5.2.3.tgz",
       "resolved": "https://registry.npmjs.org/npm-check/-/npm-check-5.2.3.tgz",
       "dependencies": {
         "glob": {
           "version": "6.0.4",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         },
         "globby": {
           "version": "4.1.0",
+          "from": "globby@https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         },
         "path-exists": {
           "version": "2.1.0",
+          "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "npm-run-path": {
       "version": "1.0.0",
+      "from": "npm-run-path@https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz"
     },
     "npm-shrinkwrap": {
       "version": "200.5.1",
+      "from": "npm-shrinkwrap@https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-200.5.1.tgz",
       "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-200.5.1.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
+          "from": "semver@https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "null-check": {
       "version": "1.0.0",
+      "from": "null-check@https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
     },
     "num2fraction": {
       "version": "1.2.2",
+      "from": "num2fraction@https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
+      "from": "number-is-nan@https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
+      "from": "oauth-sign@https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "2.1.1",
+      "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
     },
     "object-component": {
       "version": "0.0.3",
+      "from": "object-component@https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
     },
     "object-inspect": {
       "version": "0.4.0",
+      "from": "object-inspect@https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
     },
     "object-keys": {
       "version": "1.0.11",
+      "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
     },
     "object-path": {
       "version": "0.9.2",
+      "from": "object-path@https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
     },
     "object.omit": {
       "version": "2.0.0",
+      "from": "object.omit@https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
+      "from": "on-finished@https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "once": {
       "version": "1.3.3",
+      "from": "once@https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "onecolor": {
       "version": "2.4.2",
+      "from": "onecolor@https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
       "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz"
     },
     "onetime": {
       "version": "1.1.0",
+      "from": "onetime@https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "openurl": {
       "version": "1.1.0",
+      "from": "openurl@https://registry.npmjs.org/openurl/-/openurl-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.0.tgz"
     },
     "opn": {
       "version": "4.0.2",
+      "from": "opn@https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "optimist": {
       "version": "0.6.1",
+      "from": "optimist@https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
+          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
         }
       }
     },
     "option-parser": {
       "version": "0.1.3",
+      "from": "option-parser@https://registry.npmjs.org/option-parser/-/option-parser-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/option-parser/-/option-parser-0.1.3.tgz"
     },
     "optionator": {
       "version": "0.8.1",
+      "from": "optionator@https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
+          "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
         }
       }
     },
     "options": {
       "version": "0.0.6",
+      "from": "options@https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
     },
     "ora": {
       "version": "0.2.3",
+      "from": "ora@https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "orchestrator": {
       "version": "0.3.7",
+      "from": "orchestrator@https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz"
     },
     "ordered-read-streams": {
       "version": "0.1.0",
+      "from": "ordered-read-streams@https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
     },
     "os-browserify": {
       "version": "0.1.2",
+      "from": "os-browserify@https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
+      "from": "os-homedir@https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-locale": {
       "version": "1.4.0",
+      "from": "os-locale@https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-shim": {
       "version": "0.1.3",
+      "from": "os-shim@https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
+      "from": "os-tmpdir@https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
     },
     "osenv": {
       "version": "0.1.3",
+      "from": "osenv@https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
     },
     "outpipe": {
       "version": "1.1.1",
+      "from": "outpipe@https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz"
     },
     "package-json": {
       "version": "2.4.0",
+      "from": "package-json@https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz"
     },
     "pako": {
       "version": "0.2.9",
+      "from": "pako@https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
     "parents": {
       "version": "1.0.1",
+      "from": "parents@https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
     },
     "parse-asn1": {
       "version": "5.0.0",
+      "from": "parse-asn1@https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
     },
     "parse-filepath": {
       "version": "1.0.1",
+      "from": "parse-filepath@https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
+      "from": "parse-glob@https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
+      "from": "parse-json@https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parsejson": {
       "version": "0.0.1",
+      "from": "parsejson@https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
     },
     "parseqs": {
       "version": "0.0.2",
+      "from": "parseqs@https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
     },
     "parseuri": {
       "version": "0.0.4",
+      "from": "parseuri@https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
+      "from": "parseurl@https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "path-browserify": {
       "version": "0.0.0",
+      "from": "path-browserify@https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
     },
     "path-exists": {
       "version": "1.0.0",
+      "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
+      "from": "path-is-absolute@https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
       "version": "1.0.1",
+      "from": "path-is-inside@https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
     },
     "path-key": {
       "version": "1.0.0",
+      "from": "path-key@https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz"
     },
     "path-platform": {
       "version": "0.11.15",
+      "from": "path-platform@https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
     },
     "path-root": {
       "version": "0.1.1",
+      "from": "path-root@https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
     },
     "path-root-regex": {
       "version": "0.1.2",
+      "from": "path-root-regex@https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
     },
     "path-type": {
       "version": "1.1.0",
+      "from": "path-type@https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pbkdf2": {
       "version": "3.0.4",
+      "from": "pbkdf2@https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
     },
     "pend": {
       "version": "1.2.0",
+      "from": "pend@https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "phantomjs-prebuilt": {
       "version": "2.1.12",
+      "from": "phantomjs-prebuilt@https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.12.tgz",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.12.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "bl": {
           "version": "1.1.2",
+          "from": "bl@https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
         },
         "http-signature": {
           "version": "1.1.1",
+          "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "request": {
           "version": "2.74.0",
+          "from": "request@https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
         },
         "tough-cookie": {
           "version": "2.3.1",
+          "from": "tough-cookie@https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
         }
       }
     },
     "pify": {
       "version": "2.3.0",
+      "from": "pify@https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
+      "from": "pinkie@https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
+      "from": "pinkie-promise@https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pixrem": {
       "version": "3.0.2",
+      "from": "pixrem@https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz"
     },
     "pleeease-filters": {
       "version": "3.0.0",
+      "from": "pleeease-filters@https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-3.0.0.tgz"
     },
     "pluralize": {
       "version": "1.2.1",
+      "from": "pluralize@https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
     "portscanner": {
       "version": "1.0.0",
+      "from": "portscanner@https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.15",
+          "from": "async@https://registry.npmjs.org/async/-/async-0.1.15.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
         }
       }
     },
     "postcss": {
       "version": "5.0.21",
+      "from": "postcss@https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
       "dependencies": {
         "supports-color": {
           "version": "3.1.2",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         }
       }
     },
     "postcss-apply": {
       "version": "0.3.0",
+      "from": "postcss-apply@https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.3.0.tgz"
     },
     "postcss-attribute-case-insensitive": {
       "version": "1.0.1",
+      "from": "postcss-attribute-case-insensitive@https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
       "dependencies": {
         "postcss": {
           "version": "5.1.2",
+          "from": "postcss@https://registry.npmjs.org/postcss/-/postcss-5.1.2.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.1.2.tgz"
         },
         "supports-color": {
           "version": "3.1.2",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         }
       }
     },
     "postcss-calc": {
       "version": "5.3.1",
+      "from": "postcss-calc@https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz"
     },
     "postcss-color-function": {
       "version": "2.0.1",
+      "from": "postcss-color-function@https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-2.0.1.tgz"
     },
     "postcss-color-gray": {
       "version": "3.0.0",
+      "from": "postcss-color-gray@https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.0.tgz",
       "dependencies": {
         "color": {
           "version": "0.7.3",
+          "from": "color@https://registry.npmjs.org/color/-/color-0.7.3.tgz",
           "resolved": "https://registry.npmjs.org/color/-/color-0.7.3.tgz"
         },
         "color-convert": {
           "version": "0.5.3",
+          "from": "color-convert@https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
         },
         "color-name": {
           "version": "1.0.1",
+          "from": "color-name@https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz"
         },
         "color-string": {
           "version": "0.2.4",
+          "from": "color-string@https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz"
         }
       }
     },
     "postcss-color-hex-alpha": {
       "version": "2.0.0",
+      "from": "postcss-color-hex-alpha@https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
       "dependencies": {
         "color": {
           "version": "0.10.1",
+          "from": "color@https://registry.npmjs.org/color/-/color-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz"
         },
         "color-convert": {
           "version": "0.5.3",
+          "from": "color-convert@https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
         }
       }
     },
     "postcss-color-hwb": {
       "version": "2.0.0",
+      "from": "postcss-color-hwb@https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-2.0.0.tgz",
       "dependencies": {
         "color": {
           "version": "0.10.1",
+          "from": "color@https://registry.npmjs.org/color/-/color-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz"
         },
         "color-convert": {
           "version": "0.5.3",
+          "from": "color-convert@https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
         }
       }
     },
     "postcss-color-rebeccapurple": {
       "version": "2.0.0",
+      "from": "postcss-color-rebeccapurple@https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.0.tgz",
       "dependencies": {
         "color": {
           "version": "0.9.0",
+          "from": "color@https://registry.npmjs.org/color/-/color-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/color/-/color-0.9.0.tgz"
         },
         "color-convert": {
           "version": "0.5.3",
+          "from": "color-convert@https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
         }
       }
     },
     "postcss-color-rgba-fallback": {
       "version": "2.2.0",
+      "from": "postcss-color-rgba-fallback@https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz"
     },
     "postcss-colormin": {
       "version": "2.2.0",
+      "from": "postcss-colormin@https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.0.tgz"
     },
     "postcss-convert-values": {
       "version": "2.4.0",
+      "from": "postcss-convert-values@https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.4.0.tgz"
     },
     "postcss-cssnext": {
       "version": "2.8.0",
+      "from": "postcss-cssnext@https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-2.8.0.tgz"
     },
     "postcss-custom-media": {
       "version": "5.0.1",
+      "from": "postcss-custom-media@https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz"
     },
     "postcss-custom-properties": {
       "version": "5.0.1",
+      "from": "postcss-custom-properties@https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-5.0.1.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.1.0",
+          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
         }
       }
     },
     "postcss-custom-selectors": {
       "version": "3.0.0",
+      "from": "postcss-custom-selectors@https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.2.1",
+          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
         }
       }
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
+      "from": "postcss-discard-comments@https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
     },
     "postcss-discard-duplicates": {
       "version": "2.0.1",
+      "from": "postcss-discard-duplicates@https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.1.tgz"
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
+      "from": "postcss-discard-empty@https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz"
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
+      "from": "postcss-discard-overridden@https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz"
     },
     "postcss-discard-unused": {
       "version": "2.2.1",
+      "from": "postcss-discard-unused@https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.1.tgz"
     },
     "postcss-filter-plugins": {
       "version": "2.0.1",
+      "from": "postcss-filter-plugins@https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.1.tgz"
     },
     "postcss-font-variant": {
       "version": "2.0.1",
+      "from": "postcss-font-variant@https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz"
     },
     "postcss-initial": {
       "version": "1.5.2",
+      "from": "postcss-initial@https://registry.npmjs.org/postcss-initial/-/postcss-initial-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-1.5.2.tgz",
       "dependencies": {
         "lodash.template": {
           "version": "4.4.0",
+          "from": "lodash.template@https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz"
         },
         "lodash.templatesettings": {
           "version": "4.1.0",
+          "from": "lodash.templatesettings@https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
         }
       }
     },
     "postcss-media-minmax": {
       "version": "2.1.2",
+      "from": "postcss-media-minmax@https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz"
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
+      "from": "postcss-merge-idents@https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz"
     },
     "postcss-merge-longhand": {
       "version": "2.0.1",
+      "from": "postcss-merge-longhand@https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
     },
     "postcss-merge-rules": {
       "version": "2.0.10",
+      "from": "postcss-merge-rules@https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.10.tgz",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.10.tgz"
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
+      "from": "postcss-message-helpers@https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
+      "from": "postcss-minify-font-values@https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "postcss-minify-gradients": {
       "version": "1.0.3",
+      "from": "postcss-minify-gradients@https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.3.tgz"
     },
     "postcss-minify-params": {
       "version": "1.0.5",
+      "from": "postcss-minify-params@https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.5.tgz"
     },
     "postcss-minify-selectors": {
       "version": "2.0.5",
+      "from": "postcss-minify-selectors@https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.5.tgz"
     },
     "postcss-nesting": {
       "version": "2.3.1",
+      "from": "postcss-nesting@https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz"
     },
     "postcss-normalize-charset": {
       "version": "1.1.0",
+      "from": "postcss-normalize-charset@https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
     },
     "postcss-normalize-url": {
       "version": "3.0.7",
+      "from": "postcss-normalize-url@https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz"
     },
     "postcss-ordered-values": {
       "version": "2.2.1",
+      "from": "postcss-ordered-values@https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.1.tgz"
     },
     "postcss-pseudo-class-any-link": {
       "version": "1.0.0",
+      "from": "postcss-pseudo-class-any-link@https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
       "dependencies": {
         "postcss-selector-parser": {
           "version": "1.3.3",
+          "from": "postcss-selector-parser@https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz"
         }
       }
     },
     "postcss-pseudoelements": {
       "version": "3.0.0",
+      "from": "postcss-pseudoelements@https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz"
     },
     "postcss-reduce-idents": {
       "version": "2.3.0",
+      "from": "postcss-reduce-idents@https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.0.tgz"
     },
     "postcss-reduce-initial": {
       "version": "1.0.0",
+      "from": "postcss-reduce-initial@https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz"
     },
     "postcss-reduce-transforms": {
       "version": "1.0.3",
+      "from": "postcss-reduce-transforms@https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
     },
     "postcss-replace-overflow-wrap": {
       "version": "1.0.0",
+      "from": "postcss-replace-overflow-wrap@https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz"
     },
     "postcss-selector-matches": {
       "version": "2.0.1",
+      "from": "postcss-selector-matches@https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.1.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.2.1",
+          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
         }
       }
     },
     "postcss-selector-not": {
       "version": "2.0.0",
+      "from": "postcss-selector-not@https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.2.1",
+          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
         }
       }
     },
     "postcss-selector-parser": {
       "version": "2.2.1",
+      "from": "postcss-selector-parser@https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.1.tgz"
     },
     "postcss-svgo": {
       "version": "2.1.4",
+      "from": "postcss-svgo@https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.4.tgz",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.4.tgz"
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
+      "from": "postcss-unique-selectors@https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz"
     },
     "postcss-value-parser": {
       "version": "3.3.0",
+      "from": "postcss-value-parser@https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
     },
     "postcss-zindex": {
       "version": "2.1.1",
+      "from": "postcss-zindex@https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.1.1.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
+      "from": "prelude-ls@https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "prepend-http": {
       "version": "1.0.4",
+      "from": "prepend-http@https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
     },
     "preserve": {
       "version": "0.2.0",
+      "from": "preserve@https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
       "version": "1.0.2",
+      "from": "pretty-hrtime@https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
     },
     "private": {
       "version": "0.1.6",
+      "from": "private@https://registry.npmjs.org/private/-/private-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
       "version": "0.11.9",
+      "from": "process@https://registry.npmjs.org/process/-/process-0.11.9.tgz",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
+      "from": "process-nextick-args@https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
+      "from": "progress@https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
       "version": "7.1.1",
+      "from": "promise@https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
+      "from": "pseudomap@https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "public-encrypt": {
       "version": "4.0.0",
+      "from": "public-encrypt@https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
     },
     "punycode": {
       "version": "1.4.1",
+      "from": "punycode@https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "q": {
       "version": "1.4.1",
+      "from": "q@https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qjobs": {
       "version": "1.1.5",
+      "from": "qjobs@https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz"
     },
     "qs": {
       "version": "6.2.1",
+      "from": "qs@https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
     },
     "query-string": {
       "version": "4.2.3",
+      "from": "query-string@https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "querystring": {
       "version": "0.2.0",
+      "from": "querystring@https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystring-es3": {
       "version": "0.2.1",
+      "from": "querystring-es3@https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
     "quote-stream": {
       "version": "0.0.0",
+      "from": "quote-stream@https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "minimist": {
           "version": "0.0.8",
+          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "object-keys": {
           "version": "0.4.0",
+          "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.4.2",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
         },
         "xtend": {
           "version": "2.1.2",
+          "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
         }
       }
     },
     "randomatic": {
       "version": "1.1.5",
+      "from": "randomatic@https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
     },
     "randombytes": {
       "version": "2.0.3",
+      "from": "randombytes@https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
     },
     "range-parser": {
       "version": "1.2.0",
+      "from": "range-parser@https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "raw-body": {
       "version": "2.1.7",
+      "from": "raw-body@https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
     },
     "rc": {
       "version": "1.1.6",
+      "from": "rc@https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
     },
     "react": {
       "version": "15.3.1",
+      "from": "react@https://registry.npmjs.org/react/-/react-15.3.1.tgz",
       "resolved": "https://registry.npmjs.org/react/-/react-15.3.1.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "react-dom": {
       "version": "15.3.1",
+      "from": "react-dom@https://registry.npmjs.org/react-dom/-/react-dom-15.3.1.tgz",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.3.1.tgz"
     },
     "react-inlinesvg": {
       "version": "0.4.2",
+      "from": "react-inlinesvg@https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-0.4.2.tgz"
     },
     "react-redux": {
       "version": "4.4.5",
+      "from": "react-redux@https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz"
     },
     "read-all-stream": {
       "version": "3.1.0",
+      "from": "read-all-stream@https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
     },
     "read-json": {
       "version": "1.0.3",
+      "from": "read-json@https://registry.npmjs.org/read-json/-/read-json-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/read-json/-/read-json-1.0.3.tgz"
     },
     "read-only-stream": {
       "version": "2.0.0",
+      "from": "read-only-stream@https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
+      "from": "read-pkg@https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
+      "from": "read-pkg-up@https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "2.1.5",
+      "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
     },
     "readdirp": {
       "version": "2.1.0",
+      "from": "readdirp@https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
     },
     "readline2": {
       "version": "1.0.1",
+      "from": "readline2@https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "recast": {
       "version": "0.10.43",
+      "from": "recast@https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
         }
       }
     },
     "rechoir": {
       "version": "0.6.2",
+      "from": "rechoir@https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redent": {
       "version": "1.0.0",
+      "from": "redent@https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "redeyed": {
       "version": "0.5.0",
+      "from": "redeyed@https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "12001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
         }
       }
     },
     "reduce-css-calc": {
       "version": "1.3.0",
+      "from": "reduce-css-calc@https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
     },
     "reduce-function-call": {
       "version": "1.0.1",
+      "from": "reduce-function-call@https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
       "dependencies": {
         "balanced-match": {
           "version": "0.1.0",
+          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
         }
       }
     },
     "reduce-reducers": {
       "version": "0.1.2",
+      "from": "reduce-reducers@https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz"
     },
     "redux": {
       "version": "3.6.0",
+      "from": "redux@https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz"
     },
     "redux-actions": {
       "version": "0.12.0",
+      "from": "redux-actions@https://registry.npmjs.org/redux-actions/-/redux-actions-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.12.0.tgz"
     },
     "redux-logger": {
       "version": "2.6.1",
+      "from": "redux-logger@https://registry.npmjs.org/redux-logger/-/redux-logger-2.6.1.tgz",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-2.6.1.tgz"
     },
     "redux-thunk": {
       "version": "2.1.0",
+      "from": "redux-thunk@https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.1.0.tgz"
     },
     "regenerate": {
       "version": "1.3.1",
+      "from": "regenerate@https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
     },
     "regenerator-runtime": {
       "version": "0.9.5",
+      "from": "regenerator-runtime@https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
+      "from": "regex-cache@https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
     },
     "regexpu-core": {
       "version": "2.0.0",
+      "from": "regexpu-core@https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
     },
     "registry-auth-token": {
       "version": "3.0.1",
+      "from": "registry-auth-token@https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.0.1.tgz"
     },
     "registry-url": {
       "version": "3.1.0",
+      "from": "registry-url@https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
     },
     "regjsgen": {
       "version": "0.2.0",
+      "from": "regjsgen@https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
     },
     "regjsparser": {
       "version": "0.1.5",
+      "from": "regjsparser@https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
+      "from": "repeat-element@https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.5.4",
+      "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "repeating": {
       "version": "1.1.3",
+      "from": "repeating@https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
     "replace-ext": {
       "version": "0.0.1",
+      "from": "replace-ext@https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
       "version": "2.65.0",
+      "from": "request@https://registry.npmjs.org/request/-/request-2.65.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
       "dependencies": {
         "qs": {
           "version": "5.2.1",
+          "from": "qs@https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz"
         }
       }
     },
     "request-progress": {
       "version": "2.0.1",
+      "from": "request-progress@https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz"
     },
     "require-directory": {
       "version": "2.1.1",
+      "from": "require-directory@https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
     },
     "require-main-filename": {
       "version": "1.0.1",
+      "from": "require-main-filename@https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "require-package-name": {
       "version": "2.0.1",
+      "from": "require-package-name@https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz"
     },
     "require-uncached": {
       "version": "1.0.2",
+      "from": "require-uncached@https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz"
     },
     "requires-port": {
       "version": "1.0.0",
+      "from": "requires-port@https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
       "version": "1.1.7",
+      "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-dir": {
       "version": "0.1.1",
+      "from": "resolve-dir@https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
     },
     "resolve-from": {
       "version": "1.0.1",
+      "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
     },
     "resolve-url": {
       "version": "0.2.1",
+      "from": "resolve-url@https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
     },
     "resp-modifier": {
       "version": "6.0.2",
+      "from": "resp-modifier@https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz"
     },
     "restore-cursor": {
       "version": "1.0.1",
+      "from": "restore-cursor@https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "rgb": {
       "version": "0.1.0",
+      "from": "rgb@https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz"
     },
     "rgb-hex": {
       "version": "1.0.0",
+      "from": "rgb-hex@https://registry.npmjs.org/rgb-hex/-/rgb-hex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-1.0.0.tgz"
     },
     "right-align": {
       "version": "0.1.3",
+      "from": "right-align@https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.5.4",
+      "from": "rimraf@https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.6",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         }
       }
     },
     "ripemd160": {
       "version": "1.0.1",
+      "from": "ripemd160@https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
     },
     "run-async": {
       "version": "0.1.0",
+      "from": "run-async@https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "run-parallel": {
       "version": "1.1.6",
+      "from": "run-parallel@https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz"
     },
     "run-series": {
       "version": "1.1.4",
+      "from": "run-series@https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
     },
     "rx": {
       "version": "4.1.0",
+      "from": "rx@https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
+      "from": "rx-lite@https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "safe-json-parse": {
       "version": "2.0.0",
+      "from": "safe-json-parse@https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz"
     },
     "samsam": {
       "version": "1.1.2",
+      "from": "samsam@https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
     },
     "sax": {
       "version": "1.2.1",
+      "from": "sax@https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
     },
     "semver": {
       "version": "5.3.0",
+      "from": "semver@https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "semver-diff": {
       "version": "2.1.0",
+      "from": "semver-diff@https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz"
     },
     "send": {
       "version": "0.14.1",
+      "from": "send@https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "dependencies": {
         "mime": {
           "version": "1.3.4",
+          "from": "mime@https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         }
       }
     },
     "sequencify": {
       "version": "0.0.7",
+      "from": "sequencify@https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
     },
     "serve-index": {
       "version": "1.8.0",
+      "from": "serve-index@https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz"
     },
     "serve-static": {
       "version": "1.11.1",
+      "from": "serve-static@https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
     },
     "server-destroy": {
       "version": "1.0.1",
+      "from": "server-destroy@https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz"
     },
     "set-blocking": {
       "version": "2.0.0",
+      "from": "set-blocking@https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
+      "from": "set-immediate-shim@https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "setprototypeof": {
       "version": "1.0.1",
+      "from": "setprototypeof@https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
     },
     "sha.js": {
       "version": "2.4.5",
+      "from": "sha.js@https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
     },
     "shallow-copy": {
       "version": "0.0.1",
+      "from": "shallow-copy@https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
     },
     "shasum": {
       "version": "1.0.2",
+      "from": "shasum@https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
+      "from": "shebang-regex@https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shell-quote": {
       "version": "1.6.1",
+      "from": "shell-quote@https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz"
     },
     "shelljs": {
       "version": "0.3.0",
+      "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
+      "from": "sigmund@https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "3.0.0",
+      "from": "signal-exit@https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
     },
     "sinon": {
       "version": "1.17.5",
+      "from": "sinon@https://registry.npmjs.org/sinon/-/sinon-1.17.5.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.5.tgz",
       "dependencies": {
         "lolex": {
           "version": "1.3.2",
+          "from": "lolex@https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
         }
       }
     },
     "sinon-chai": {
       "version": "2.8.0",
+      "from": "sinon-chai@https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz"
     },
     "slash": {
       "version": "1.0.0",
+      "from": "slash@https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
     },
     "slice-ansi": {
       "version": "0.0.4",
+      "from": "slice-ansi@https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "slide": {
       "version": "1.1.6",
+      "from": "slide@https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
     },
     "slowparse": {
       "version": "1.1.4",
+      "from": "slowparse@https://registry.npmjs.org/slowparse/-/slowparse-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/slowparse/-/slowparse-1.1.4.tgz"
     },
     "sntp": {
       "version": "1.0.9",
+      "from": "sntp@https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "socket.io": {
       "version": "1.4.8",
+      "from": "socket.io@https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz"
     },
     "socket.io-adapter": {
       "version": "0.4.0",
+      "from": "socket.io-adapter@https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "socket.io-parser": {
           "version": "2.2.2",
+          "from": "socket.io-parser@https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "dependencies": {
             "debug": {
               "version": "0.7.4",
+              "from": "debug@https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
@@ -5913,750 +6965,928 @@
     },
     "socket.io-client": {
       "version": "1.4.8",
+      "from": "socket.io-client@https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
       "dependencies": {
         "component-emitter": {
           "version": "1.2.0",
+          "from": "component-emitter@https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
         }
       }
     },
     "socket.io-parser": {
       "version": "2.2.6",
+      "from": "socket.io-parser@https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "json3": {
           "version": "3.3.2",
+          "from": "json3@https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
           "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
         }
       }
     },
     "sort-keys": {
       "version": "1.1.2",
+      "from": "sort-keys@https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
     },
     "sorted-object": {
       "version": "1.0.0",
+      "from": "sorted-object@https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
     },
     "source-map": {
       "version": "0.5.6",
+      "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
     },
     "source-map-resolve": {
       "version": "0.3.1",
+      "from": "source-map-resolve@https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz"
     },
     "source-map-support": {
       "version": "0.2.10",
+      "from": "source-map-support@https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
+          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "source-map-url": {
       "version": "0.3.0",
+      "from": "source-map-url@https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
     },
     "sparkles": {
       "version": "1.0.0",
+      "from": "sparkles@https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
+      "from": "spdx-correct@https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.3",
+      "from": "spdx-expression-parse@https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.2",
+      "from": "spdx-license-ids@https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
+      "from": "sprintf-js@https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.10.0",
+      "from": "sshpk@https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.2.3",
+          "from": "asn1@https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
         },
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "stackframe": {
       "version": "0.3.1",
+      "from": "stackframe@https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
     },
     "static-eval": {
       "version": "0.2.4",
+      "from": "static-eval@https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
       "dependencies": {
         "escodegen": {
           "version": "0.0.28",
+          "from": "escodegen@https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz"
         },
         "esprima": {
           "version": "1.0.4",
+          "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "estraverse": {
           "version": "1.3.2",
+          "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
         }
       }
     },
     "static-module": {
       "version": "1.3.1",
+      "from": "static-module@https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.4.10",
+          "from": "concat-stream@https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.14",
+              "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
             }
           }
         },
         "duplexer2": {
           "version": "0.0.2",
+          "from": "duplexer2@https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.14",
+              "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "object-keys": {
           "version": "0.4.0",
+          "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.4.2",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
         },
         "xtend": {
           "version": "2.1.2",
+          "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
         }
       }
     },
     "statuses": {
       "version": "1.3.0",
+      "from": "statuses@https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
     },
     "stream-browserify": {
       "version": "2.0.1",
+      "from": "stream-browserify@https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
     },
     "stream-combiner2": {
       "version": "1.1.1",
+      "from": "stream-combiner2@https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
     },
     "stream-consume": {
       "version": "0.1.0",
+      "from": "stream-consume@https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
     },
     "stream-http": {
       "version": "2.3.1",
+      "from": "stream-http@https://registry.npmjs.org/stream-http/-/stream-http-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.3.1.tgz"
     },
     "stream-splicer": {
       "version": "2.0.0",
+      "from": "stream-splicer@https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz"
     },
     "stream-throttle": {
       "version": "0.1.3",
+      "from": "stream-throttle@https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz"
     },
     "strict-uri-encode": {
       "version": "1.1.0",
+      "from": "strict-uri-encode@https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
     },
     "string-template": {
       "version": "0.2.1",
+      "from": "string-template@https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
     },
     "string-width": {
       "version": "1.0.2",
+      "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
     "string.prototype.codepointat": {
       "version": "0.2.0",
+      "from": "string.prototype.codepointat@https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
+      "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
+      "from": "stringstream@https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
+      "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
+      "from": "strip-bom@https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-eof": {
       "version": "1.0.0",
+      "from": "strip-eof@https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
+      "from": "strip-indent@https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
+      "from": "strip-json-comments@https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "subarg": {
       "version": "1.0.0",
+      "from": "subarg@https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
+      "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "svgo": {
       "version": "0.6.6",
+      "from": "svgo@https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz"
     },
     "symbol-observable": {
       "version": "1.0.2",
+      "from": "symbol-observable@https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.2.tgz"
     },
     "syntax-error": {
       "version": "1.1.6",
+      "from": "syntax-error@https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
+          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         }
       }
     },
     "table": {
       "version": "3.7.8",
+      "from": "table@https://registry.npmjs.org/table/-/table-3.7.8.tgz",
       "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz"
     },
     "text-encoding": {
       "version": "0.6.0",
+      "from": "text-encoding@https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.0.tgz"
     },
     "text-table": {
       "version": "0.2.0",
+      "from": "text-table@https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "tfunk": {
       "version": "3.0.2",
+      "from": "tfunk@https://registry.npmjs.org/tfunk/-/tfunk-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.0.2.tgz"
     },
     "throat": {
       "version": "2.0.2",
+      "from": "throat@https://registry.npmjs.org/throat/-/throat-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/throat/-/throat-2.0.2.tgz"
     },
     "throttleit": {
       "version": "1.0.0",
+      "from": "throttleit@https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
     },
     "through": {
       "version": "2.3.8",
+      "from": "through@https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "2.0.1",
+      "from": "through2@https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "tildify": {
       "version": "1.2.0",
+      "from": "tildify@https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
     },
     "time-stamp": {
       "version": "1.0.1",
+      "from": "time-stamp@https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
     },
     "timed-out": {
       "version": "2.0.0",
+      "from": "timed-out@https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
     },
     "timers-browserify": {
       "version": "1.4.2",
+      "from": "timers-browserify@https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
     },
     "tmp": {
       "version": "0.0.28",
+      "from": "tmp@https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
     },
     "to-array": {
       "version": "0.1.4",
+      "from": "to-array@https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
     },
     "to-arraybuffer": {
       "version": "1.0.1",
+      "from": "to-arraybuffer@https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.2",
+      "from": "to-fast-properties@https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
     },
     "tough-cookie": {
       "version": "2.2.2",
+      "from": "tough-cookie@https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
+      "from": "trim-newlines@https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "try-call": {
       "version": "0.0.2",
+      "from": "try-call@https://registry.npmjs.org/try-call/-/try-call-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/try-call/-/try-call-0.0.2.tgz"
     },
     "tryit": {
       "version": "1.0.2",
+      "from": "tryit@https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
     },
     "tty-browserify": {
       "version": "0.0.0",
+      "from": "tty-browserify@https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.3",
+      "from": "tunnel-agent@https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tv4": {
       "version": "1.2.7",
+      "from": "tv4@https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
       "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
     },
     "tweetnacl": {
       "version": "0.13.3",
+      "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
       "version": "0.3.2",
+      "from": "type-check@https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "1.0.0",
+      "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
       "version": "1.6.13",
+      "from": "type-is@https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
+      "from": "typedarray@https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "ua-parser-js": {
       "version": "0.7.10",
+      "from": "ua-parser-js@https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
     },
     "uglify-js": {
       "version": "2.7.0",
+      "from": "uglify-js@https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
+          "from": "async@https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cliui": {
           "version": "2.1.0",
+          "from": "cliui@https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
         },
         "window-size": {
           "version": "0.1.0",
+          "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         },
         "wordwrap": {
           "version": "0.0.2",
+          "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         },
         "yargs": {
           "version": "3.10.0",
+          "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
     "uglify-save-license": {
       "version": "0.4.1",
+      "from": "uglify-save-license@https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
+      "from": "uglify-to-browserify@https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "ultron": {
       "version": "1.0.2",
+      "from": "ultron@https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
     "umd": {
       "version": "3.0.1",
+      "from": "umd@https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
     },
     "unc-path-regex": {
       "version": "0.1.2",
+      "from": "unc-path-regex@https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
     },
     "underscore": {
       "version": "1.7.0",
+      "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "uniq": {
       "version": "1.0.1",
+      "from": "uniq@https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
     },
     "uniqid": {
       "version": "3.1.0",
+      "from": "uniqid@https://registry.npmjs.org/uniqid/-/uniqid-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-3.1.0.tgz"
     },
     "uniqs": {
       "version": "2.0.0",
+      "from": "uniqs@https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
     },
     "unique-stream": {
       "version": "1.0.0",
+      "from": "unique-stream@https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
+      "from": "unpipe@https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "untildify": {
       "version": "2.1.0",
+      "from": "untildify@https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
     },
     "unzip-response": {
       "version": "1.0.0",
+      "from": "unzip-response@https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
     },
     "update-notifier": {
       "version": "0.6.3",
+      "from": "update-notifier@https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.3.tgz",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.3.tgz"
     },
     "urix": {
       "version": "0.1.0",
+      "from": "urix@https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
     },
     "url": {
       "version": "0.11.0",
+      "from": "url@https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
+          "from": "punycode@https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
     },
     "url-parse-lax": {
       "version": "1.0.0",
+      "from": "url-parse-lax@https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
     },
     "urllite": {
       "version": "0.5.0",
+      "from": "urllite@https://registry.npmjs.org/urllite/-/urllite-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/urllite/-/urllite-0.5.0.tgz"
     },
     "user-home": {
       "version": "1.1.1",
+      "from": "user-home@https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "useragent": {
       "version": "2.1.9",
+      "from": "useragent@https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
+          "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
         }
       }
     },
     "utf8": {
       "version": "2.1.1",
+      "from": "utf8@https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz"
     },
     "util": {
       "version": "0.10.3",
+      "from": "util@https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
+      "from": "util-deprecate@https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
+      "from": "utils-merge@https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "uuid": {
       "version": "2.0.2",
+      "from": "uuid@https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
     },
     "v8flags": {
       "version": "2.0.11",
+      "from": "v8flags@https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
+      "from": "validate-npm-package-license@https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "vendors": {
       "version": "1.0.1",
+      "from": "vendors@https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
+      "from": "verror@https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vinyl": {
       "version": "0.5.3",
+      "from": "vinyl@https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
     },
     "vinyl-buffer": {
       "version": "1.0.0",
+      "from": "vinyl-buffer@https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.5",
+          "from": "bl@https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         }
       }
     },
     "vinyl-fs": {
       "version": "0.3.14",
+      "from": "vinyl-fs@https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "dependencies": {
         "clone": {
           "version": "0.2.0",
+          "from": "clone@https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "graceful-fs": {
           "version": "3.0.11",
+          "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "strip-bom": {
           "version": "1.0.0",
+          "from": "strip-bom@https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
         },
         "through2": {
           "version": "0.6.5",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
+          "from": "vinyl@https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "vinyl-source-stream": {
       "version": "1.1.0",
+      "from": "vinyl-source-stream@https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "dependencies": {
         "clone": {
           "version": "0.2.0",
+          "from": "clone@https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
+          "from": "through2@https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
+          "from": "vinyl@https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "vinyl-sourcemaps-apply": {
       "version": "0.2.1",
+      "from": "vinyl-sourcemaps-apply@https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
     },
     "vm-browserify": {
       "version": "0.0.4",
+      "from": "vm-browserify@https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
     },
     "void-elements": {
       "version": "2.0.1",
+      "from": "void-elements@https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
     },
     "w3c-blob": {
       "version": "0.0.1",
+      "from": "w3c-blob@https://registry.npmjs.org/w3c-blob/-/w3c-blob-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/w3c-blob/-/w3c-blob-0.0.1.tgz"
     },
     "walkdir": {
       "version": "0.0.11",
+      "from": "walkdir@https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz"
     },
     "watchify": {
       "version": "3.7.0",
+      "from": "watchify@https://registry.npmjs.org/watchify/-/watchify-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.7.0.tgz"
     },
     "weinre": {
       "version": "2.0.0-pre-I0Z7U9OV",
+      "from": "weinre@https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
       "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz"
     },
     "whatwg-fetch": {
       "version": "1.0.0",
+      "from": "whatwg-fetch@https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
     },
     "whet.extend": {
       "version": "0.9.9",
+      "from": "whet.extend@https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
     },
     "which": {
       "version": "1.2.10",
+      "from": "which@https://registry.npmjs.org/which/-/which-1.2.10.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
     "which-module": {
       "version": "1.0.0",
+      "from": "which-module@https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
     },
     "widest-line": {
       "version": "1.0.0",
+      "from": "widest-line@https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz"
     },
     "window-size": {
       "version": "0.1.4",
+      "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
     },
     "wordwrap": {
       "version": "0.0.3",
+      "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
     },
     "wrap-ansi": {
       "version": "2.0.0",
+      "from": "wrap-ansi@https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
+      "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "write": {
       "version": "0.2.1",
+      "from": "write@https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "write-file-atomic": {
       "version": "1.2.0",
+      "from": "write-file-atomic@https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz"
     },
     "ws": {
       "version": "1.1.0",
+      "from": "ws@https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz"
     },
     "xdg-basedir": {
       "version": "2.0.0",
+      "from": "xdg-basedir@https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
     },
     "xmlhttprequest": {
       "version": "1.8.0",
+      "from": "xmlhttprequest@https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",
+      "from": "xmlhttprequest-ssl@https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xregexp": {
       "version": "3.1.1",
+      "from": "xregexp@https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz"
     },
     "xtend": {
       "version": "4.0.1",
+      "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
       "version": "3.2.1",
+      "from": "y18n@https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
       "version": "2.0.0",
+      "from": "yallist@https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
       "version": "5.0.0",
+      "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
       "dependencies": {
         "window-size": {
           "version": "0.2.0",
+          "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
         }
       }
     },
     "yargs-parser": {
       "version": "3.2.0",
+      "from": "yargs-parser@https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
+          "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         }
       }
     },
     "yauzl": {
       "version": "2.4.1",
+      "from": "yauzl@https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
     },
     "yeast": {
       "version": "0.1.2",
+      "from": "yeast@https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "classnames": "^2.1.5",
     "css": "^2.2.1",
     "envify": "^3.4.1",
+    "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
     "esprima": "^3.0.0",
     "firebase": "^2.4.1",
     "github-api": "^2.3.0",

--- a/src/application.js
+++ b/src/application.js
@@ -1,3 +1,4 @@
+import './init';
 import './util/Bugsnag';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -5,8 +6,6 @@ import Immutable from 'immutable';
 import installDevTools from 'immutable-devtools';
 import Application from './components/Application';
 import initI18n from './util/initI18n';
-
-import './init';
 
 installDevTools(Immutable);
 

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
+import fs from 'fs';
+import path from 'path';
 import {Provider} from 'react-redux';
 import bowser from 'bowser';
 import createApplicationStore from '../createApplicationStore';
 import Workspace from './Workspace';
 import BrowserError from './BrowserError';
 import {includeStoreInBugReports} from '../util/Bugsnag';
+
+const supportedBrowsers = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '../../config/browsers.json')
+));
 
 class Application extends React.Component {
   constructor() {
@@ -15,12 +21,10 @@ class Application extends React.Component {
   }
 
   _isUnsupportedBrowser() {
-    return bowser.isUnsupportedBrowser({
-      msie: '10',
-      firefox: '12',
-      chrome: '30',
-      safari: '7.1',
-    }, window.navigator.userAgent);
+    return bowser.isUnsupportedBrowser(
+      supportedBrowsers,
+      window.navigator.userAgent
+    );
   }
 
   render() {

--- a/src/init.js
+++ b/src/init.js
@@ -1,1 +1,2 @@
 import 'babel-polyfill';
+import 'es6-set/implement';


### PR DESCRIPTION
* Add a polyfill for ES6 Set, specifically to ensure that `Set.prototype.forEach` is available. Lodash relies on this, but some older browser versions that we can otherwise support don’t have it.
* Increase version requirements to IE11 and Firefox 28, which are respectively the first versions to fully support modern flexbox. Popcode’s layout heavily depends on flexbox.
* Pass list of supported browsers to `cssnext`/`autoprefixer`, so that our CSS will contain all appropriate vendor prefixes for the browser versions we support.