### PR TITLE
Force html doctype in generated preview

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -33,7 +33,7 @@ class Preview extends React.Component {
         breakLoops: isLivePreview,
         nonBlockingAlertsAndPrompts: isLivePreview,
       }
-    ).documentElement.outerHTML;
+    );
   }
 
   _handlePopOutClick() {

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -211,7 +211,9 @@ class PreviewGenerator {
 }
 
 function generatePreview(project, options) {
-  return new PreviewGenerator(project, options).previewDocument;
+  const previewDocument =
+    new PreviewGenerator(project, options).previewDocument;
+  return `<!DOCTYPE html> ${previewDocument.documentElement.outerHTML}`;
 }
 
 function generateTextPreview(project) {


### PR DESCRIPTION
I just hardcoded to html doctype, since that's what our html validators force anyway. I couldn't find any way to programmatically get the doctype from the DOMParser output, and my other thought was to grab the current document's doctype (in case times change), but that involved some nasty parsing  (http://stackoverflow.com/a/10162353/265714 )

Fixes: #510
