### PR TITLE
Show error message with link when gist import fails

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -27,7 +27,9 @@
     "gist-export-error": "Something went wrong trying to create that gist. Please try again.",
     "gist-export-complete": "Your gist export is ready!",
     "gist-export-link": "Click here to open it",
-    "gist-import-not-found": "Looks like that gist doesn’t exist. Check the URL and try again."
+    "gist-import-not-found": "Looks like that gist doesn’t exist. Check the URL and try again.",
+    "gist-import-error": "There was a problem importing that gist.",
+    "gist-import-link": "Click here to open it"
   },
   "languages": {
     "html": "HTML",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -6,6 +6,7 @@ import map from 'lodash/map';
 import isFunction from 'lodash/isFunction';
 import FirebasePersistor from '../persistors/FirebasePersistor';
 import Gists from '../services/Gists';
+import Bugsnag from '../util/Bugsnag';
 import appFirebase from '../services/appFirebase';
 import validations from '../validations';
 
@@ -305,9 +306,13 @@ function bootstrap({gistId} = {gistId: null}) {
         Gists.loadFromId(gistId, getState().user.toJS()).catch((error) => {
           if (get(error, 'response.status') === 404) {
             dispatch(notificationTriggered('gist-import-not-found'));
-            return Promise.resolve();
+          } else {
+            Bugsnag.notify(error);
+            dispatch(
+              notificationTriggered('gist-import-error', 'error', {gistId})
+            );
           }
-          return Promise.reject(error);
+          return Promise.resolve();
         });
     } else {
       gistLoaded = Promise.resolve();

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import partial from 'lodash/partial';
 import NotificationContainer from './NotificationContainer';
-import {GenericNotification, GistExportNotification} from './notifications';
+import {
+  GenericNotification,
+  GistExportNotification,
+  GistImportError,
+} from './notifications';
 
 const NOTIFICATION_COMPONENTS = {
   'gist-export-complete': GistExportNotification,
+  'gist-import-error': GistImportError,
 };
 
 function chooseNotificationComponent(notification) {

--- a/src/components/notifications/GistImportError.jsx
+++ b/src/components/notifications/GistImportError.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import i18n from 'i18next-client';
+
+function gistUrlFromId(gistId) {
+  return `https://gist.github.com/${gistId}`;
+}
+
+export default function GistImportError(props) {
+  return (
+    <span>
+      {i18n.t('notifications.gist-import-error')}{' '}
+      <a href={gistUrlFromId(props.payload.gistId)} target="_blank">
+        {i18n.t('notifications.gist-import-link')}
+      </a>
+    </span>
+  );
+}
+
+GistImportError.propTypes = {
+  payload: React.PropTypes.object.isRequired,
+  type: React.PropTypes.string.isRequired,
+};

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -1,7 +1,9 @@
 import GenericNotification from './GenericNotification';
 import GistExportNotification from './GistExportNotification';
+import GistImportError from './GistImportError';
 
 export {
   GenericNotification,
   GistExportNotification,
+  GistImportError,
 };


### PR DESCRIPTION
If a gist import fails—for instance, because the classroom’s IP is rate
limited—we should at least show a good error message and a link to open
the gist, so students can copy the code in. This does that.

![](https://dl.dropboxusercontent.com/u/37033819/2016-11-06_1934.png?raw=1)

Fixes #538