### PR TITLE
Handle PrettyCSS error with no token

### DIFF
--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -110,5 +110,13 @@ describe('css', () => {
       assertFailsValidationAtLine(css, stylesheet, 2)
     );
   });
+
+  context('thoroughly unparseable CSS', () => {
+    const stylesheet = '<a href=\"http;.facebook.com>';
+
+    it('fails at the first line', () =>
+      assertFailsValidationAtLine(css, stylesheet, 1)
+    );
+  });
 });
 

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -113,6 +113,9 @@ class PrettyCssValidator extends Validator {
   }
 
   _locationForError(error) {
+    if (!error.token) {
+      return {row: 0, column: 0};
+    }
     return {row: error.token.line - 1, column: error.token.charNum - 1};
   }
 }


### PR DESCRIPTION
In the case that the entry in the CSS editor is nothing like actual CSS, PrettyCSS might return an error with no `token`. Since we use the `token` to determine the location of the error, in this case we just fall back to the first line.