### PR TITLE
Target PrettyCSS version with fix for catastrophic backtracking

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,8 +9,9 @@
       "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
     },
     "PrettyCSS": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/PrettyCSS/-/PrettyCSS-0.3.12.tgz"
+      "version": "0.3.12-unicodefix",
+      "from": "PrettyCSS@git+https://github.com/popcodeorg/PrettyCSS.git#5ab276ba72992cef0c08b28348d9cbfcb948bfa0",
+      "resolved": "git+https://github.com/popcodeorg/PrettyCSS.git#5ab276ba72992cef0c08b28348d9cbfcb948bfa0"
     },
     "abbrev": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "bugs": "https://trello.com/b/ONaFg6wh/popcode",
   "license": "MIT",
   "dependencies": {
-    "PrettyCSS": "^0.3.12",
+    "PrettyCSS": "git+https://github.com/popcodeorg/PrettyCSS#v0.3.12-unicodefix",
     "base64-js": "^1.0.2",
     "bowser": "^1.4.5",
     "brace": "^0.8.0",


### PR DESCRIPTION
An erroneous escape sequence in the PrettyCSS tokenizer caused Popcode to freeze when a long, invalid URL value was added to the CSS, e.g.:

```css
div {
  background: url("data:image/jpg;someverylongstringhere
}
```

(Note that there is no closing quotation mark or parenthesis)

The maintainer of PrettyCSS has pushed [a commit that fixes the problem](https://github.com/fidian/PrettyCSS/commit/dfab549b426df8f27f540e0637b810648b0b7dc1). Target a tag that points to this version directly until there is an official PrettyCSS release with the fix.

Fixes #527 