### PR TITLE
Handle click of error associated with minimized editor

### DIFF
--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -6,7 +6,12 @@ import {useFakeTimers} from 'sinon';
 import createApplicationStore from '../../../src/createApplicationStore';
 import waitFor from '../../helpers/waitFor';
 
-import {TYPING_DEBOUNCE_DELAY, userTyped} from '../../../src/actions/ui';
+import {
+  TYPING_DEBOUNCE_DELAY,
+  editorFocusedRequestedLine,
+  userTyped,
+  userRequestedFocusedLine,
+} from '../../../src/actions/ui';
 
 const timeInterval = 1000 * 60 * 60 * 24;
 
@@ -54,5 +59,31 @@ describe('interfaceStateActions', () => {
         })
       )
     );
+  });
+
+  describe('userRequestedFocusedLine', () => {
+    beforeEach(
+      () => store.dispatch(userRequestedFocusedLine('javascript', 4, 2))
+    );
+
+    it('sets requestedFocusedLine to given value', () => {
+      assert.deepEqual(
+        store.getState().ui.getIn(['editors', 'requestedFocusedLine']).toJS(),
+        {language: 'javascript', line: 4, column: 2}
+      );
+    });
+  });
+
+  describe('editorFocusedRequestedLine', () => {
+    beforeEach(() => {
+      store.dispatch(userRequestedFocusedLine('javascript', 4, 2));
+      store.dispatch(editorFocusedRequestedLine());
+    });
+
+    it('sets requestedFocusedLine to null', () => {
+      assert.isNull(
+        store.getState().ui.getIn(['editors', 'requestedFocusedLine']),
+      );
+    });
   });
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -9,7 +9,11 @@ import appFirebase from '../services/appFirebase';
 import validations from '../validations';
 
 import {createProject, changeCurrentProject} from './projects';
-import {userTyped} from './ui';
+import {
+  userTyped,
+  userRequestedFocusedLine,
+  editorFocusedRequestedLine,
+} from './ui';
 import {isPristineProject} from '../util/projectUtils';
 
 function generateProjectKey() {
@@ -307,5 +311,7 @@ export {
   toggleDashboard,
   toggleDashboardSubmenu,
   userTyped,
+  userRequestedFocusedLine,
+  editorFocusedRequestedLine,
   bootstrap,
 };

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -23,3 +23,12 @@ export function userTyped() {
     dispatch(userIsDoneTypingWithDebounce());
   };
 }
+
+export const userRequestedFocusedLine = createAction(
+  'USER_REQUESTED_FOCUSED_LINE',
+  (language, line, column) => ({language, line, column})
+);
+
+export const editorFocusedRequestedLine = createAction(
+  'EDITOR_FOCUSED_REQUESTED_LINE'
+);

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ACE from 'brace';
 import bindAll from 'lodash/bindAll';
+import get from 'lodash/get';
 import throttle from 'lodash/throttle';
 
 import 'brace/mode/html';
@@ -31,6 +32,7 @@ class Editor extends React.Component {
   }
 
   componentDidMount() {
+    this._focusRequestedLine(this.props.requestedFocusedLine);
     window.addEventListener('resize', this._handleWindowResize);
   }
 
@@ -41,6 +43,8 @@ class Editor extends React.Component {
         nextProps.source !== this._editor.getValue()) {
       this._editor.setValue(nextProps.source);
     }
+
+    this._focusRequestedLine(nextProps.requestedFocusedLine);
 
     if (nextProps.percentageOfHeight !== this.props.percentageOfHeight) {
       requestAnimationFrame(this._resizeEditor);
@@ -58,9 +62,18 @@ class Editor extends React.Component {
     window.removeEventListener('resize', this._handleWindowResize);
   }
 
-  _jumpToLine(line, column) {
-    this._editor.moveCursorTo(line, column);
+  _focusRequestedLine(requestedFocusedLine) {
+    if (get(requestedFocusedLine, 'language') !== this.props.language) {
+      return;
+    }
+
+    this._editor.moveCursorTo(
+      requestedFocusedLine.line,
+      requestedFocusedLine.column
+    );
+    this._editor.clearSelection();
     this._editor.focus();
+    this.props.onRequestedLineFocused();
   }
 
   _resizeEditor() {
@@ -116,8 +129,10 @@ Editor.propTypes = {
   language: React.PropTypes.string.isRequired,
   percentageOfHeight: React.PropTypes.number.isRequired,
   projectKey: React.PropTypes.string.isRequired,
+  requestedFocusedLine: React.PropTypes.object,
   source: React.PropTypes.string.isRequired,
   onInput: React.PropTypes.func.isRequired,
+  onRequestedLineFocused: React.PropTypes.func.isRequired,
 };
 
 export default Editor;

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -22,6 +22,8 @@ import {
   toggleDashboard,
   toggleDashboardSubmenu,
   userTyped,
+  userRequestedFocusedLine,
+  editorFocusedRequestedLine,
   bootstrap,
 } from '../actions';
 
@@ -61,7 +63,6 @@ class Workspace extends React.Component {
       '_handleComponentMinimized',
       '_handleDashboardSubmenuToggled',
       '_handleEditorInput',
-      '_handleEditorMountedOrUnmounted',
       '_handleErrorClick',
       '_handleLibraryToggled',
       '_handleLogOut',
@@ -69,10 +70,9 @@ class Workspace extends React.Component {
       '_handleProjectSelected',
       '_handleRuntimeError',
       '_handleStartLogIn',
-      '_handleToggleDashboard'
+      '_handleToggleDashboard',
+      '_handleRequestedLineFocused'
     );
-
-    this.editors = {};
   }
 
   componentWillMount() {
@@ -119,11 +119,8 @@ class Workspace extends React.Component {
   }
 
   _handleErrorClick(language, line, column) {
-    this.editors[language]._jumpToLine(line, column);
-  }
-
-  _handleEditorMountedOrUnmounted(language, editor) {
-    this.editors[language] = editor;
+    this.props.dispatch(maximizeComponent(`editor.${language}`));
+    this.props.dispatch(userRequestedFocusedLine(language, line, column));
   }
 
   _handleEditorInput(language, source) {
@@ -224,9 +221,10 @@ class Workspace extends React.Component {
             language={language}
             percentageOfHeight={1 / editors.length}
             projectKey={this.props.currentProject.projectKey}
-            ref={partial(this._handleEditorMountedOrUnmounted, language)}
+            requestedFocusedLine={this.props.ui.editors.requestedFocusedLine}
             source={this.props.currentProject.sources[language]}
             onInput={partial(this._handleEditorInput, language)}
+            onRequestedLineFocused={this._handleRequestedLineFocused}
           />
         </EditorContainer>
       );
@@ -250,6 +248,10 @@ class Workspace extends React.Component {
 
   _handleLogOut() {
     appFirebase.unauth();
+  }
+
+  _handleRequestedLineFocused() {
+    this.props.dispatch(editorFocusedRequestedLine());
   }
 
   _renderDashboard() {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -2,6 +2,7 @@ import Immutable from 'immutable';
 
 const defaultState = new Immutable.Map().
   set('editors', new Immutable.Map({typing: false})).
+  set('requestedLine', null).
   set('minimizedComponents', new Immutable.Set()).
   set(
     'dashboard',
@@ -48,6 +49,18 @@ function ui(stateIn, action) {
         'minimizedComponents',
         (components) => components.delete(action.payload.componentName)
       );
+
+    case 'USER_REQUESTED_FOCUSED_LINE':
+      return state.setIn(
+        ['editors', 'requestedFocusedLine'],
+        new Immutable.Map().
+          set('language', action.payload.language).
+          set('line', action.payload.line).
+          set('column', action.payload.column)
+      );
+
+    case 'EDITOR_FOCUSED_REQUESTED_LINE':
+      return state.setIn(['editors', 'requestedFocusedLine'], null);
 
     default:
       return state;


### PR DESCRIPTION
In this situation:

* Type invalid code into an editor
* Minimize that editor
* Then click on the error message in the list

Expected behavior: The editor is maximized and focused, with the cursor at the position of the erroneous code.

Previous behavior: uncaught exception.

![](https://dl.dropboxusercontent.com/u/37033819/2016-09-17_1003.png?raw=1)

This pull request afforded an opportunity to finally fix one of my least favorite things about Popcode’s implementation, namely that the `Workspace` component held references to the `Editor` component instances that it owned. Worse, when an error was clicked, the `Workspace` would call a method *directly on the `Editor`*. This is not how components are supposed to work. It’s also the cause of the uncaught exception—with the editor minimized, the `Editor` component was not mounted, so the `Workspace` was trying to call a method on an undefined component reference.

I have had a lot of trouble coming up with a satisfying way to represent what feels like a completely transient event—“the user clicked an error”—and a completely transient reaction—“move the cursor in the appropriate editor to the position of the error”—in Flux state. Specifically, I *don’t* want to represent the cursor position and focus state of each editor in the Flux store—that would involve a ton of unnecessary data flow just so we can handle one fairly niche user interaction. In this pull request, I took a different approach, which I think is pretty good:

* There is a `ui.editors.requestedFocusedLine` state property. This is usually `null`, but when populated, it contains information about a line that the user wants the cursor to move to, but which we have not yet actually moved the cursor to.
* When the user clicks an error, we dispatch a `USER_REQUESTED_FOCUSED_LINE` action, which causes the aforementioned property to populate.
* The `Editor` component pays attention to this property; if it receives a value that corresponds to its language, it moves the cursor appropriately, and then immediately dispatches an `EDITOR_FOCUSED_REQUESTED_LINE` action.
* This action causes the `ui.editors.requestedFocusedLine` property go back to `null`.

Unsurprisingly, migrating this interaction to a pure one-way data flow makes it a lot easier to work with and reason about. In general, we now know that, at any given time, we’re in one of three situations:

1. The user hasn’t clicked an error.
2. The user clicked an error, but we haven’t moved the cursor yet.
3. The user clicked an error, and we moved the cursor.

States 1 and 3 end up looking identical in the Flux state tree.

This approach solves a specific problem with a naïve solution to the original bug. When an error is clicked, we need to maximize the editor.  This is done by issuing a `COMPONENT_MAXIMIZED` action. However, this won’t cause the component to mount synchronously; we need to wait for React to flush component state. That means, if we want to call a method directly on a component we’re holding a `ref` to, we need to do so in some kind of next-tick block, which is unsatisfying and fragile.

Instead, by using Flux state to communicate the user’s intent to focus a line, we stop having to worry about the exact sequence of rendering.  When the `Editor` component mounts, it checks to see if there is a pending focused-line request, and focuses the line if there is. It also, of course, checks for focused-line requests when props change. So, the right thing happens regardless of the order things happen in.

Generally, this approach seems to offer a promising pattern for situations where one-way data flow and components as functions of state seem ill-suited. By representing a seemingly transient event as a fleeting but real state—something needs to happen, but hasn’t happened yet—we are able to keep components loosely coupled, get more robust behavior, and have an implementation that’s easier to reason about.