### PR TITLE
Don’t allow omission of any close tags

### DIFF
--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -55,6 +55,14 @@ describe('html', () => {
     )
   );
 
+  it('generates unclosed-tag error for missing closing p tag', () =>
+    assertFailsValidationWith(
+      html,
+      htmlWithBody('<p>'),
+      'mismatched-close-tag'
+    )
+  );
+
   it('generates unterminated-close-tag error for unfinished closing tag', () =>
     assertFailsValidationWith(
       html,

--- a/src/validations/linters.js
+++ b/src/validations/linters.js
@@ -4,6 +4,9 @@ import htmllint from 'htmllint';
 import {JSHINT as jshint} from 'jshint';
 import prettyCSS from 'PrettyCSS';
 import Slowparse from 'slowparse/src';
+import SlowparseHTMLParser from 'slowparse/src/HTMLParser';
+
+SlowparseHTMLParser.prototype.omittableCloseTagHtmlElements = [];
 
 export {
   css,


### PR DESCRIPTION
In HTML5, a few close tags can be omitted, e.g. `<p>`. So, this is valid HTML:

```html
<!doctype html>
<html>
  <body>
    <p>My paragraph
  </body>
</html>
```

However this confusing, inconsistent, and bad practice. Not something we want to teach students they can do.

So, we override the Slowparse parser to clear the list of tags that may be omitted. Directly reaching into the parser’s prototype and modifying one of its properties isn’t the most elegant-feeling solution, but it’s the only way I could find to do it given the API that Slowparse currently exposes.