### PR TITLE
Fix production sourcemaps

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -68,7 +68,11 @@ gulp.task('js', ['env'], () => {
   const productionWebpackConfig = Object.create(webpackConfiguration);
   productionWebpackConfig.plugins = productionWebpackConfig.plugins.concat(
     new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.UglifyJsPlugin()
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {warnings: false},
+      output: {comments: false},
+      sourceMap: true,
+    })
   );
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Needed to enable sourcemaps both at the Webpack level and the Uglify level.