### PR TITLE
simple fix to bring dashboard items to the front

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -236,6 +236,7 @@ body {
   margin: 1px 0;
   padding: 0.2rem 0.5rem;
   text-decoration: none;
+  z-index: 1;
 }
 
 .dashboard-menu-item--grid {


### PR DESCRIPTION
Simple fix to the problem where in smaller window sizes, the Pop svg blocks the click target for the dashboard menu items. By bringing the dashboard menu items to the front, the Pop svg will not block them.