### PR TITLE
Use location.href workaround to work around Chrome closing bug in popout

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -12,6 +12,7 @@ import Gists from '../services/Gists';
 import {EmptyGistError} from '../services/Gists';
 import ProjectList from './ProjectList';
 import LibraryPicker from './LibraryPicker';
+import {openWindowWithWorkaroundForChromeClosingBug} from '../util';
 import config from '../config';
 
 const spinnerPage = base64.fromByteArray(
@@ -144,8 +145,9 @@ class Dashboard extends React.Component {
       }
     }
 
-    const newWindow = open('about:blank', '_blank');
-    newWindow.location.href = `data:text/html;base64,${spinnerPage}`;
+    const newWindow = openWindowWithWorkaroundForChromeClosingBug(
+      `data:text/html;base64,${spinnerPage}`
+    );
 
     const gistWillExport = Gists.createFromProject(
       this.props.currentProject,

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 
 import PreviewFrame from './PreviewFrame';
 import generatePreview from '../util/generatePreview';
+import {openWindowWithWorkaroundForChromeClosingBug} from '../util';
 
 class Preview extends React.Component {
   constructor() {
@@ -44,7 +45,8 @@ class Preview extends React.Component {
     const uint8array = new TextEncoder('utf-8').encode(doc);
     const base64encoded = base64.fromByteArray(uint8array);
     const url = `data:text/html;charset=utf-8;base64,${base64encoded}`;
-    window.open(url, 'preview');
+
+    openWindowWithWorkaroundForChromeClosingBug(url);
   }
 
   render() {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,7 @@
+export function openWindowWithWorkaroundForChromeClosingBug(
+  location, name = '_blank'
+) {
+  const newWindow = open('about:blank', name);
+  newWindow.location.href = location;
+  return newWindow;
+}


### PR DESCRIPTION
It appears that a recent version of Chrome has introduced a regression that causes newly-opened windows to immediately close if they are opened with a data URI. This behavior definitely used to work fine, and it also works as expected in Firefox. [Here is a reduction of the bug](https://outoftime.github.io/presentations/openbug/index.html).

Even more oddly, I do not see this behavior in development, only production. Others have seen it in development, though.

Happily, opening `about:blank` and then immediately setting the `location.href` of the new window to the desired location (data URI) seems to work fine.

Fixes #505