### PR TITLE
Fail fast if attempting to create a gist with no content

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -23,7 +23,8 @@
   },
   "applicationErrors": {
     "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
-    "auth-error": "Something went wrong trying to sign in. Please try again!"
+    "auth-error": "Something went wrong trying to sign in. Please try again!",
+    "empty-gist": "You need some code in your project to export a gist!"
   },
   "languages": {
     "html": "HTML",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -5,6 +5,7 @@ import bindAll from 'lodash/bindAll';
 import partial from 'lodash/partial';
 import classnames from 'classnames';
 import Gists from '../services/Gists';
+import {EmptyGistError} from '../services/Gists';
 import ProjectList from './ProjectList';
 import LibraryPicker from './LibraryPicker';
 import config from '../config';
@@ -123,6 +124,13 @@ class Dashboard extends React.Component {
     Gists.createFromProject(this.props.currentProject, this.props.currentUser).
       then((response) => {
         newWindow.location = response.html_url;
+      }, (error) => {
+        if (error instanceof EmptyGistError) {
+          this.props.onEmptyGist();
+          newWindow.close();
+          return Promise.resolve();
+        }
+        return Promise.reject(error);
       });
   }
 
@@ -240,6 +248,7 @@ Dashboard.propTypes = {
   currentProject: React.PropTypes.object,
   currentUser: React.PropTypes.object.isRequired,
   validationState: React.PropTypes.string.isRequired,
+  onEmptyGist: React.PropTypes.func.isRequired,
   onLibraryToggled: React.PropTypes.func.isRequired,
   onLogOut: React.PropTypes.func.isRequired,
   onNewProject: React.PropTypes.func.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -76,7 +76,8 @@ class Workspace extends React.Component {
       '_handleStartLogIn',
       '_handleToggleDashboard',
       '_handleRequestedLineFocused',
-      '_handleApplicationErrorDismissed'
+      '_handleApplicationErrorDismissed',
+      '_handleEmptyGist'
     );
   }
 
@@ -275,6 +276,10 @@ class Workspace extends React.Component {
     this.props.dispatch(editorFocusedRequestedLine());
   }
 
+  _handleEmptyGist() {
+    this.props.dispatch(applicationErrorTriggered('empty-gist'));
+  }
+
   _renderDashboard() {
     if (!this.props.ui.dashboard.isOpen) {
       return null;
@@ -288,6 +293,7 @@ class Workspace extends React.Component {
           currentProject={this.props.currentProject}
           currentUser={this.props.currentUser}
           validationState={this._getOverallValidationState()}
+          onEmptyGist={this._handleEmptyGist}
           onLibraryToggled={this._handleLibraryToggled}
           onLogOut={this._handleLogOut}
           onNewProject={this._handleNewProject}


### PR DESCRIPTION
GitHub does not allow gists with no content. In this case, bail before attempting to send the gist to GitHub, and display an error message.

![](https://dl.dropboxusercontent.com/u/37033819/2016-10-03_2144.png?raw=1)