### PR TITLE
Don’t attempt to inspect DOM if document root is null

### DIFF
--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -139,5 +139,9 @@ describe('html', () => {
     )
   );
 
+  it('produces an error for a malformed DOCTYPE that doesn’t parse', () =>
+    assertFailsValidationWith(html, '<!DOCT\n', 'doctype')
+  );
+
   assertPassesAcceptance(html, 'html');
 });

--- a/src/validations/html/htmlInspector.js
+++ b/src/validations/html/htmlInspector.js
@@ -1,4 +1,5 @@
 import last from 'lodash/last';
+import isNull from 'lodash/isNull';
 import Validator from '../Validator';
 
 const errorMap = {
@@ -18,6 +19,10 @@ class HtmlInspectorValidator extends Validator {
   }
 
   _getRawErrors() {
+    if (isNull(this._doc.documentElement)) {
+      return Promise.resolve([]);
+    }
+
     return System.import('../linters').then(({HTMLInspector}) =>
       new Promise((resolve) => {
         HTMLInspector.inspect({


### PR DESCRIPTION
Certain malformed HTML may caused the parsed document to have a null `documentElement`. In this case, the `HTMLInspector` validator just bails, rather than passing `null` into `HTMLInspector`, which caused an uncaught error.

Fixes #324