### PR TITLE
Gracefully handle library keys referring to nonexistent libraries

### DIFF
--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -152,6 +152,10 @@ class PreviewGenerator {
 
   _attachLibraries(includePreviewFrame = false) {
     this._project.enabledLibraries.forEach((libraryKey) => {
+      if (!(libraryKey in libraries)) {
+        return;
+      }
+
       const library = libraries[libraryKey];
       this._attachLibrary(library);
     });

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -143,6 +143,10 @@ class JsHintValidator extends Validator {
 
     this._jshintOptions = defaults(clone(jshintrc), {predef: []});
     enabledLibraries.forEach((libraryKey) => {
+      if (!(libraryKey in libraries)) {
+        return;
+      }
+
       const library = libraries[libraryKey];
 
       if (library.predefined) {


### PR DESCRIPTION
We’ve recently removed some libraries from the application, at least temporarily. Most likely no one is using them, but if a saved project does include a removed library, we want to gracefully handle that case.

Since we may reintroduce these libraries later, I don’t want to filter them out of the projects themselves; instead, I just want to safely handle cases where a library key does not refer to an available library.