### PR TITLE
Ensure Pop stays within bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "name": "Alex Pelan",
       "email": "alexpelan@gmail.com",
       "url": "http://www.alexpelan.com/"
+    },
+    {
+      "name": "Carol Chau",
+      "email": "carol.chau@macaulay.cuny.edu",
+      "url": "https://github.com/carolchau"
     }
   ],
   "keywords": "code editor education learning",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -202,10 +202,6 @@ class Dashboard extends React.Component {
   }
 
   _renderPop() {
-    if (this.props.activeSubmenu) {
-      return null;
-    }
-
     return (
       <div className="dashboard-popContainer">
         {this._renderPopSvg('neutral', 'passed')}
@@ -253,6 +249,7 @@ class Dashboard extends React.Component {
         {this._renderLoginState()}
         {this._renderMenu()}
         {this._renderSubmenu()}
+        <div className="dashboard-spacer" />
         {this._renderPop()}
         {this._renderLinks()}
       </div>

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -247,20 +247,29 @@ body {
   font-weight: bold;
 }
 
-.dashboard-popContainer {
+.dashboard-spacer {
   flex: 1 0 auto;
+}
+
+.dashboard-popContainer {
+  flex: 0 1 auto;
   position: relative;
+  display: flex;
 }
 
 .dashboard-pop {
   display: none;
+  flex: 0 1 100%;
+  overflow: hidden;
 }
 
 .dashboard-pop--visible {
   display: block;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
+}
+
+.dashboard-pop--visible svg {
+  max-height: 100%;
+  max-width: 100%;
 }
 
 .dashboard-links {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -48,16 +48,8 @@
   --color-purple: #ff00ff;
 }
 
-html, body {
-  min-height: 100%;
-}
-
 body {
   font-family: 'Roboto', sans-serif;
-}
-
-#main, .layout {
-  height: 100%;
 }
 
 .layout {
@@ -323,6 +315,7 @@ body {
 }
 
 .editors {
+  height: 100vh;
   display: flex;
   flex-direction: column;
   font-family: 'Inconsolata';
@@ -330,7 +323,7 @@ body {
 
 .editors-editorContainer {
   box-sizing: border-box;
-  flex: 0 1 100%;
+  flex: 0 1 100vh;
   border-right: 2px solid var(--color-gray);
   border-bottom: 2px solid var(--color-gray);
   position: relative;

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -228,7 +228,6 @@ body {
   margin: 1px 0;
   padding: 0.2rem 0.5rem;
   text-decoration: none;
-  z-index: 1;
 }
 
 .dashboard-menu-item--grid {

--- a/static/index.html
+++ b/static/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
   <head>
     <title>Popcode | HTML, CSS, and JavaScript editor for students</title>


### PR DESCRIPTION
Previously we had an issue with Pop encroaching into the button area of the dashboard with very small viewport heights. This fixes that issue.

In Chrome, the behavior is ideal: Pop will resize to accommodate both the width and height available to it.

![image](https://cloud.githubusercontent.com/assets/14214/19386781/2f20179a-91e4-11e6-8a41-86dcd9f7deee.png)

In Firefox and Safari, Pop does not resize to accommodate small vertical space, but its container is `overflow:hidden` so at least it will not encroach.

![image](https://cloud.githubusercontent.com/assets/14214/19386816/52783204-91e4-11e6-825f-de368ceec480.png)

This is accomplished by removing the absolute positioning of Pop within an expanding flex container. Instead, we add a expanding flex spacer above Pop, and then set Pop to take up only the space it needs. We further set a `max-width` and `max-height` on the SVG itself.

Fixes #189 