### PR TITLE
CSS class names conform to standard BEM

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
         ],
         "camelcase": [
             2,
-            {"properties": "always"}
+            {"properties": "never"}
         ],
         "comma-dangle": [
           2,

--- a/src/components/BrowserError.jsx
+++ b/src/components/BrowserError.jsx
@@ -15,7 +15,7 @@ function BrowserError(props) {
   const browserName = props.browser.name;
 
   return (
-    <div id="unsupported-browser">
+    <div className="unsupported-browser">
       <p>{i18n.t('bad-browser.message', {name: browserName})}</p>
 
       <p>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -22,7 +22,7 @@ class Dashboard extends React.Component {
           />
           <span className="dashboard__username">{name}</span>
           <span
-            className="dashboard__logInOut"
+            className="dashboard__log-in-out"
             onClick={this.props.onLogOut}
           >
             {i18n.t('dashboard.session.logOutPrompt')}
@@ -36,7 +36,7 @@ class Dashboard extends React.Component {
           {i18n.t('dashboard.session.notLoggedIn')}
         </span>
         <span
-          className="dashboard__logInOut"
+          className="dashboard__log-in-out"
           onClick={this.props.onStartLogIn}
         >
           {i18n.t('dashboard.session.logInPrompt')}
@@ -49,9 +49,9 @@ class Dashboard extends React.Component {
     return (
       <div
         className={classnames(
-          'dashboard__menuItem',
-          'dashboard__menuItem_grid',
-          {'dashboard__menuItem_active':
+          'dashboard__menu-item',
+          'dashboard__menu-item_grid',
+          {'dashboard__menu-item_active':
             this.props.activeSubmenu === submenu}
         )}
         onClick={partial(this.props.onSubmenuToggled, submenu)}
@@ -66,7 +66,7 @@ class Dashboard extends React.Component {
     if (this.props.currentUser.authenticated) {
       newProjectButton = (
         <div
-          className="dashboard__menuItem dashboard__menuItem_grid"
+          className="dashboard__menu-item dashboard__menu-item_grid"
           onClick={this.props.onNewProject}
         >
           {i18n.t('dashboard.menu.new-project')}
@@ -85,9 +85,9 @@ class Dashboard extends React.Component {
         <div
           className={
             classnames(
-              'dashboard__menuItem',
-              'dashboard__menuItem_grid',
-              {'dashboard__menuItem_spinner': this.props.gistExportInProgress}
+              'dashboard__menu-item',
+              'dashboard__menu-item_grid',
+              {'dashboard__menu-item_spinner': this.props.gistExportInProgress}
             )
           }
           onClick={this.props.onExportGist}
@@ -95,7 +95,7 @@ class Dashboard extends React.Component {
           {i18n.t('dashboard.menu.export-gist')}
         </div>
         <a
-          className="dashboard__menuItem dashboard__menuItem_grid"
+          className="dashboard__menu-item dashboard__menu-item_grid"
           href={config.feedbackUrl}
           target="_blank"
         >
@@ -156,7 +156,7 @@ class Dashboard extends React.Component {
 
   _renderPop() {
     return (
-      <div className="dashboard__popContainer">
+      <div className="dashboard__pop-container">
         {this._renderPopSvg('neutral', 'passed')}
         {this._renderPopSvg('thinking', 'validating')}
         {this._renderPopSvg('horns', 'failed')}
@@ -189,8 +189,8 @@ class Dashboard extends React.Component {
   render() {
     const sidebarClassnames = classnames(
       'dashboard',
-      'u__flexContainer',
-      'u__flexContainer_column',
+      'u__flex-container',
+      'u__flex-container_column',
       {
         dashboard_yellow: this.props.validationState === 'validating',
         dashboard_red: this.props.validationState === 'failed',

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -50,8 +50,8 @@ class Dashboard extends React.Component {
       <div
         className={classnames(
           'dashboard__menuItem',
-          'dashboard__menuItem--grid',
-          {'dashboard__menuItem--active':
+          'dashboard__menuItem_grid',
+          {'dashboard__menuItem_active':
             this.props.activeSubmenu === submenu}
         )}
         onClick={partial(this.props.onSubmenuToggled, submenu)}
@@ -66,7 +66,7 @@ class Dashboard extends React.Component {
     if (this.props.currentUser.authenticated) {
       newProjectButton = (
         <div
-          className="dashboard__menuItem dashboard__menuItem--grid"
+          className="dashboard__menuItem dashboard__menuItem_grid"
           onClick={this.props.onNewProject}
         >
           {i18n.t('dashboard.menu.new-project')}
@@ -78,7 +78,7 @@ class Dashboard extends React.Component {
     }
 
     return (
-      <div className="dashboard__menu dashboard__menu--grid">
+      <div className="dashboard__menu dashboard__menu_grid">
         {newProjectButton}
         {loadProjectButton}
         {this._renderSubmenuToggleButton('libraryPicker', 'libraries')}
@@ -86,8 +86,8 @@ class Dashboard extends React.Component {
           className={
             classnames(
               'dashboard__menuItem',
-              'dashboard__menuItem--grid',
-              {'dashboard__menuItem--spinner': this.props.gistExportInProgress}
+              'dashboard__menuItem_grid',
+              {'dashboard__menuItem_spinner': this.props.gistExportInProgress}
             )
           }
           onClick={this.props.onExportGist}
@@ -95,7 +95,7 @@ class Dashboard extends React.Component {
           {i18n.t('dashboard.menu.export-gist')}
         </div>
         <a
-          className="dashboard__menuItem dashboard__menuItem--grid"
+          className="dashboard__menuItem dashboard__menuItem_grid"
           href={config.feedbackUrl}
           target="_blank"
         >
@@ -144,7 +144,7 @@ class Dashboard extends React.Component {
         className={classnames(
           'dashboard__pop',
           {
-            'dashboard__pop--visible':
+            dashboard__pop_visible:
               this.props.validationState === validationState,
           }
         )}
@@ -190,10 +190,10 @@ class Dashboard extends React.Component {
     const sidebarClassnames = classnames(
       'dashboard',
       'u__flexContainer',
-      'u__flexContainer--column',
+      'u__flexContainer_column',
       {
-        'dashboard--yellow': this.props.validationState === 'validating',
-        'dashboard--red': this.props.validationState === 'failed',
+        dashboard_yellow: this.props.validationState === 'validating',
+        dashboard_red: this.props.validationState === 'failed',
       }
     );
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -15,14 +15,14 @@ class Dashboard extends React.Component {
       const name = currentUser.info.displayName || currentUser.info.username;
 
       return (
-        <div className="dashboard-session">
+        <div className="dashboard__session">
           <img
-            className="dashboard-session-avatar"
+            className="dashboard__avatar"
             src={currentUser.info.profileImageURL}
           />
-          <span className="dashboard-session-name">{name}</span>
+          <span className="dashboard__username">{name}</span>
           <span
-            className="dashboard-session-logInOut"
+            className="dashboard__logInOut"
             onClick={this.props.onLogOut}
           >
             {i18n.t('dashboard.session.logOutPrompt')}
@@ -31,12 +31,12 @@ class Dashboard extends React.Component {
       );
     }
     return (
-      <div className="dashboard-session">
-        <span className="dashboard-session-name">
+      <div className="dashboard__session">
+        <span className="dashboard__username">
           {i18n.t('dashboard.session.notLoggedIn')}
         </span>
         <span
-          className="dashboard-session-logInOut"
+          className="dashboard__logInOut"
           onClick={this.props.onStartLogIn}
         >
           {i18n.t('dashboard.session.logInPrompt')}
@@ -49,9 +49,9 @@ class Dashboard extends React.Component {
     return (
       <div
         className={classnames(
-          'dashboard-menu-item',
-          'dashboard-menu-item--grid',
-          {'dashboard-menu-item--active':
+          'dashboard__menuItem',
+          'dashboard__menuItem--grid',
+          {'dashboard__menuItem--active':
             this.props.activeSubmenu === submenu}
         )}
         onClick={partial(this.props.onSubmenuToggled, submenu)}
@@ -66,7 +66,7 @@ class Dashboard extends React.Component {
     if (this.props.currentUser.authenticated) {
       newProjectButton = (
         <div
-          className="dashboard-menu-item dashboard-menu-item--grid"
+          className="dashboard__menuItem dashboard__menuItem--grid"
           onClick={this.props.onNewProject}
         >
           {i18n.t('dashboard.menu.new-project')}
@@ -78,16 +78,16 @@ class Dashboard extends React.Component {
     }
 
     return (
-      <div className="dashboard-menu dashboard-menu--grid">
+      <div className="dashboard__menu dashboard__menu--grid">
         {newProjectButton}
         {loadProjectButton}
         {this._renderSubmenuToggleButton('libraryPicker', 'libraries')}
         <div
           className={
             classnames(
-              'dashboard-menu-item',
-              'dashboard-menu-item--grid',
-              {'dashboard-menu-item--spinner': this.props.gistExportInProgress}
+              'dashboard__menuItem',
+              'dashboard__menuItem--grid',
+              {'dashboard__menuItem--spinner': this.props.gistExportInProgress}
             )
           }
           onClick={this.props.onExportGist}
@@ -95,7 +95,7 @@ class Dashboard extends React.Component {
           {i18n.t('dashboard.menu.export-gist')}
         </div>
         <a
-          className="dashboard-menu-item dashboard-menu-item--grid"
+          className="dashboard__menuItem dashboard__menuItem--grid"
           href={config.feedbackUrl}
           target="_blank"
         >
@@ -142,9 +142,9 @@ class Dashboard extends React.Component {
     return (
       <div
         className={classnames(
-          'dashboard-pop',
+          'dashboard__pop',
           {
-            'dashboard-pop--visible':
+            'dashboard__pop--visible':
               this.props.validationState === validationState,
           }
         )}
@@ -156,7 +156,7 @@ class Dashboard extends React.Component {
 
   _renderPop() {
     return (
-      <div className="dashboard-popContainer">
+      <div className="dashboard__popContainer">
         {this._renderPopSvg('neutral', 'passed')}
         {this._renderPopSvg('thinking', 'validating')}
         {this._renderPopSvg('horns', 'failed')}
@@ -166,19 +166,19 @@ class Dashboard extends React.Component {
 
   _renderLinks() {
     return (
-      <div className="dashboard-links">
+      <div className="dashboard__links">
         <a
-          className="dashboard-links-link fontawesome"
+          className="dashboard__link fontawesome"
           href="https://github.com/popcodeorg/popcode"
           target="_blank"
         >&#xf09b;</a>
         <a
-          className="dashboard-links-link fontawesome"
+          className="dashboard__link fontawesome"
           href="https://twitter.com/popcodeorg"
           target="_blank"
         >&#xf099;</a>
         <a
-          className="dashboard-links-link fontawesome"
+          className="dashboard__link fontawesome"
           href="https://slack.popcode.org/"
           target="_blank"
         >&#xf198;</a>
@@ -189,8 +189,8 @@ class Dashboard extends React.Component {
   render() {
     const sidebarClassnames = classnames(
       'dashboard',
-      'u-flexContainer',
-      'u-flexContainer--column',
+      'u__flexContainer',
+      'u__flexContainer--column',
       {
         'dashboard--yellow': this.props.validationState === 'validating',
         'dashboard--red': this.props.validationState === 'failed',
@@ -202,7 +202,7 @@ class Dashboard extends React.Component {
         {this._renderLoginState()}
         {this._renderMenu()}
         {this._renderSubmenu()}
-        <div className="dashboard-spacer" />
+        <div className="dashboard__spacer" />
         {this._renderPop()}
         {this._renderLinks()}
       </div>

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -131,7 +131,7 @@ class Editor extends React.Component {
   render() {
     return (
       <div
-        className="editors-editorContainer-editor"
+        className="editors__editor"
         ref={this._setupEditor}
       />
     );

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -6,7 +6,7 @@ function EditorContainer(props) {
 
   if (props.source === '') {
     helpText = (
-      <div className="editors__helpText">
+      <div className="editors__help-text">
         {i18n.t(
           'editors.helpText',
           {language: props.language}
@@ -16,7 +16,7 @@ function EditorContainer(props) {
   }
 
   return (
-    <div className="editors__editorContainer">
+    <div className="editors__editor-container">
       <div
         className="environment__label label"
         onClick={props.onMinimize}

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -6,7 +6,7 @@ function EditorContainer(props) {
 
   if (props.source === '') {
     helpText = (
-      <div className="editors-editorContainer-helpText">
+      <div className="editors__helpText">
         {i18n.t(
           'editors.helpText',
           {language: props.language}
@@ -16,9 +16,9 @@ function EditorContainer(props) {
   }
 
   return (
-    <div className="editors-editorContainer">
+    <div className="editors__editorContainer">
       <div
-        className="environment-column-label label"
+        className="environment__label label"
         onClick={props.onMinimize}
       >
         {i18n.t(`languages.${props.language}`)}

--- a/src/components/ErrorItem.jsx
+++ b/src/components/ErrorItem.jsx
@@ -4,7 +4,7 @@ import partial from 'lodash/partial';
 function ErrorItem(props) {
   return (
     <li
-      className="errorList__error"
+      className="error-list__error"
       data-error-reason={props.reason}
       onClick={partial(
         props.onClick,
@@ -13,7 +13,7 @@ function ErrorItem(props) {
       )}
     >
       <div>{props.row + 1}</div>
-      <div className="errorList__message">{props.text}</div>
+      <div className="error-list__message">{props.text}</div>
     </li>
   );
 }

--- a/src/components/ErrorItem.jsx
+++ b/src/components/ErrorItem.jsx
@@ -4,7 +4,7 @@ import partial from 'lodash/partial';
 function ErrorItem(props) {
   return (
     <li
-      className="errorList-error"
+      className="errorList__error"
       data-error-reason={props.reason}
       onClick={partial(
         props.onClick,
@@ -12,8 +12,8 @@ function ErrorItem(props) {
         props.column
       )}
     >
-      <div className="errorList-error-line">{props.row + 1}</div>
-      <div className="errorList-error-message">{props.text}</div>
+      <div>{props.row + 1}</div>
+      <div className="errorList__message">{props.text}</div>
     </li>
   );
 }

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -10,8 +10,8 @@ function ErrorList(props) {
     <div
       className={classnames(
         'errorList',
-        'output-item',
-        {'errorList--docked': docked, 'output-item--shrink': docked}
+        'output__item',
+        {'errorList--docked': docked, 'output__item--shrink': docked}
       )}
     >
       <ErrorSublist

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -11,7 +11,7 @@ function ErrorList(props) {
       className={classnames(
         'errorList',
         'output__item',
-        {'errorList--docked': docked, 'output__item--shrink': docked}
+        {'errorList_docked': docked, output__item_shrink: docked}
       )}
     >
       <ErrorSublist

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -9,9 +9,9 @@ function ErrorList(props) {
   return (
     <div
       className={classnames(
-        'errorList',
+        'error-list',
         'output__item',
-        {'errorList_docked': docked, output__item_shrink: docked}
+        {'error-list_docked': docked, output__item_shrink: docked}
       )}
     >
       <ErrorSublist

--- a/src/components/ErrorSublist.jsx
+++ b/src/components/ErrorSublist.jsx
@@ -26,11 +26,11 @@ function ErrorSublist(props) {
   );
 
   return (
-    <div className="errorList-errorSublist">
-      <h2 className="errorList-errorSublist-header">
+    <div>
+      <h2 className="errorList__header">
         {errorMessage}
       </h2>
-      <ul className="errorList-errorSublist-list">
+      <ul className="errorList__errors">
         {errors}
       </ul>
     </div>

--- a/src/components/ErrorSublist.jsx
+++ b/src/components/ErrorSublist.jsx
@@ -27,10 +27,10 @@ function ErrorSublist(props) {
 
   return (
     <div>
-      <h2 className="errorList__header">
+      <h2 className="error-list__header">
         {errorMessage}
       </h2>
-      <ul className="errorList__errors">
+      <ul className="error-list__errors">
         {errors}
       </ul>
     </div>

--- a/src/components/LibraryPicker.jsx
+++ b/src/components/LibraryPicker.jsx
@@ -20,7 +20,7 @@ class LibraryPicker extends React.Component {
       />
     ));
 
-    return <div className="dashboard-menu">{libraryButtons}</div>;
+    return <div className="dashboard__menu">{libraryButtons}</div>;
   }
 }
 

--- a/src/components/LibraryPickerItem.jsx
+++ b/src/components/LibraryPickerItem.jsx
@@ -5,8 +5,8 @@ function LibraryPickerItem(props) {
   return (
     <div
       className={classnames(
-        'dashboard-menu-item',
-        {'dashboard-menu-item--active': props.enabled}
+        'dashboard__menuItem',
+        {'dashboard__menuItem--active': props.enabled}
       )} onClick={props.onLibraryToggled}
     >
       {props.library.name}

--- a/src/components/LibraryPickerItem.jsx
+++ b/src/components/LibraryPickerItem.jsx
@@ -5,8 +5,8 @@ function LibraryPickerItem(props) {
   return (
     <div
       className={classnames(
-        'dashboard__menuItem',
-        {'dashboard__menuItem_active': props.enabled}
+        'dashboard__menu-item',
+        {'dashboard__menu-item_active': props.enabled}
       )} onClick={props.onLibraryToggled}
     >
       {props.library.name}

--- a/src/components/LibraryPickerItem.jsx
+++ b/src/components/LibraryPickerItem.jsx
@@ -6,7 +6,7 @@ function LibraryPickerItem(props) {
     <div
       className={classnames(
         'dashboard__menuItem',
-        {'dashboard__menuItem--active': props.enabled}
+        {'dashboard__menuItem_active': props.enabled}
       )} onClick={props.onLibraryToggled}
     >
       {props.library.name}

--- a/src/components/NotificationContainer.jsx
+++ b/src/components/NotificationContainer.jsx
@@ -6,8 +6,8 @@ export default function NotificationContainer(props) {
     <div
       className={
         classnames(
-          'notificationList__notification',
-          `notificationList__notification--${props.severity}`
+          'notification-list__notification',
+          `notificationList__notification_${props.severity}`
         )
       }
     >

--- a/src/components/NotificationContainer.jsx
+++ b/src/components/NotificationContainer.jsx
@@ -7,13 +7,13 @@ export default function NotificationContainer(props) {
       className={
         classnames(
           'notification-list__notification',
-          `notificationList__notification_${props.severity}`
+          `notification-list__notification_${props.severity}`
         )
       }
     >
       {props.children}
       <span
-        className="notificationList__dismiss"
+        className="notification-list__dismiss"
         onClick={props.onErrorDismissed}
       >&#xf00d;</span>
     </div>

--- a/src/components/NotificationContainer.jsx
+++ b/src/components/NotificationContainer.jsx
@@ -6,14 +6,14 @@ export default function NotificationContainer(props) {
     <div
       className={
         classnames(
-          'notificationList-notification',
-          `notificationList-notification--${props.severity}`
+          'notificationList__notification',
+          `notificationList__notification--${props.severity}`
         )
       }
     >
       {props.children}
       <span
-        className="notificationList-notification-dismiss"
+        className="notificationList__dismiss"
         onClick={props.onErrorDismissed}
       >&#xf00d;</span>
     </div>

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -43,7 +43,7 @@ export default function NotificationList(props) {
   });
 
   return (
-    <div className="notificationList">{notificationList}</div>
+    <div className="notification-list">{notificationList}</div>
   );
 }
 

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -47,7 +47,7 @@ class Output extends React.Component {
 
   _renderErrors() {
     if (this.props.validationState === 'validating') {
-      return <div className="output__delayedErrorOverlay" />;
+      return <div className="output__delayed-error-overlay" />;
     }
 
     if (this.props.validationState === 'failed') {

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -47,7 +47,7 @@ class Output extends React.Component {
 
   _renderErrors() {
     if (this.props.validationState === 'validating') {
-      return <div className="output-delayedErrorOverlay" />;
+      return <div className="output__delayedErrorOverlay" />;
     }
 
     if (this.props.validationState === 'failed') {
@@ -59,9 +59,9 @@ class Output extends React.Component {
 
   render() {
     return (
-      <div className="environment-column output">
+      <div className="environment__column output">
         <div
-          className="environment-column-label label"
+          className="environment__label label"
           onClick={this.props.onMinimize}
         >
           {i18n.t('workspace.components.output')}

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -59,7 +59,7 @@ class Preview extends React.Component {
         )}
       >
         <div
-          className="preview__popOutButton"
+          className="preview__pop-out-button"
           onClick={this._handlePopOutClick}
         />
         <PreviewFrame

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -54,12 +54,12 @@ class Preview extends React.Component {
       <div
         className={classnames(
           'preview',
-          'output-item',
-          {'u-hidden': !this.props.isValid}
+          'output__item',
+          {u__hidden: !this.props.isValid}
         )}
       >
         <div
-          className="preview-popOutButton"
+          className="preview__popOutButton"
           onClick={this._handlePopOutClick}
         />
         <PreviewFrame

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -112,7 +112,7 @@ class PreviewFrame extends React.Component {
 
     return (
       <iframe
-        className="preview-frame"
+        className="preview__frame"
         sandbox={sandboxOptions}
         {...srcProps}
       />

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -15,17 +15,17 @@ function ProjectList(props) {
     return (
       <div
         className={classnames(
-          'projectPreview',
-          'dashboard__menuItem',
-          {'dashboard__menuItem_active': isSelected}
+          'project-preview',
+          'dashboard__menu-item',
+          {'dashboard__menu-item_active': isSelected}
         )}
         key={project.projectKey}
         onClick={partial(props.onProjectSelected, project)}
       >
-        <div className="projectPreview__timestamp">
+        <div className="project-preview__timestamp">
           {moment(project.updatedAt).fromNow()}
         </div>
-        <div className="projectPreview-previewText">
+        <div>
           {preview.slice(0, MAX_LENGTH)}
         </div>
       </div>

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -17,7 +17,7 @@ function ProjectList(props) {
         className={classnames(
           'projectPreview',
           'dashboard__menuItem',
-          {'dashboard__menuItem--active': isSelected}
+          {'dashboard__menuItem_active': isSelected}
         )}
         key={project.projectKey}
         onClick={partial(props.onProjectSelected, project)}
@@ -33,7 +33,7 @@ function ProjectList(props) {
   });
 
   return (
-    <div className="dashboard__menu dashboard__menu--scrollable">
+    <div className="dashboard__menu dashboard__menu_scrollable">
       {projects}
     </div>
   );

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -16,13 +16,13 @@ function ProjectList(props) {
       <div
         className={classnames(
           'projectPreview',
-          'dashboard-menu-item',
-          {'dashboard-menu-item--active': isSelected}
+          'dashboard__menuItem',
+          {'dashboard__menuItem--active': isSelected}
         )}
         key={project.projectKey}
         onClick={partial(props.onProjectSelected, project)}
       >
-        <div className="projectPreview-timestamp">
+        <div className="projectPreview__timestamp">
           {moment(project.updatedAt).fromNow()}
         </div>
         <div className="projectPreview-previewText">
@@ -33,7 +33,7 @@ function ProjectList(props) {
   });
 
   return (
-    <div className="dashboard-menu dashboard-menu--scrollable">
+    <div className="dashboard__menu dashboard__menu--scrollable">
       {projects}
     </div>
   );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,7 +9,7 @@ class Sidebar extends React.Component {
     const components = this.props.minimizedComponents.
       map((componentName) => (
         <div
-          className="sidebar-minimizedComponent"
+          className="sidebar__minimizedComponent"
           key={componentName}
           onClick={partial(this.props.onComponentMaximized, componentName)}
         >
@@ -18,7 +18,7 @@ class Sidebar extends React.Component {
       ));
 
     return (
-      <div className="sidebar-minimizedComponents">
+      <div className="sidebar__minimizedComponents">
         {components}
       </div>
     );
@@ -35,15 +35,15 @@ class Sidebar extends React.Component {
 
     return (
       <div className={sidebarClassnames}>
-        <div className="sidebar-wordmarkContainer">
+        <div className="sidebar__wordmarkContainer">
           <Isvg src="/images/wordmark-vertical.svg" />
         </div>
         <div
           className={classnames(
-            'sidebar-arrow',
+            'sidebar__arrow',
             {
-              'sidebar-arrow--show': !this.props.dashboardIsOpen,
-              'sidebar-arrow--hide': this.props.dashboardIsOpen,
+              'sidebar__arrow--show': !this.props.dashboardIsOpen,
+              'sidebar__arrow--hide': this.props.dashboardIsOpen,
             }
           )}
           onClick={this.props.onToggleDashboard}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -28,8 +28,8 @@ class Sidebar extends React.Component {
     const sidebarClassnames = classnames(
       'sidebar',
       {
-        'sidebar--yellow': this.props.validationState === 'validating',
-        'sidebar--red': this.props.validationState === 'failed',
+        sidebar_yellow: this.props.validationState === 'validating',
+        sidebar_red: this.props.validationState === 'failed',
       }
     );
 
@@ -42,8 +42,8 @@ class Sidebar extends React.Component {
           className={classnames(
             'sidebar__arrow',
             {
-              'sidebar__arrow--show': !this.props.dashboardIsOpen,
-              'sidebar__arrow--hide': this.props.dashboardIsOpen,
+              sidebar__arrow_show: !this.props.dashboardIsOpen,
+              sidebar__arrow_hide: this.props.dashboardIsOpen,
             }
           )}
           onClick={this.props.onToggleDashboard}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,7 +9,7 @@ class Sidebar extends React.Component {
     const components = this.props.minimizedComponents.
       map((componentName) => (
         <div
-          className="sidebar__minimizedComponent"
+          className="sidebar__minimized-component"
           key={componentName}
           onClick={partial(this.props.onComponentMaximized, componentName)}
         >
@@ -18,7 +18,7 @@ class Sidebar extends React.Component {
       ));
 
     return (
-      <div className="sidebar__minimizedComponents">
+      <div className="sidebar__minimized-components">
         {components}
       </div>
     );
@@ -35,7 +35,7 @@ class Sidebar extends React.Component {
 
     return (
       <div className={sidebarClassnames}>
-        <div className="sidebar__wordmarkContainer">
+        <div className="sidebar__wordmark-container">
           <Isvg src="/images/wordmark-vertical.svg" />
         </div>
         <div

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -424,7 +424,7 @@ class Workspace extends React.Component {
         <div className="layout">
           {this._renderDashboard()}
           {this._renderSidebar()}
-          <div className="layout__main" id="workspace">
+          <div className="workspace layout__main">
             {this._renderEnvironment()}
           </div>
         </div>

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -272,7 +272,7 @@ class Workspace extends React.Component {
     }
 
     return (
-      <div className="environment-column editors">{editors}</div>
+      <div className="environment__column editors">{editors}</div>
     );
   }
 
@@ -371,7 +371,7 @@ class Workspace extends React.Component {
     }
 
     return (
-      <div className="layout-dashboard">
+      <div className="layout__dashboard">
         <Dashboard
           activeSubmenu={this.props.ui.dashboard.activeSubmenu}
           allProjects={this.props.allProjects}
@@ -393,7 +393,7 @@ class Workspace extends React.Component {
 
   _renderSidebar() {
     return (
-      <div className="layout-sidebar">
+      <div className="layout__sidebar">
         <Sidebar
           dashboardIsOpen={this.props.ui.dashboard.isOpen}
           minimizedComponents={this.props.ui.minimizedComponents}
@@ -424,7 +424,7 @@ class Workspace extends React.Component {
         <div className="layout">
           {this._renderDashboard()}
           {this._renderSidebar()}
-          <div className="layout-main" id="workspace">
+          <div className="layout__main" id="workspace">
             {this._renderEnvironment()}
           </div>
         </div>

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -78,27 +78,27 @@ body {
   background-color: var(--color-red);
 }
 
-.sidebar__wordmarkContainer {
+.sidebar__wordmark-container {
   flex: 1 0 auto;
   position: relative;
 }
 
-.sidebar__wordmarkContainer svg {
+.sidebar__wordmark-container svg {
   padding: 10px;
   max-width: 24px;
   height: auto;
   max-height: 100%;
 }
 
-.sidebar__wordmarkContainer path {
+.sidebar__wordmark-container path {
   fill: black !important;
 }
 
-.sidebar__minimizedComponents {
+.sidebar__minimized-components {
   flex: 0 0 auto;
 }
 
-.sidebar__minimizedComponent {
+.sidebar__minimized-component {
   background-color: white;
   text-align: center;
   margin-top: 0.5em;
@@ -108,7 +108,7 @@ body {
   cursor: pointer;
 }
 
-.sidebar__minimizedComponent:before {
+.sidebar__minimized-component:before {
   display: block;
   position: absolute;
   width: 1em;
@@ -195,7 +195,7 @@ body {
   padding-left: 0.5rem;
 }
 
-.dashboard__logInOut {
+.dashboard__log-in-out {
   padding-left: 1rem;
   text-decoration: underline;
   cursor: pointer;
@@ -218,7 +218,7 @@ body {
   justify-content: space-between;
 }
 
-.dashboard__menuItem {
+.dashboard__menu-item {
   display: block;
   font-size: 0.8rem;
   background-color: white;
@@ -230,7 +230,7 @@ body {
   text-decoration: none;
 }
 
-.dashboard__menuItem_grid {
+.dashboard__menu-item_grid {
   flex: 0 0 calc(50% - 1px);
   white-space: nowrap;
   margin: 0 0 0.5rem 0;
@@ -238,7 +238,7 @@ body {
   text-align: center;
 }
 
-.dashboard__menuItem_spinner {
+.dashboard__menu-item_spinner {
   color: transparent;
   background-image: url('/images/spinner.gif');
   background-repeat: no-repeat;
@@ -247,15 +247,15 @@ body {
   cursor: not-allowed;
 }
 
-.dashboard__menuItem:hover, .dashboard__menuItem_active {
+.dashboard__menu-item:hover, .dashboard__menu-item_active {
   background-color: var(--color-gray);
 }
 
-.dashboard__menuItem_spinner:hover {
+.dashboard__menu-item_spinner:hover {
   background-color: white;
 }
 
-.dashboard__menuItem_active {
+.dashboard__menu-item_active {
   font-weight: bold;
 }
 
@@ -263,7 +263,7 @@ body {
   flex: 1 0 auto;
 }
 
-.dashboard__popContainer {
+.dashboard__pop-container {
   flex: 0 1 auto;
   position: relative;
   display: flex;
@@ -303,7 +303,7 @@ body {
   font-family: 'FontAwesome';
 }
 
-.projectPreview__timestamp {
+.project-preview__timestamp {
   text-align: right;
   color: var(--color-gray);
   font-style: italic;
@@ -349,7 +349,7 @@ body {
   font-family: 'Inconsolata';
 }
 
-.editors__editorContainer {
+.editors__editor-container {
   box-sizing: border-box;
   flex: 0 1 100vh;
   border-right: 2px solid var(--color-gray);
@@ -359,7 +359,7 @@ body {
   display: flex;
 }
 
-.editors__editorContainer:last-child {
+.editors__editor-container:last-child {
   border-bottom: 0;
 }
 
@@ -368,7 +368,7 @@ body {
   flex: 1 0 100%;
 }
 
-.editors__helpText {
+.editors__help-text {
   position: absolute;
   z-index: 1;
   max-width: 11rem;
@@ -409,7 +409,7 @@ body {
   flex: 0 1 auto;
 }
 
-.output__delayedErrorOverlay {
+.output__delayed-error-overlay {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -432,7 +432,7 @@ body {
   flex: 1 0 100%;
 }
 
-.preview__popOutButton {
+.preview__pop-out-button {
   background: url(/images/popout.png);
   width: 16px;
   height: 18px;
@@ -444,61 +444,61 @@ body {
   z-index: 1;
 }
 
-.preview__popOutButton:hover {
+.preview__pop-out-button:hover {
   opacity: 0.5;
 }
 
-.errorList {
+.error-list {
   position: relative;
   overflow: scroll;
   background: white;
 }
 
-.errorList_docked {
+.error-list_docked {
   overflow: scroll;
   border-top: 3px solid var(--color-gray);
 }
 
-.errorList__header {
+.error-list__header {
   text-align: center;
   margin: 1rem 0 0.5rem;
   font-size: 1rem;
 }
 
-.errorList__errors {
+.error-list__errors {
   list-style-type: none;
   margin: 0;
   padding: 0.5rem 1rem;
   background-color: var(--color-gray);
 }
 
-.errorList__error {
+.error-list__error {
   padding: 0.5rem 0;
   cursor: pointer;
 }
 
-.notificationList__notification {
+.notification-list__notification {
   text-align: center;
   margin-bottom: 0.2rem;
   padding: 0.2rem 0;
 }
 
-.notificationList__notification a {
+.notification-list__notification a {
   color: inherit;
   text-align: center;
   margin-bottom: 0.2rem;
   padding: 0.2rem 0;
 }
 
-.notificationList__notification_error {
+.notification-list__notification_error {
   background-color: var(--color-red);
 }
 
-.notificationList__notification_notice {
+.notification-list__notification_notice {
   background-color: var(--color-green);
 }
 
-.notificationList__dismiss {
+.notification-list__dismiss {
   font-family: 'FontAwesome';
   display: block;
   padding: 0.2rem 0.5rem;
@@ -516,23 +516,23 @@ body {
   }
 }
 
-.u__flexContainer {
+.u__flex-container {
   display: flex;
 }
 
-.u__flexContainer_column {
+.u__flex-container_column {
   flex-direction: column;
 }
 
-.u__flexItem {
+.u__flex-item {
   flex: 0 1 auto;
 }
 
-.u__flexItem_grow {
+.u__flex-item_grow {
   flex: 1 0 auto;
 }
 
-.u__flexItem_fill {
+.u__flex-item_fill {
   flex: 1 0 100%;
 }
 

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -314,7 +314,7 @@ body {
   flex: 1 1 100%;
 }
 
-#workspace {
+.workspace {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -506,7 +506,7 @@ body {
   cursor: pointer;
 }
 
-#unsupported-browser {
+.unsupported-browser {
   font-size: 1.5rem;
   margin-top: 5rem;
   text-align: center;

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -70,11 +70,11 @@ body {
   flex: 0 1 auto;
 }
 
-.sidebar--yellow {
+.sidebar_yellow {
   background-color: var(--color-yellow);
 }
 
-.sidebar--red {
+.sidebar_red {
   background-color: var(--color-red);
 }
 
@@ -148,13 +148,13 @@ body {
   right: 0;
 }
 
-.sidebar__arrow--show::before {
+.sidebar__arrow_show::before {
   border-right: var(--sidebar-arrow-stroke);
   transform: rotate(45deg);
   transform-origin: left 50%;
 }
 
-.sidebar__arrow--hide::before {
+.sidebar__arrow_hide::before {
   border-left: var(--sidebar-arrow-stroke);
   transform: rotate(-45deg);
   transform-origin: right 50%;
@@ -166,11 +166,11 @@ body {
   height: 100vh;
 }
 
-.dashboard--yellow {
+.dashboard_yellow {
   background-color: var(--color-yellow);
 }
 
-.dashboard--red {
+.dashboard_red {
   background-color: var(--color-red);
 }
 
@@ -205,12 +205,12 @@ body {
   flex: 0 0 auto;
 }
 
-.dashboard__menu--scrollable {
+.dashboard__menu_scrollable {
   flex: 0 1 auto;
   overflow: scroll;
 }
 
-.dashboard__menu--grid {
+.dashboard__menu_grid {
   display: flex;
   flex-flow: row wrap;
   align-items: flex-start;
@@ -230,7 +230,7 @@ body {
   text-decoration: none;
 }
 
-.dashboard__menuItem--grid {
+.dashboard__menuItem_grid {
   flex: 0 0 calc(50% - 1px);
   white-space: nowrap;
   margin: 0 0 0.5rem 0;
@@ -238,7 +238,7 @@ body {
   text-align: center;
 }
 
-.dashboard__menuItem--spinner {
+.dashboard__menuItem_spinner {
   color: transparent;
   background-image: url('/images/spinner.gif');
   background-repeat: no-repeat;
@@ -247,15 +247,15 @@ body {
   cursor: not-allowed;
 }
 
-.dashboard__menuItem:hover, .dashboard__menuItem--active {
+.dashboard__menuItem:hover, .dashboard__menuItem_active {
   background-color: var(--color-gray);
 }
 
-.dashboard__menuItem--spinner:hover {
+.dashboard__menuItem_spinner:hover {
   background-color: white;
 }
 
-.dashboard__menuItem--active {
+.dashboard__menuItem_active {
   font-weight: bold;
 }
 
@@ -275,11 +275,11 @@ body {
   overflow: hidden;
 }
 
-.dashboard__pop--visible {
+.dashboard__pop_visible {
   display: block;
 }
 
-.dashboard__pop--visible svg {
+.dashboard__pop_visible svg {
   max-height: 100%;
   max-width: 100%;
 }
@@ -405,7 +405,7 @@ body {
   flex: 1 1 auto;
 }
 
-.output__item--shrink {
+.output__item_shrink {
   flex: 0 1 auto;
 }
 
@@ -454,7 +454,7 @@ body {
   background: white;
 }
 
-.errorList--docked {
+.errorList_docked {
   overflow: scroll;
   border-top: 3px solid var(--color-gray);
 }
@@ -490,11 +490,11 @@ body {
   padding: 0.2rem 0;
 }
 
-.notificationList__notification--error {
+.notificationList__notification_error {
   background-color: var(--color-red);
 }
 
-.notificationList__notification--notice {
+.notificationList__notification_notice {
   background-color: var(--color-green);
 }
 
@@ -520,7 +520,7 @@ body {
   display: flex;
 }
 
-.u__flexContainer--column {
+.u__flexContainer_column {
   flex-direction: column;
 }
 
@@ -528,11 +528,11 @@ body {
   flex: 0 1 auto;
 }
 
-.u__flexItem--grow {
+.u__flexItem_grow {
   flex: 1 0 auto;
 }
 
-.u__flexItem--fill {
+.u__flexItem_fill {
   flex: 1 0 100%;
 }
 

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -56,7 +56,7 @@ body {
   display: flex;
 }
 
-.layout-sidebar {
+.layout__sidebar {
   flex: 0 0 auto;
   border-right: 1px solid var(--color-gray);
   display: flex;
@@ -78,27 +78,27 @@ body {
   background-color: var(--color-red);
 }
 
-.sidebar-wordmarkContainer {
+.sidebar__wordmarkContainer {
   flex: 1 0 auto;
   position: relative;
 }
 
-.sidebar-wordmarkContainer svg {
+.sidebar__wordmarkContainer svg {
   padding: 10px;
   max-width: 24px;
   height: auto;
   max-height: 100%;
 }
 
-.sidebar-wordmarkContainer path {
+.sidebar__wordmarkContainer path {
   fill: black !important;
 }
 
-.sidebar-minimizedComponents {
+.sidebar__minimizedComponents {
   flex: 0 0 auto;
 }
 
-.sidebar-minimizedComponent {
+.sidebar__minimizedComponent {
   background-color: white;
   text-align: center;
   margin-top: 0.5em;
@@ -108,7 +108,7 @@ body {
   cursor: pointer;
 }
 
-.sidebar-minimizedComponent:before {
+.sidebar__minimizedComponent:before {
   display: block;
   position: absolute;
   width: 1em;
@@ -126,7 +126,7 @@ body {
   --sidebar-arrow-stroke: 4px solid black;
 }
 
-.sidebar-arrow {
+.sidebar__arrow {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -134,7 +134,7 @@ body {
   width: 100%;
 }
 
-.sidebar-arrow::before {
+.sidebar__arrow::before {
   border-top: var(--sidebar-arrow-stroke);
   content: "";
   height: 0;
@@ -148,13 +148,13 @@ body {
   right: 0;
 }
 
-.sidebar-arrow--show::before {
+.sidebar__arrow--show::before {
   border-right: var(--sidebar-arrow-stroke);
   transform: rotate(45deg);
   transform-origin: left 50%;
 }
 
-.sidebar-arrow--hide::before {
+.sidebar__arrow--hide::before {
   border-left: var(--sidebar-arrow-stroke);
   transform: rotate(-45deg);
   transform-origin: right 50%;
@@ -174,7 +174,7 @@ body {
   background-color: var(--color-red);
 }
 
-.dashboard-session {
+.dashboard__session {
   flex: 0 0 auto;
   font-size: 0.8rem;
   white-space: nowrap;
@@ -183,34 +183,34 @@ body {
   overflow: hidden;
 }
 
-.dashboard-session-avatar {
+.dashboard__avatar {
   max-width: 32px;
   max-height: 32px;
   border-radius: 50%;
   vertical-align: middle;
 }
 
-.dashboard-session-name {
+.dashboard__username {
   font-weight: bold;
   padding-left: 0.5rem;
 }
 
-.dashboard-session-logInOut {
+.dashboard__logInOut {
   padding-left: 1rem;
   text-decoration: underline;
   cursor: pointer;
 }
 
-.dashboard-menu {
+.dashboard__menu {
   flex: 0 0 auto;
 }
 
-.dashboard-menu--scrollable {
+.dashboard__menu--scrollable {
   flex: 0 1 auto;
   overflow: scroll;
 }
 
-.dashboard-menu--grid {
+.dashboard__menu--grid {
   display: flex;
   flex-flow: row wrap;
   align-items: flex-start;
@@ -218,7 +218,7 @@ body {
   justify-content: space-between;
 }
 
-.dashboard-menu-item {
+.dashboard__menuItem {
   display: block;
   font-size: 0.8rem;
   background-color: white;
@@ -230,7 +230,7 @@ body {
   text-decoration: none;
 }
 
-.dashboard-menu-item--grid {
+.dashboard__menuItem--grid {
   flex: 0 0 calc(50% - 1px);
   white-space: nowrap;
   margin: 0 0 0.5rem 0;
@@ -238,7 +238,7 @@ body {
   text-align: center;
 }
 
-.dashboard-menu-item--spinner {
+.dashboard__menuItem--spinner {
   color: transparent;
   background-image: url('/images/spinner.gif');
   background-repeat: no-repeat;
@@ -247,51 +247,51 @@ body {
   cursor: not-allowed;
 }
 
-.dashboard-menu-item:hover, .dashboard-menu-item--active {
+.dashboard__menuItem:hover, .dashboard__menuItem--active {
   background-color: var(--color-gray);
 }
 
-.dashboard-menu-item--spinner:hover {
+.dashboard__menuItem--spinner:hover {
   background-color: white;
 }
 
-.dashboard-menu-item--active {
+.dashboard__menuItem--active {
   font-weight: bold;
 }
 
-.dashboard-spacer {
+.dashboard__spacer {
   flex: 1 0 auto;
 }
 
-.dashboard-popContainer {
+.dashboard__popContainer {
   flex: 0 1 auto;
   position: relative;
   display: flex;
 }
 
-.dashboard-pop {
+.dashboard__pop {
   display: none;
   flex: 0 1 100%;
   overflow: hidden;
 }
 
-.dashboard-pop--visible {
+.dashboard__pop--visible {
   display: block;
 }
 
-.dashboard-pop--visible svg {
+.dashboard__pop--visible svg {
   max-height: 100%;
   max-width: 100%;
 }
 
-.dashboard-links {
+.dashboard__links {
   flex: 0 0 auto;
   display: flex;
   flex-flow: row nowrap;
   justify-content: center;
 }
 
-.dashboard-links-link {
+.dashboard__link {
   flex: 0 0 auto;
   padding: 1rem;
   color: inherit;
@@ -303,14 +303,14 @@ body {
   font-family: 'FontAwesome';
 }
 
-.projectPreview-timestamp {
+.projectPreview__timestamp {
   text-align: right;
   color: var(--color-gray);
   font-style: italic;
   font-weight: normal;
 }
 
-.layout-main {
+.layout__main {
   flex: 1 1 100%;
 }
 
@@ -320,7 +320,7 @@ body {
   height: 100%;
 }
 
-.layout-dashboard {
+.layout__dashboard {
   flex: 1 0 20%;
 }
 
@@ -332,11 +332,11 @@ body {
   height: 100vh;
 }
 
-.environment-column {
-  flex: 1 1 50%;
+.environment__column {
+  flex: 1 1 0;
 }
 
-.environment-column-label {
+.environment__label {
   position: absolute;
   bottom: 1em;
   right: 1em;
@@ -349,7 +349,7 @@ body {
   font-family: 'Inconsolata';
 }
 
-.editors-editorContainer {
+.editors__editorContainer {
   box-sizing: border-box;
   flex: 0 1 100vh;
   border-right: 2px solid var(--color-gray);
@@ -359,16 +359,16 @@ body {
   display: flex;
 }
 
-.editors-editorContainer:last-child {
+.editors__editorContainer:last-child {
   border-bottom: 0;
 }
 
-.editors-editorContainer-editor {
+.editors__editor {
   z-index: 0;
   flex: 1 0 100%;
 }
 
-.editors-editorContainer-helpText {
+.editors__helpText {
   position: absolute;
   z-index: 1;
   max-width: 11rem;
@@ -401,15 +401,15 @@ body {
   position: relative;
 }
 
-.output-item {
+.output__item {
   flex: 1 1 auto;
 }
 
-.output-item--shrink {
+.output__item--shrink {
   flex: 0 1 auto;
 }
 
-.output-delayedErrorOverlay {
+.output__delayedErrorOverlay {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -426,13 +426,13 @@ body {
   display: flex;
 }
 
-.preview-frame {
+.preview__frame {
   border: 0;
   z-index: 0;
   flex: 1 0 100%;
 }
 
-.preview-popOutButton {
+.preview__popOutButton {
   background: url(/images/popout.png);
   width: 16px;
   height: 18px;
@@ -444,7 +444,7 @@ body {
   z-index: 1;
 }
 
-.preview-popOutButton:hover {
+.preview__popOutButton:hover {
   opacity: 0.5;
 }
 
@@ -459,46 +459,46 @@ body {
   border-top: 3px solid var(--color-gray);
 }
 
-.errorList-errorSublist-header {
+.errorList__header {
   text-align: center;
   margin: 1rem 0 0.5rem;
   font-size: 1rem;
 }
 
-.errorList-errorSublist-list {
+.errorList__errors {
   list-style-type: none;
   margin: 0;
   padding: 0.5rem 1rem;
   background-color: var(--color-gray);
 }
 
-.errorList-error {
+.errorList__error {
   padding: 0.5rem 0;
   cursor: pointer;
 }
 
-.notificationList-notification {
+.notificationList__notification {
   text-align: center;
   margin-bottom: 0.2rem;
   padding: 0.2rem 0;
 }
 
-.notificationList-notification a {
+.notificationList__notification a {
   color: inherit;
   text-align: center;
   margin-bottom: 0.2rem;
   padding: 0.2rem 0;
 }
 
-.notificationList-notification--error {
+.notificationList__notification--error {
   background-color: var(--color-red);
 }
 
-.notificationList-notification--notice {
+.notificationList__notification--notice {
   background-color: var(--color-green);
 }
 
-.notificationList-notification-dismiss {
+.notificationList__dismiss {
   font-family: 'FontAwesome';
   display: block;
   padding: 0.2rem 0.5rem;
@@ -516,26 +516,26 @@ body {
   }
 }
 
-.u-flexContainer {
+.u__flexContainer {
   display: flex;
 }
 
-.u-flexContainer--column {
+.u__flexContainer--column {
   flex-direction: column;
 }
 
-.u-flexItem {
+.u__flexItem {
   flex: 0 1 auto;
 }
 
-.u-flexItem--grow {
+.u__flexItem--grow {
   flex: 1 0 auto;
 }
 
-.u-flexItem--fill {
+.u__flexItem--fill {
   flex: 1 0 100%;
 }
 
-.u-hidden {
+.u__hidden {
   display: none;
 }


### PR DESCRIPTION
We’ve been using a variant of [Block, Element, Modifier](https://en.bem.info/) that conforms to (most of) the rules but does not follow the standard naming convention.

To make it easier to contribute to the project, switch to standard BEM naming convention so that the BEM documentation is maximally useful.

Specifically:

* Use double-underscore to delimit elements
* Use single-underscore to delimit modifiers
* Use kebab case (dashes) for internal word delimiting in block/element/modifier names
* Don’t nest elements (this is the rule we were breaking)

So, for example, `notificationList-notification--error` becomes `notification-list__notification_error`

And, `errorList-errorSublist-header` becomes `error-list__header` (no nested elements)

Fixes #555