### PR TITLE
Run release build tests using BrowserStack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ node_js:
 - 4.2.3
 env:
   matrix:
-  - CXX=g++-4.8 LOG_REDUX_ACTIONS=false FIREBASE_APP=popcode
+  - CXX=g++-4.8 LOG_REDUX_ACTIONS=false FIREBASE_APP=popcode BROWSER_STACK_USERNAME=matthewbrown17
   global:
-    secure: oNSex8CSxFztUhsuIVREJmJTH2H3D+zW1Q8tckp717HyJQQ3j1cVd1FUPJpLYu8sYAxMbf1HrxGPYfXUfXAXPKcXK6eCoWVUfJ9sCjTPgI+IKNYWshOsZxgkpZDELqK02iXfiX2N9IBX9Ucf/QLrtcmVCx4uSOIwU0zlKTnZZKOIaVhZMh9WJl0zetMdnh4zwRwJ0JqN/NDbEq43gKC87BZsk09/j/2kq3soyIqLoTe4kzkOxpnQUYBlQaL0XgrjODnMxiL+7tvmNJXzMgYH5VgfjU8mSrA78JnmrakbQIMtTn53rCXNM+LD67RbvSWwiUwTT6Ve7hYNyriovfXqk3UKL5KoawThn6/SF4zFc8lma395OMbE2NVTU0VaOGZ5wiiQvVeZftg272RRFeAHRSRjERjO5+mAi65nKLEcO7uIIMVG/hVcKVUplo9yfQpLOJyPaVke3iLP74D5s0PLxROM11qwYhrEHk7uE5nhPhc8GADtUbEjIh/HbOeLDpsK0unjwbiQzqQ1P5kxx0Z33ISjraM4aIpMch6bL8kPLKXPxF3i/7J16NkTnbNic6W+O8IOCuHgHgt+7NVdt+NNgQyZJockS4FVdGg3yktgXCFlKwcBcQNMkud3pDhUnivGlK6XV5cZRb3G6Kx/DwpjWqW405lCIFLtyicqKZ/13FI=
+  - secure: oNSex8CSxFztUhsuIVREJmJTH2H3D+zW1Q8tckp717HyJQQ3j1cVd1FUPJpLYu8sYAxMbf1HrxGPYfXUfXAXPKcXK6eCoWVUfJ9sCjTPgI+IKNYWshOsZxgkpZDELqK02iXfiX2N9IBX9Ucf/QLrtcmVCx4uSOIwU0zlKTnZZKOIaVhZMh9WJl0zetMdnh4zwRwJ0JqN/NDbEq43gKC87BZsk09/j/2kq3soyIqLoTe4kzkOxpnQUYBlQaL0XgrjODnMxiL+7tvmNJXzMgYH5VgfjU8mSrA78JnmrakbQIMtTn53rCXNM+LD67RbvSWwiUwTT6Ve7hYNyriovfXqk3UKL5KoawThn6/SF4zFc8lma395OMbE2NVTU0VaOGZ5wiiQvVeZftg272RRFeAHRSRjERjO5+mAi65nKLEcO7uIIMVG/hVcKVUplo9yfQpLOJyPaVke3iLP74D5s0PLxROM11qwYhrEHk7uE5nhPhc8GADtUbEjIh/HbOeLDpsK0unjwbiQzqQ1P5kxx0Z33ISjraM4aIpMch6bL8kPLKXPxF3i/7J16NkTnbNic6W+O8IOCuHgHgt+7NVdt+NNgQyZJockS4FVdGg3yktgXCFlKwcBcQNMkud3pDhUnivGlK6XV5cZRb3G6Kx/DwpjWqW405lCIFLtyicqKZ/13FI=
+  - secure: SfrceTUdcPMC9Jk7T9eIFVxDGdoOC9sUUg6nQX+3GerJ+vefoVFjspx/StYPr5Jci7NWqFCGns/8Ctu7eOK7p9lFnHeleuNGxKhotsmV2dfF3DjzkusuTisVhFMNKclVCxSSuQYswBZJ8ZUCdxMYq3XIyl5kfxD7t8Tb09cdeYWPw1SUkSdjMYbVUkL+Q+tidb4FudhIH5hZQ+gAAtRYidxG1esNj0cB1ITyN5eM3UkGM59/TFqvIGfolJEBJFW7gyeqedKlgiavdXVaEOvBk4kqu+2q7waMTYbCMPLBFNBBH7bEdPt4OA5hU5qlVuCMH7y3CKHOikSDiIBzLEIcx1cy1xmHzvxuDya340vW0IK8PnvSV2jp/3uy4XWc0SXq+zWAZTfHwYFObx32byo0pBTnx8CVkxdhwNZYwfCU7KIPHJ++WVpxTyx/BrJT5BkqmTbnccsJrpr75DNfm/lrthWjz66Es2sdZVb5Knn/ezfHyKP92hcl1jNhddkX4YWH1rZt5UYA1paQrsMgolKnt9oRBsaN5/2A5X+2hHzwDRSV20XP7d7ZLwDtUCsUQf7aMo5B4P6p3ElRGpLyA04YRm/x/aegQujVMrgdIKxZ/u/TtM0gPkkoeFcbDSrQq3PVEiOGMiDxKPrKMEE4f0nYqs6mpeyoBn6lSyCXDWhXcAo=
 cache:
   apt: true
   directories:
-    - node_modules
+  - node_modules
 addons:
   apt:
     sources:
@@ -17,16 +18,16 @@ addons:
     packages:
     - g++-4.8
 before_install:
-  - npm install -g npm@'>=3.8.0'
-  - npm prune
+- npm install -g npm@'>=3.8.0'
+- npm prune
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
 script:
 - npm test
-- "gulp build --production"
+- gulp build --production
 before_deploy:
-- "gulp syncFirebase"
+- gulp syncFirebase
 deploy:
   provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     packages:
     - g++-4.8
 before_install:
-- npm install -g npm@'>=3.8.0'
+- npm install -g npm@'3.10.7'
 - npm prune
 before_script:
 - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -137,8 +137,25 @@ for all the sordid details.
 
 ## Thanks to ##
 
-[Bugsnag](https://bugsnag.com) provides excellent error alerting to Popcode for
-free.
+These companies generously offer Popcode access to paid tiers of their
+excellent services, free of charge:
+
+<table><tbody><tr>
+<td>
+<a href="https://browserstack.com">
+<img alt="BrowserStack"
+src="https://cloud.githubusercontent.com/assets/14214/19059103/23ffe174-89ab-11e6-8de3-482780488df5.png">
+</a>
+</td>
+<td>
+<a href="https://bugsnag.com">
+<img alt="Bugsnag"
+src="https://cloud.githubusercontent.com/assets/14214/19059115/428a80f4-89ab-11e6-8d05-d8d0795266fd.png">
+</a>
+</td>
+</tr>
+</tbody>
+</table>
 
 ## Contact ##
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -38,6 +38,16 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
     },
+    "agent-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+        }
+      }
+    },
     "ajv": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.7.4.tgz"
@@ -536,6 +546,10 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz"
+    },
     "binary-extensions": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz"
@@ -666,6 +680,14 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz"
     },
+    "browserstack": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.0.tgz"
+    },
+    "browserstacktunnel-wrapper": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz"
+    },
     "bs-recipes": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.2.3.tgz"
@@ -685,6 +707,10 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
     },
     "bugsnag-js": {
       "version": "3.0.4",
@@ -829,6 +855,10 @@
     "chai-immutable": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/chai-immutable/-/chai-immutable-1.6.0.tgz"
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
@@ -2424,6 +2454,16 @@
         }
       }
     },
+    "fstream": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
@@ -2819,6 +2859,10 @@
     "https-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
     },
     "i18next-client": {
       "version": "1.11.4",
@@ -3288,6 +3332,10 @@
         }
       }
     },
+    "karma-browserstack-launcher": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.1.1.tgz"
+    },
     "karma-chai": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz"
@@ -3597,6 +3645,20 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
     },
+    "match-stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        }
+      }
+    },
     "math-expression-evaluator": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz"
@@ -3807,6 +3869,7 @@
     },
     "npm": {
       "version": "2.15.11",
+      "from": "npm@https://registry.npmjs.org/npm/-/npm-2.15.11.tgz",
       "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.11.tgz",
       "dependencies": {
         "abbrev": {
@@ -4931,6 +4994,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
     },
+    "over": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
+    },
     "package-json": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz"
@@ -5439,6 +5506,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
     },
+    "pullstream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        }
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
@@ -5835,6 +5916,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+    },
     "setprototypeof": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
@@ -5884,6 +5969,20 @@
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+    },
+    "slice-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -6219,6 +6318,10 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/transform-loader/-/transform-loader-0.2.3.tgz"
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
@@ -6332,6 +6435,20 @@
     "untildify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
+    },
+    "unzip": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        }
+      }
     },
     "unzip-response": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "imports-loader": "^0.6.5",
     "json-loader": "^0.5.4",
     "karma": "^1.1.0",
+    "karma-browserstack-launcher": "^1.1.1",
     "karma-chai": "^0.1.0",
     "karma-chai-as-promised": "^0.1.2",
     "karma-chrome-launcher": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "engines": {
     "node": "6.3.1",
-    "npm": "3.10.3"
+    "npm": "3.10.7"
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/bower install",

--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -9,7 +9,9 @@ import {
 
 import css from '../../../src/validations/css';
 
-describe('css', () => {
+describe('css', function() {
+  this.timeout(10000); // eslint-disable-line no-invalid-this
+
   it('allows valid flexbox', () =>
     assertPassesValidation(css, `
       .flex-container {


### PR DESCRIPTION
BrowserStack allows us to run tests on a bunch of real browsers. Cool!

One problem is that we need credentials to run tests on BrowserStack.  And since this is an open source project, that either means making my credentials public, or only allowing them to be used when run from the canonical `popcodeorg` repo. For now, we’ll go with the latter.

This means that PR tests will only be run in Firefox, which is available locally on Travis. This is not the end of the world, as we will still run the tests on the full suite of browsers before cutting a new release.