### PR TITLE
Gracefully handle failed sign-in

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -21,6 +21,10 @@
     "message": "Popcode doesn’t work with your version of __name__.",
     "download": "Click here to download a new version."
   },
+  "globalErrors": {
+    "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
+    "auth-error": "Something went wrong trying to sign in. Please try again!"
+  },
   "languages": {
     "html": "HTML",
     "css": "CSS",

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,7 +21,7 @@
     "message": "Popcode doesn’t work with your version of __name__.",
     "download": "Click here to download a new version."
   },
-  "globalErrors": {
+  "applicationErrors": {
     "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
     "auth-error": "Something went wrong trying to sign in. Please try again!"
   },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1057,6 +1057,10 @@
       "from": "chai-as-promised@https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
     },
+    "chai-immutable": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chai-immutable/-/chai-immutable-1.6.0.tgz"
+    },
     "chalk": {
       "version": "1.1.3",
       "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4036,9 +4036,8 @@
       }
     },
     "lodash": {
-      "version": "4.15.0",
-      "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.1.tgz"
     },
     "lodash-es": {
       "version": "4.15.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "browserify-incremental": "^3.0.1",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "chai-immutable": "^1.6.0",
     "check-dependencies": "^1.0.1",
     "eslint": "^3.3.0",
     "eslint-plugin-react": "^6.1.0",

--- a/spec/examples/actions/projects.spec.js
+++ b/spec/examples/actions/projects.spec.js
@@ -48,12 +48,8 @@ describe('projectActions', () => {
     let projectKey;
 
     beforeEach(() => {
-      store.dispatch(createProject());
-      projectKey = getCurrentProject(store.getState()).projectKey;
-      store.dispatch(toggleLibrary(projectKey, 'jquery'));
-      store.dispatch(createProject());
-      const secondProjectKey = getCurrentProject(store.getState()).projectKey;
-      store.dispatch(toggleLibrary(secondProjectKey, 'jquery'));
+      projectKey = createAndMutateProject();
+      createAndMutateProject();
       store.dispatch(changeCurrentProject(projectKey));
     });
 
@@ -65,4 +61,11 @@ describe('projectActions', () => {
       assert.lengthOf(getProjectKeys(store.getState()), 2);
     });
   });
+
+  function createAndMutateProject() {
+    store.dispatch(createProject());
+    const projectKey = getCurrentProject(store.getState()).projectKey;
+    store.dispatch(toggleLibrary(projectKey, 'jquery'));
+    return projectKey;
+  }
 });

--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -108,7 +108,7 @@ describe('interfaceStateActions', () => {
       store.dispatch(userDismissedGlobalError('some-error'));
     });
 
-    it('sets globalErrors to contain argument', () => {
+    it('removes argument from globalErrors', () => {
       assert.notInclude(
         store.getState().ui.get('globalErrors'),
         'some-error'

--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -11,8 +11,8 @@ import {
   editorFocusedRequestedLine,
   userTyped,
   userRequestedFocusedLine,
-  globalErrorTriggered,
-  userDismissedGlobalError,
+  applicationErrorTriggered,
+  userDismissedApplicationError,
 } from '../../../src/actions/ui';
 
 const timeInterval = 1000 * 60 * 60 * 24;
@@ -89,28 +89,28 @@ describe('interfaceStateActions', () => {
     });
   });
 
-  describe('globalErrorTriggered', () => {
+  describe('applicationErrorTriggered', () => {
     beforeEach(() => {
-      store.dispatch(globalErrorTriggered('some-error'));
+      store.dispatch(applicationErrorTriggered('some-error'));
     });
 
-    it('sets globalErrors to contain argument', () => {
+    it('sets applicationErrors to contain argument', () => {
       assert.include(
-        store.getState().ui.get('globalErrors'),
+        store.getState().ui.get('applicationErrors'),
         'some-error'
       );
     });
   });
 
-  describe('userDismissedGlobalError', () => {
+  describe('userDismissedApplicationError', () => {
     beforeEach(() => {
-      store.dispatch(globalErrorTriggered('some-error'));
-      store.dispatch(userDismissedGlobalError('some-error'));
+      store.dispatch(applicationErrorTriggered('some-error'));
+      store.dispatch(userDismissedApplicationError('some-error'));
     });
 
-    it('removes argument from globalErrors', () => {
+    it('removes argument from applicationErrors', () => {
       assert.notInclude(
-        store.getState().ui.get('globalErrors'),
+        store.getState().ui.get('applicationErrors'),
         'some-error'
       );
     });

--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -11,6 +11,8 @@ import {
   editorFocusedRequestedLine,
   userTyped,
   userRequestedFocusedLine,
+  globalErrorTriggered,
+  userDismissedGlobalError,
 } from '../../../src/actions/ui';
 
 const timeInterval = 1000 * 60 * 60 * 24;
@@ -83,6 +85,33 @@ describe('interfaceStateActions', () => {
     it('sets requestedFocusedLine to null', () => {
       assert.isNull(
         store.getState().ui.getIn(['editors', 'requestedFocusedLine']),
+      );
+    });
+  });
+
+  describe('globalErrorTriggered', () => {
+    beforeEach(() => {
+      store.dispatch(globalErrorTriggered('some-error'));
+    });
+
+    it('sets globalErrors to contain argument', () => {
+      assert.include(
+        store.getState().ui.get('globalErrors'),
+        'some-error'
+      );
+    });
+  });
+
+  describe('userDismissedGlobalError', () => {
+    beforeEach(() => {
+      store.dispatch(globalErrorTriggered('some-error'));
+      store.dispatch(userDismissedGlobalError('some-error'));
+    });
+
+    it('sets globalErrors to contain argument', () => {
+      assert.notInclude(
+        store.getState().ui.get('globalErrors'),
+        'some-error'
       );
     });
   });

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -1,6 +1,8 @@
 import chai from 'chai';
+import chaiImmutable from 'chai-immutable';
 import chaiAsPromised from 'chai-as-promised';
 
 import '../src/init';
 
 chai.use(chaiAsPromised);
+chai.use(chaiImmutable);

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,6 +13,8 @@ import {
   userTyped,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
+  globalErrorTriggered,
+  userDismissedGlobalError,
 } from './ui';
 import {isPristineProject} from '../util/projectUtils';
 
@@ -313,5 +315,7 @@ export {
   userTyped,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
+  globalErrorTriggered,
+  userDismissedGlobalError,
   bootstrap,
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,8 +13,8 @@ import {
   userTyped,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
-  globalErrorTriggered,
-  userDismissedGlobalError,
+  applicationErrorTriggered,
+  userDismissedApplicationError,
 } from './ui';
 import {isPristineProject} from '../util/projectUtils';
 
@@ -315,7 +315,7 @@ export {
   userTyped,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
-  globalErrorTriggered,
-  userDismissedGlobalError,
+  applicationErrorTriggered,
+  userDismissedApplicationError,
   bootstrap,
 };

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -33,12 +33,12 @@ export const editorFocusedRequestedLine = createAction(
   'EDITOR_FOCUSED_REQUESTED_LINE'
 );
 
-export const globalErrorTriggered = createAction(
+export const applicationErrorTriggered = createAction(
   'GLOBAL_ERROR_TRIGGERED',
   (errorType) => ({errorType})
 );
 
-export const userDismissedGlobalError = createAction(
+export const userDismissedApplicationError = createAction(
   'USER_DISMISSED_GLOBAL_ERROR',
   (errorType) => ({errorType})
 );

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -32,3 +32,13 @@ export const userRequestedFocusedLine = createAction(
 export const editorFocusedRequestedLine = createAction(
   'EDITOR_FOCUSED_REQUESTED_LINE'
 );
+
+export const globalErrorTriggered = createAction(
+  'GLOBAL_ERROR_TRIGGERED',
+  (errorType) => ({errorType})
+);
+
+export const userDismissedGlobalError = createAction(
+  'USER_DISMISSED_GLOBAL_ERROR',
+  (errorType) => ({errorType})
+);

--- a/src/components/ApplicationErrors.jsx
+++ b/src/components/ApplicationErrors.jsx
@@ -2,27 +2,27 @@ import React from 'react';
 import i18n from 'i18next-client';
 import partial from 'lodash/partial';
 
-export default function GlobalErrors(props) {
+export default function ApplicationErrors(props) {
   if (!props.errors.length) {
     return null;
   }
 
   const errorList = props.errors.map((error) => (
-    <div className="globalErrors-globalError" key={error}>
-      {i18n.t(`globalErrors.${error}`)}
+    <div className="applicationErrors-error" key={error}>
+      {i18n.t(`applicationErrors.${error}`)}
       <span
-        className="globalErrors-globalError-dismiss"
+        className="applicationErrors-error-dismiss"
         onClick={partial(props.onErrorDismissed, error)}
       >&#xf00d;</span>
     </div>
   ));
 
   return (
-    <div className="globalErrors">{errorList}</div>
+    <div className="applicationErrors">{errorList}</div>
   );
 }
 
-GlobalErrors.propTypes = {
+ApplicationErrors.propTypes = {
   errors: React.PropTypes.array,
   onErrorDismissed: React.PropTypes.func,
 };

--- a/src/components/GlobalErrors.jsx
+++ b/src/components/GlobalErrors.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import i18n from 'i18next-client';
+import partial from 'lodash/partial';
+
+export default function GlobalErrors(props) {
+  if (!props.errors.length) {
+    return null;
+  }
+
+  const errorList = props.errors.map((error) => (
+    <div className="globalErrors-globalError" key={error}>
+      {i18n.t(`globalErrors.${error}`)}
+      <span
+        className="globalErrors-globalError-dismiss"
+        onClick={partial(props.onErrorDismissed, error)}
+      >&#xf00d;</span>
+    </div>
+  ));
+
+  return (
+    <div className="globalErrors">{errorList}</div>
+  );
+}
+
+GlobalErrors.propTypes = {
+  errors: React.PropTypes.array,
+  onErrorDismissed: React.PropTypes.func,
+};

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -8,6 +8,7 @@ import sortBy from 'lodash/sortBy';
 import map from 'lodash/map';
 import i18n from 'i18next-client';
 import qs from 'qs';
+import Bugsnag from '../util/Bugsnag';
 import appFirebase from '../services/appFirebase';
 
 import {
@@ -24,6 +25,8 @@ import {
   userTyped,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
+  globalErrorTriggered,
+  userDismissedGlobalError,
   bootstrap,
 } from '../actions';
 
@@ -34,6 +37,7 @@ import Editor from './Editor';
 import Output from './Output';
 import Sidebar from './Sidebar';
 import Dashboard from './Dashboard';
+import GlobalErrors from './GlobalErrors';
 
 function mapStateToProps(state) {
   const projects = sortBy(
@@ -71,7 +75,8 @@ class Workspace extends React.Component {
       '_handleRuntimeError',
       '_handleStartLogIn',
       '_handleToggleDashboard',
-      '_handleRequestedLineFocused'
+      '_handleRequestedLineFocused',
+      '_handleGlobalErrorDismissed'
     );
   }
 
@@ -243,7 +248,21 @@ class Workspace extends React.Component {
     appFirebase.authWithOAuthPopup(
       'github',
       {remember: 'sessionOnly', scope: 'gist'}
-    );
+    ).catch((e) => {
+      switch (e.code) {
+        case 'USER_CANCELLED':
+          this.props.dispatch(globalErrorTriggered('user-cancelled-auth'));
+          break;
+        default:
+          this.props.dispatch(globalErrorTriggered('auth-error'));
+          Bugsnag.notifyException(e, e.code);
+          break;
+      }
+    });
+  }
+
+  _handleGlobalErrorDismissed(error) {
+    this.props.dispatch(userDismissedGlobalError(error));
   }
 
   _handleLogOut() {
@@ -303,11 +322,17 @@ class Workspace extends React.Component {
 
   render() {
     return (
-      <div className="layout">
-        {this._renderDashboard()}
-        {this._renderSidebar()}
-        <div className="layout-main" id="workspace">
-          {this._renderEnvironment()}
+      <div>
+        <GlobalErrors
+          errors={this.props.ui.globalErrors}
+          onErrorDismissed={this._handleGlobalErrorDismissed}
+        />
+        <div className="layout">
+          {this._renderDashboard()}
+          {this._renderSidebar()}
+          <div className="layout-main" id="workspace">
+            {this._renderEnvironment()}
+          </div>
         </div>
       </div>
     );

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -25,8 +25,8 @@ import {
   userTyped,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
-  globalErrorTriggered,
-  userDismissedGlobalError,
+  applicationErrorTriggered,
+  userDismissedApplicationError,
   bootstrap,
 } from '../actions';
 
@@ -37,7 +37,7 @@ import Editor from './Editor';
 import Output from './Output';
 import Sidebar from './Sidebar';
 import Dashboard from './Dashboard';
-import GlobalErrors from './GlobalErrors';
+import ApplicationErrors from './ApplicationErrors';
 
 function mapStateToProps(state) {
   const projects = sortBy(
@@ -76,7 +76,7 @@ class Workspace extends React.Component {
       '_handleStartLogIn',
       '_handleToggleDashboard',
       '_handleRequestedLineFocused',
-      '_handleGlobalErrorDismissed'
+      '_handleApplicationErrorDismissed'
     );
   }
 
@@ -251,18 +251,20 @@ class Workspace extends React.Component {
     ).catch((e) => {
       switch (e.code) {
         case 'USER_CANCELLED':
-          this.props.dispatch(globalErrorTriggered('user-cancelled-auth'));
+          this.props.dispatch(
+            applicationErrorTriggered('user-cancelled-auth')
+          );
           break;
         default:
-          this.props.dispatch(globalErrorTriggered('auth-error'));
+          this.props.dispatch(applicationErrorTriggered('auth-error'));
           Bugsnag.notifyException(e, e.code);
           break;
       }
     });
   }
 
-  _handleGlobalErrorDismissed(error) {
-    this.props.dispatch(userDismissedGlobalError(error));
+  _handleApplicationErrorDismissed(error) {
+    this.props.dispatch(userDismissedApplicationError(error));
   }
 
   _handleLogOut() {
@@ -323,9 +325,9 @@ class Workspace extends React.Component {
   render() {
     return (
       <div>
-        <GlobalErrors
-          errors={this.props.ui.globalErrors}
-          onErrorDismissed={this._handleGlobalErrorDismissed}
+        <ApplicationErrors
+          errors={this.props.ui.applicationErrors}
+          onErrorDismissed={this._handleApplicationErrorDismissed}
         />
         <div className="layout">
           {this._renderDashboard()}

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -458,6 +458,21 @@ body {
   cursor: pointer;
 }
 
+.globalErrors-globalError {
+  background-color: var(--color-red);
+  text-align: center;
+  margin-bottom: 0.2rem;
+  padding: 0.2rem 0;
+}
+
+.globalErrors-globalError-dismiss {
+  font-family: 'FontAwesome';
+  display: block;
+  padding: 0.2rem 0.5rem;
+  float: right;
+  cursor: pointer;
+}
+
 #unsupported-browser {
   font-size: 1.5rem;
   margin-top: 5rem;

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -458,14 +458,14 @@ body {
   cursor: pointer;
 }
 
-.globalErrors-globalError {
+.applicationErrors-error {
   background-color: var(--color-red);
   text-align: center;
   margin-bottom: 0.2rem;
   padding: 0.2rem 0;
 }
 
-.globalErrors-globalError-dismiss {
+.applicationErrors-error-dismiss {
   font-family: 'FontAwesome';
   display: block;
   padding: 0.2rem 0.5rem;

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -4,6 +4,7 @@ const defaultState = new Immutable.Map().
   set('editors', new Immutable.Map({typing: false})).
   set('requestedLine', null).
   set('minimizedComponents', new Immutable.Set()).
+  set('globalErrors', new Immutable.Set()).
   set(
     'dashboard',
     new Immutable.Map().
@@ -61,6 +62,18 @@ function ui(stateIn, action) {
 
     case 'EDITOR_FOCUSED_REQUESTED_LINE':
       return state.setIn(['editors', 'requestedFocusedLine'], null);
+
+    case 'GLOBAL_ERROR_TRIGGERED':
+      return state.update(
+        'globalErrors',
+        (errors) => errors.add(action.payload.errorType)
+      );
+
+    case 'USER_DISMISSED_GLOBAL_ERROR':
+      return state.update(
+        'globalErrors',
+        (errors) => errors.remove(action.payload.errorType)
+      );
 
     default:
       return state;

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -4,7 +4,7 @@ const defaultState = new Immutable.Map().
   set('editors', new Immutable.Map({typing: false})).
   set('requestedLine', null).
   set('minimizedComponents', new Immutable.Set()).
-  set('globalErrors', new Immutable.Set()).
+  set('applicationErrors', new Immutable.Set()).
   set(
     'dashboard',
     new Immutable.Map().
@@ -65,13 +65,13 @@ function ui(stateIn, action) {
 
     case 'GLOBAL_ERROR_TRIGGERED':
       return state.update(
-        'globalErrors',
+        'applicationErrors',
         (errors) => errors.add(action.payload.errorType)
       );
 
     case 'USER_DISMISSED_GLOBAL_ERROR':
       return state.update(
-        'globalErrors',
+        'applicationErrors',
         (errors) => errors.remove(action.payload.errorType)
       );
 

--- a/src/util/projectUtils.js
+++ b/src/util/projectUtils.js
@@ -1,8 +1,7 @@
-import toArray from 'lodash/toArray';
 import {Map} from 'immutable';
 
 export function getProjectKeys(state) {
-  return toArray(state.projects.keys());
+  return Array.from(state.projects.keys());
 }
 
 export function getCurrentProject(state) {


### PR DESCRIPTION
We saw two classes of sign in error: one where the user intentionally cancels sign in (by closing the popup without choosing to authorize), and another vaguer failure.

In the first case, we’ll display a specific message instructing the user to try again and click the green button:

![](https://dl.dropboxusercontent.com/u/37033819/2016-09-20_2124.png?raw=1)

In the second case, we’ll display a more general message, and also notify Bugsnag of the error, including the error code that came back from Firebase.

This means generally setting up a framework for displaying application-level errors in red banners at the top of the screen, which can then be dismissed.