### PR TITLE
Always open gists in new tab

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -134,7 +134,7 @@ class Dashboard extends React.Component {
       }
     }
 
-    const newWindow = open('about:blank', 'gist');
+    const newWindow = open('about:blank', '_blank');
     newWindow.location = `data:text/html;base64,${spinnerPage}`;
 
     Gists.createFromProject(this.props.currentProject, this.props.currentUser).


### PR DESCRIPTION
Exported gists are always opened in a new tab, rather than reusing the same tab. This is for two reasons:

1. It’s generally confusing to load the exported gist in an already-open tab, particularly as there is no way to focus it.
2. There is a crazy bug where if you export a gist, then open Popcode in the exported gist window, then try to export a gist again, it will reuse the window that Popcode is currently running in! Meaning it stops running, no gist is exported, and the spinner is forever.

So: Open a new window to `_blank`.