### PR TITLE
Fix javascript error when redefining property

### DIFF
--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -47,9 +47,11 @@ const alertAndPromptReplacementScript = `(${(() => {
       value: (message) => {
         _swal(message);
       },
+      configurable: true,
     },
     prompt: {
       value: (message, defaultValue = '') => defaultValue,
+      configurable: true,
     },
   });
 


### PR DESCRIPTION
Object.defineProperties by default uses configurable: true when
defining a property, which means that if you attempt to define that
property again later there will be a TypeError. This makes us fault
tolerant, which we want to be since the TypeError shows up in the UI.