### PR TITLE
Default to empty string when HTML not present in imported gist

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -228,7 +228,7 @@ function importProjectFromGist(projectKey, gistData) {
   const project = {
     projectKey,
     sources: {
-      html: get(find(files, {language: 'HTML'}), 'content'),
+      html: get(find(files, {language: 'HTML'}), 'content', ''),
       css: map(filter(files, {language: 'CSS'}), 'content').join('\n\n'),
       javascript: map(filter(files, {language: 'JavaScript'}), 'content').
         join('\n\n'),


### PR DESCRIPTION
When importing from a gist, we should gracefully handle one or more languages not having code present. This happens naturally when retrieving CSS and JavaScript, because for those languages we take *all* matching sections of the gist and join them together; thus the base case is joining an empty array, generating an empty string. In the case of HTML, however, it doesn’t make sense to concatenate multiple HTML sections, because each presumably contains a full HTML document; so, we just take the first. If no HTML document is present, this search yields an undefined value. So, explicitly fall back to an empty string.