### PR TITLE
Export libraries to popcode.json and reload when importing

### DIFF
--- a/spec/examples/actions/index.spec.js
+++ b/spec/examples/actions/index.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+/* global sinon */
+
+import '../../helper';
+import {assert} from 'chai';
+
+import createApplicationStore from '../../../src/createApplicationStore';
+
+import {
+  createProject,
+} from '../../../src/actions/projects';
+
+import {
+  importProjectFromGist,
+} from '../../../src/actions/index';
+
+import {
+  getProjectKeys,
+  getCurrentProject,
+} from '../../../src/util/projectUtils';
+
+describe('indexActions', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createApplicationStore();
+  });
+
+  describe('importProjectFromGist', () => {
+    it('sets enabledLibraries to default if no popcode.json exists', () => {
+      const gistData = {
+        files: {
+          "index.html":
+            {
+              language: 'html',
+              content: '<h1>Hello, world!</h1>',
+            },
+        },
+      };
+      store.dispatch(createProject());
+      const currentProject = getCurrentProject(store.getState());
+      store.dispatch(importProjectFromGist(currentProject.projectKey, gistData))
+      const updatedProject = getCurrentProject(store.getState());
+      assert.equal(updatedProject.enabledLibraries.length, 0);
+    });
+
+    it('sets enabledLibraries to the enabledLibarires property in popcode.json', () => {
+      const gistData = {
+        files: {
+          "index.html": 
+            {
+              language: 'html',
+              content: '<h1>Hello, world!</h1>',
+            },
+          "popcode.json":
+            {
+              language: 'json',
+              filename: 'popcode.json',
+              content: '{"enabledLibraries":["jquery"]}',
+            },
+        },
+      };
+      store.dispatch(createProject());
+      const currentProject = getCurrentProject(store.getState());
+      store.dispatch(importProjectFromGist(currentProject.projectKey, gistData))
+      const updatedProject = getCurrentProject(store.getState());
+      assert.equal(updatedProject.enabledLibraries.length, 1);
+      assert.equal(updatedProject.enabledLibraries[0], "jquery");
+    });
+
+  });
+
+});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -231,6 +231,7 @@ function initializeCurrentProjectFromGist(gistData) {
 
 function importProjectFromGist(projectKey, gistData) {
   const files = values(gistData.files);
+  const popcodeJson = parsePopcodeJson(files);
   const project = {
     projectKey,
     sources: {
@@ -239,7 +240,7 @@ function importProjectFromGist(projectKey, gistData) {
       javascript: map(filter(files, {language: 'JavaScript'}), 'content').
         join('\n\n'),
     },
-    enabledLibraries: [],
+    enabledLibraries: popcodeJson.enabledLibraries || [],
     updatedAt: Date.now(),
   };
 
@@ -247,6 +248,14 @@ function importProjectFromGist(projectKey, gistData) {
     type: 'PROJECT_IMPORTED',
     payload: {project},
   };
+}
+
+function parsePopcodeJson(files) {
+  const popcodeJsonFile = find(files, {filename: 'popcode.json'});
+  if (!popcodeJsonFile) {
+    return {};
+  }
+  return JSON.parse(get(popcodeJsonFile, 'content', '{}'));
 }
 
 function minimizeComponent(componentName) {
@@ -325,4 +334,5 @@ export {
   applicationErrorTriggered,
   userDismissedApplicationError,
   bootstrap,
+  importProjectFromGist,
 };

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -31,6 +31,12 @@ function createGistFromProject(project) {
       language: 'JavaScript',
     };
   }
+  if (project.enabledLibraries.length) {
+    files['popcode.json'] = {
+      content: createPopcodeJson(project),
+      language: 'JSON',
+    };
+  }
 
   return {
     description: 'Exported from Popcode.',
@@ -63,6 +69,13 @@ function updateGistWithImportUrl(github, gistData) {
   return gist.update({
     description: `${gistData.description} Click to import: ${uri.href}`,
   }).then((response) => response.data);
+}
+
+function createPopcodeJson(project) {
+  const json = {
+    enabledLibraries: project.enabledLibraries,
+  };
+  return JSON.stringify(json);
 }
 
 const Gists = {


### PR DESCRIPTION
popcode.json could later be extended to save any other metadata that
we want to.

Fixes: #195