### PR TITLE
Explicitly use a blank `src` for preview frame when no source document is available

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -102,11 +102,19 @@ class PreviewFrame extends React.Component {
   }
 
   render() {
+    let srcProps;
+
+    if (this.props.src) {
+      srcProps = {srcDoc: this.props.src};
+    } else {
+      srcProps = {src: 'about:blank'};
+    }
+
     return (
       <iframe
         className="preview-frame"
         sandbox={sandboxOptions}
-        srcDoc={this.props.src}
+        {...srcProps}
       />
     );
   }


### PR DESCRIPTION
In order to keep from constantly adding and removing an `iframe` from the DOM, we keep the iframe around all the time, and just hide it when we don’t need it (e.g. when validations are in progress or there are errors).

In this case the `PreviewFrame` component is passed a blank `src`, because we don’t want to give potentially invalid HTML/CSS/JS to the frame, which could then cause runtime errors/console errors/etc.

However, in Safari, this constant switching from blank to non-blank `srcDoc` for the iframe causes it to intermittently (but pretty regularly) get “stuck” on a blank document, even when the `srcDoc` contains a document with content.

There is no particular reason that this should be the case, so it seems like a browser bug. We haven’t seen this behavior in Firefox or Chrome (except maybe once on a Chromebook).

After some experimentation, I’ve discovered that explicitly setting the `src` of the iframe to `about:blank` when there is no `src` available prevents the bad behavior: the frame consistently renders the up-to-date code assembled from the values of the editors.

Fixes #521