### PR TITLE
Retry loading gist if request fails

### DIFF
--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -108,7 +108,8 @@ const Gists = {
   loadFromId(gistId, user) {
     const github = clientForUser(user);
     const gist = github.getGist(gistId);
-    return gist.read().then((response) => response.data);
+    return promiseRetry((retry) => gist.read().catch(retry), {retries: 3}).
+      then((response) => response.data);
   },
 };
 


### PR DESCRIPTION
If request to load gist fails, retry a few times with exponential backoff.

Fixes #278
Fixes #331 