### PR TITLE
#514 Make it possible to minimize the preview pane

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -47,7 +47,7 @@
         "css": "CSS",
         "javascript": "JS"
       },
-      "preview": "Preview"
+      "output": "Output"
     }
   },
   "errors": {

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -18,7 +18,7 @@ function EditorContainer(props) {
   return (
     <div className="editors-editorContainer">
       <div
-        className="editors-editorContainer-label"
+        className="editors-editorContainer-label container-label"
         onClick={props.onMinimize}
       >
         {i18n.t(`languages.${props.language}`)}

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -18,7 +18,7 @@ function EditorContainer(props) {
   return (
     <div className="editors-editorContainer">
       <div
-        className="editors-editorContainer-label container-label"
+        className="environment-column-label label"
         onClick={props.onMinimize}
       >
         {i18n.t(`languages.${props.language}`)}

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import i18n from 'i18next-client';
 import isEmpty from 'lodash/isEmpty';
 import ErrorList from './ErrorList';
 import Preview from './Preview';
@@ -23,6 +24,7 @@ class Output extends React.Component {
         isValid={this.props.validationState === 'passed'}
         project={this.props.project}
         onClearRuntimeErrors={this.props.onClearRuntimeErrors}
+        onMinimize={this.props.onMinimize}
         onRuntimeError={this.props.onRuntimeError}
       />
     );
@@ -59,6 +61,12 @@ class Output extends React.Component {
   render() {
     return (
       <div className="environment-column output">
+        <div
+          className="preview-label container-label"
+          onClick={this.props.onMinimize}
+        >
+          {i18n.t('workspace.components.preview')}
+        </div>
         {this._renderErrors()}
         {this._renderPreview()}
         {this._renderRuntimeErrorList()}
@@ -74,6 +82,7 @@ Output.propTypes = {
   validationState: React.PropTypes.string,
   onClearRuntimeErrors: React.PropTypes.func.isRequired,
   onErrorClick: React.PropTypes.func.isRequired,
+  onMinimize: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -24,7 +24,6 @@ class Output extends React.Component {
         isValid={this.props.validationState === 'passed'}
         project={this.props.project}
         onClearRuntimeErrors={this.props.onClearRuntimeErrors}
-        onMinimize={this.props.onMinimize}
         onRuntimeError={this.props.onRuntimeError}
       />
     );
@@ -62,10 +61,10 @@ class Output extends React.Component {
     return (
       <div className="environment-column output">
         <div
-          className="preview-label container-label"
+          className="environment-column-label label"
           onClick={this.props.onMinimize}
         >
-          {i18n.t('workspace.components.preview')}
+          {i18n.t('workspace.components.output')}
         </div>
         {this._renderErrors()}
         {this._renderPreview()}

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import values from 'lodash/values';
 import bindAll from 'lodash/bindAll';
 import includes from 'lodash/includes';
+import isEmpty from 'lodash/isEmpty';
 import partial from 'lodash/partial';
 import sortBy from 'lodash/sortBy';
 import map from 'lodash/map';
@@ -210,6 +211,10 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
+    if (includes(this.props.ui.minimizedComponents, 'preview')) {
+      return null;
+    }
+
     return (
       <Output
         errors={this.props.errors}
@@ -218,6 +223,10 @@ class Workspace extends React.Component {
         validationState={this._getOverallValidationState()}
         onClearRuntimeErrors={this._handleClearRuntimeErrors}
         onErrorClick={this._handleErrorClick}
+        onMinimize={
+          partial(this._handleComponentMinimized,
+            'preview')
+        }
         onRuntimeError={this._handleRuntimeError}
       />
     );
@@ -257,6 +266,10 @@ class Workspace extends React.Component {
         </EditorContainer>
       );
     });
+
+    if (isEmpty(editors)) {
+      return null;
+    }
 
     return (
       <div className="environment-column editors">{editors}</div>

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -211,7 +211,7 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
-    if (includes(this.props.ui.minimizedComponents, 'preview')) {
+    if (includes(this.props.ui.minimizedComponents, 'output')) {
       return null;
     }
 
@@ -225,7 +225,7 @@ class Workspace extends React.Component {
         onErrorClick={this._handleErrorClick}
         onMinimize={
           partial(this._handleComponentMinimized,
-            'preview')
+            'output')
         }
         onRuntimeError={this._handleRuntimeError}
       />

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -336,22 +336,11 @@ body {
   flex: 1 1 50%;
 }
 
-.container-label {
+.environment-column-label {
   position: absolute;
   bottom: 1em;
   right: 1em;
-  background-color: black;
-  color: white;
   z-index: 1;
-  padding: 0.2rem;
-  opacity: 0.2;
-  font-size: 0.8rem;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.container-label:hover {
-  opacity: 0.5;
 }
 
 .editors {
@@ -389,6 +378,20 @@ body {
   margin: -1rem 0 0 -5.5rem;
   opacity: 0.4;
   font-family: Roboto;
+}
+
+.label {
+  background-color: black;
+  color: white;
+  padding: 0.2rem;
+  opacity: 0.2;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.label:hover {
+  opacity: 0.5;
 }
 
 .output {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -329,14 +329,32 @@ body {
   flex: 1 1 auto;
   display: flex;
   flex-direction: row;
+  height: 100vh;
 }
 
 .environment-column {
   flex: 1 1 50%;
 }
 
+.container-label {
+  position: absolute;
+  bottom: 1em;
+  right: 1em;
+  background-color: black;
+  color: white;
+  z-index: 1;
+  padding: 0.2rem;
+  opacity: 0.2;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.container-label:hover {
+  opacity: 0.5;
+}
+
 .editors {
-  height: 100vh;
   display: flex;
   flex-direction: column;
   font-family: 'Inconsolata';
@@ -359,24 +377,6 @@ body {
 .editors-editorContainer-editor {
   z-index: 0;
   flex: 1 0 100%;
-}
-
-.editors-editorContainer-label {
-  position: absolute;
-  bottom: 1em;
-  right: 1em;
-  background-color: black;
-  color: white;
-  z-index: 1;
-  padding: 0.2rem;
-  opacity: 0.2;
-  font-size: 0.8rem;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.editors-editorContainer-label:hover {
-  opacity: 0.5;
 }
 
 .editors-editorContainer-helpText {


### PR DESCRIPTION
Addresses issue #514

Matched functionality that hides the HTML, CSS, JS panes to the Preview pane.

Slightly modified editor code so that Preview pane will match page width when HTML, CSS and JS panes are hidden.