### PR TITLE
Gracefully handle 404 when trying to import a gist

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -25,7 +25,8 @@
     "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
     "auth-error": "Something went wrong trying to sign in. Please try again!",
     "empty-gist": "You need some code in your project to export a gist!",
-    "gist-export-error": "Something went wrong trying to create that gist. Please try again."
+    "gist-export-error": "Something went wrong trying to create that gist. Please try again.",
+    "gist-import-not-found": "Looks like that gist doesn’t exist. Check the URL and try again."
   },
   "languages": {
     "html": "HTML",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -286,7 +286,14 @@ function bootstrap({gistId} = {gistId: null}) {
 
     let gistLoaded;
     if (gistId) {
-      gistLoaded = Gists.loadFromId(gistId, getState().user.toJS());
+      gistLoaded =
+        Gists.loadFromId(gistId, getState().user.toJS()).catch((error) => {
+          if (get(error, 'response.status') === 404) {
+            dispatch(applicationErrorTriggered('gist-import-not-found'));
+            return Promise.resolve();
+          }
+          return Promise.reject(error);
+        });
     } else {
       gistLoaded = Promise.resolve();
     }


### PR DESCRIPTION
It’s entirely possible for a gist ID in the query param to refer to a nonexistent gist. In this case, we should display an error message and go about our day.

![image](https://cloud.githubusercontent.com/assets/14214/19294450/c3b00316-8ffa-11e6-815a-0f14af75e315.png)
