### PR TITLE
Ensure we can read gist from GitHub API before attempting to open it

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -24,7 +24,8 @@
   "applicationErrors": {
     "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
     "auth-error": "Something went wrong trying to sign in. Please try again!",
-    "empty-gist": "You need some code in your project to export a gist!"
+    "empty-gist": "You need some code in your project to export a gist!",
+    "gist-export-error": "Something went wrong trying to create that gist. Please try again."
   },
   "languages": {
     "html": "HTML",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5560,6 +5560,20 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "dependencies": {
+        "err-code": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.1.tgz"
+        },
+        "retry": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz"
+        }
+      }
+    },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.15.0",
     "loop-protect": "git+https://github.com/jsbin/loop-protect.git#v1.0.1",
     "moment": "^2.14.1",
+    "promise-retry": "^1.1.1",
     "qs": "^6.1.0",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -146,6 +146,8 @@ class Dashboard extends React.Component {
           newWindow.close();
           return Promise.resolve();
         }
+        this.props.onGistExportError();
+        newWindow.close();
         return Promise.reject(error);
       });
   }
@@ -265,6 +267,7 @@ Dashboard.propTypes = {
   currentUser: React.PropTypes.object.isRequired,
   validationState: React.PropTypes.string.isRequired,
   onEmptyGist: React.PropTypes.func.isRequired,
+  onGistExportError: React.PropTypes.func.isRequired,
   onLibraryToggled: React.PropTypes.func.isRequired,
   onLogOut: React.PropTypes.func.isRequired,
   onNewProject: React.PropTypes.func.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -77,7 +77,8 @@ class Workspace extends React.Component {
       '_handleToggleDashboard',
       '_handleRequestedLineFocused',
       '_handleApplicationErrorDismissed',
-      '_handleEmptyGist'
+      '_handleEmptyGist',
+      '_handleGistExportError'
     );
   }
 
@@ -280,6 +281,10 @@ class Workspace extends React.Component {
     this.props.dispatch(applicationErrorTriggered('empty-gist'));
   }
 
+  _handleGistExportError() {
+    this.props.dispatch(applicationErrorTriggered('gist-export-error'));
+  }
+
   _renderDashboard() {
     if (!this.props.ui.dashboard.isOpen) {
       return null;
@@ -294,6 +299,7 @@ class Workspace extends React.Component {
           currentUser={this.props.currentUser}
           validationState={this._getOverallValidationState()}
           onEmptyGist={this._handleEmptyGist}
+          onGistExportError={this._handleGistExportError}
           onLibraryToggled={this._handleLibraryToggled}
           onLogOut={this._handleLogOut}
           onNewProject={this._handleNewProject}

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -1,8 +1,6 @@
 import GitHub from 'github-api';
-import pick from 'lodash/pick';
 import trim from 'lodash/trim';
 import isEmpty from 'lodash/isEmpty';
-import Bugsnag from '../util/Bugsnag';
 const anonymousGithub = new GitHub({});
 
 export function EmptyGistError(message) {
@@ -63,22 +61,7 @@ function updateGistWithImportUrl(github, gistData) {
 
   return gist.update({
     description: `${gistData.description} Click to import: ${uri.href}`,
-  }).then(
-    (response) => response.data,
-    notifyAndRejectApiError
-  );
-}
-
-function notifyAndRejectApiError(error) {
-  if (error.response) {
-    Bugsnag.notifyException(
-      error,
-      'GistError',
-      {failedRequest: pick(error, ['request', 'response', 'status'])}
-    );
-  }
-
-  return Promise.reject(error);
+  }).then((response) => response.data);
 }
 
 const Gists = {
@@ -103,10 +86,7 @@ const Gists = {
   loadFromId(gistId, user) {
     const github = clientForUser(user);
     const gist = github.getGist(gistId);
-    return gist.read().then(
-      (response) => response.data,
-      notifyAndRejectApiError
-    );
+    return gist.read().then((response) => response.data);
   },
 };
 


### PR DESCRIPTION
Various classes have observed situations in which newly-created gists, when opened in the new tab, yield a GitHub 404 page. This is odd behavior, considering we are just using the `html_url` returned by the GitHub API.

Bit of a shot in the dark here, since the error isn’t readily reproduced, but my theory right now is that we’re hitting an eventual consistency situation or a slightly laggy database replica on GitHub’s end.

To try to combat this, after creating (and possibly updating) the gist, we send an API request to fetch the newly created gist. If the request fails, we’ll retry with exponential backoff several times.

The hope is that a 404 on the web URL will correlate with a 404 in the API. There is certainly no guarantee of this, but it’s worth a shot.