### PR TITLE
Allow dashes in attribute names

### DIFF
--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -87,6 +87,36 @@ describe('html', () => {
     )
   );
 
+  it('allows lowercase attributes', () =>
+    assertPassesValidation(
+      html,
+      htmlWithBody('<div id="first">Content</div>')
+    )
+  );
+
+  it('allows lowercase data attributes', () =>
+    assertPassesValidation(
+      html,
+      htmlWithBody('<div data-id="1">Content</div>')
+    )
+  );
+
+  it('generates error for uppercase attributes', () =>
+    assertFailsValidationWith(
+      html,
+      htmlWithBody('<div ID="first">Content</div>'),
+      'lower-case-attribute-name'
+    )
+  );
+
+  it('generates error for uppercase data attributes', () =>
+    assertFailsValidationWith(
+      html,
+      htmlWithBody('<div data-ID="first">Content</div>'),
+      'lower-case-attribute-name'
+    )
+  );
+
   it('generates meaningful error for extra tag at end of doc', () =>
     assertFailsValidationWith(
       html,

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -80,7 +80,7 @@ const htmlLintOptions = {
     'scrolling',
     'width',
   ],
-  'attr-name-style': 'lowercase',
+  'attr-name-style': 'dash',
   'attr-no-dup': true,
   'attr-quote-style': 'quoted',
   'doctype-first': true,


### PR DESCRIPTION
By using `htmllint` `attr-name-style` `lowercase`, we were overzealously requiring attribute names consisted entirely of lowercase characters. In fact we want to allow dashes as well. Switch to the `dash` style, which matches the pattern we are in fact interested in.