### PR TITLE
Resolved long word wrap issue in error pane

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -473,6 +473,20 @@ body {
   cursor: pointer;
 }
 
+.errorList-error-message {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
 .notificationList-notification {
   text-align: center;
   margin-bottom: 0.2rem;


### PR DESCRIPTION
Added styling to allow long 'words' to wrap in the error pane. This should fix issue https://github.com/popcodeorg/popcode/issues/548. 