### PR TITLE
Remove “put your code here” comment

### DIFF
--- a/templates/new.html
+++ b/templates/new.html
@@ -4,6 +4,6 @@
         <title>Page Title</title>
     </head>
     <body>
-        <!-- Put your page markup here -->
+        
     </body>
 </html>


### PR DESCRIPTION
From observing students using the editor, this is just confusing.  Instead, just put a line of whitespace inside the body where the student can start typing.