### PR TITLE
Import missing TextEncoder polyfill

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -7,6 +7,7 @@ import i18n from 'i18next-client';
 import bindAll from 'lodash/bindAll';
 import partial from 'lodash/partial';
 import classnames from 'classnames';
+import {TextEncoder} from 'text-encoding';
 import Gists from '../services/Gists';
 import {EmptyGistError} from '../services/Gists';
 import ProjectList from './ProjectList';


### PR DESCRIPTION
Safari does not support this, but unfortunately the linter didn’t catch it because it is part of the browser API.