### PR TITLE
Temporarily log the user ID on login

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,6 +3,7 @@ import find from 'lodash/find';
 import filter from 'lodash/filter';
 import values from 'lodash/values';
 import map from 'lodash/map';
+import isFunction from 'lodash/isFunction';
 import FirebasePersistor from '../persistors/FirebasePersistor';
 import Gists from '../services/Gists';
 import appFirebase from '../services/appFirebase';
@@ -288,6 +289,10 @@ function bootstrap({gistId} = {gistId: null}) {
         if (authData === null) {
           dispatch(logOut());
         } else {
+          if (isFunction(get(window, 'console.log'))) {
+            // eslint-disable-next-line no-console
+            console.log('logged in with user ID', authData.uid);
+          }
           dispatch(logIn(authData));
         }
         resolve();


### PR DESCRIPTION
Popcode is totally freezing when a certain student signs in. Since Firebase now creates opaque user IDs, I need to have an instructor grab her UID from the console so I can look at the data in her account and figure out what might be going on.

Relates to #527