### PR TITLE
Graceful handling of closed gist windows

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -11,8 +11,7 @@
       "libraries": "Libraries",
       "export-gist": "Export Gist",
       "send-feedback": "Send Feedback"
-    },
-    "anonymous-gist-export": "Are you sure you want to export this gist anonymously? If you sign in before exporting, the gist will be added to your GitHub account."
+    }
   },
   "editors": {
     "helpText": "Type in your $t(languages.__language__) code here."
@@ -26,6 +25,7 @@
     "auth-error": "Something went wrong trying to sign in. Please try again!",
     "empty-gist": "You need some code in your project to export a gist!",
     "gist-export-error": "Something went wrong trying to create that gist. Please try again.",
+    "gist-export-window-closed": "Looks like you closed your gist tab before it finished exporting. Please try again.",
     "gist-import-not-found": "Looks like that gist doesn’t exist. Check the URL and try again."
   },
   "languages": {
@@ -34,7 +34,10 @@
     "javascript": "JavaScript"
   },
   "workspace": {
-    "confirm-unload": "If you leave the page, you will lose your work. To save your work, you must log in using your GitHub account.",
+    "confirmations": {
+      "unload-unsaved": "If you leave the page, you will lose your work. To save your work, you must log in using your GitHub account.",
+      "anonymous-gist-export": "Are you sure you want to export this gist anonymously? If you sign in before exporting, the gist will be added to your GitHub account."
+    },
     "components": {
       "editor": {
         "html": "HTML",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Isvg from 'react-inlinesvg';
 import i18n from 'i18next-client';
-import bindAll from 'lodash/bindAll';
 import partial from 'lodash/partial';
 import classnames from 'classnames';
 import ProjectList from './ProjectList';
@@ -9,11 +8,6 @@ import LibraryPicker from './LibraryPicker';
 import config from '../config';
 
 class Dashboard extends React.Component {
-  constructor() {
-    super();
-    bindAll(this, '_handleNewProject');
-  }
-
   _renderLoginState() {
     const currentUser = this.props.currentUser;
 
@@ -73,7 +67,7 @@ class Dashboard extends React.Component {
       newProjectButton = (
         <div
           className="dashboard-menu-item dashboard-menu-item--grid"
-          onClick={this._handleNewProject}
+          onClick={this.props.onNewProject}
         >
           {i18n.t('dashboard.menu.new-project')}
         </div>
@@ -109,10 +103,6 @@ class Dashboard extends React.Component {
         </a>
       </div>
     );
-  }
-
-  _handleNewProject() {
-    this.props.onNewProject();
   }
 
   _renderSubmenu() {


### PR DESCRIPTION
If the gist export takes a long time, the student may close the window before it completes (or fails). We want to handle this gracefully:

* If the export completes and the student has closed the window, we display an application error instructing the student to try again.
* If the export fails and the student has closed the window, we don’t try to close the window again.

Also used this as an opportunity to move the meat of the gist export logic out of the `Dashboard` and into the `Workspace`, since the latter as the view controller should take care of (or delegate to the action creators) pretty much anything interesting.

Threw in another small fix which is to always open a new tab for the exported gist, rather than reusing the same tab for successive exports (which is 100% confusing).

Finally, I noticed that there was a pretty useless `_handleNewProject` method on `Dashboard`, which does nothing more than wrap the `onNewProject` prop the `Dashboard` is given, so I unrolled that.

Closes #263 