### PR TITLE
Set window href after initial call to open()

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -144,10 +144,8 @@ class Dashboard extends React.Component {
       }
     }
 
-    const newWindow = open(
-      `data:text/html;base64,${spinnerPage}`,
-      '_blank'
-    );
+    const newWindow = open('about:blank', '_blank');
+    newWindow.location.href = `data:text/html;base64,${spinnerPage}`;
 
     const gistWillExport = Gists.createFromProject(
       this.props.currentProject,


### PR DESCRIPTION
I’m now seeing an issue in production that @alexpelan had previously reported in a different branch, namely that the Gist export window closes as soon as it opens!

I set a bunch of breakpoints in production but could not make heads or tails of it. There does not appear to be an error occurring.

The one thing that that branch has in common with newly-released production code is calling `open` directly on a `data` URI, instead of calling it on `about:blank` and then setting the `location`. So, rolling back to that in hopes that it will help.

I cannot reproduce the error in dev at all.