### PR TITLE
Construct path-matching patterns to be platform-independent

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,10 +7,10 @@ const includes = require('lodash/includes');
 
 function matchModule(modulePath) {
   const modulePattern = new RegExp(
-    `\\/node_modules\\/${escapeRegExp(modulePath)}`
+    escapeRegExp(path.join('/node_modules', modulePath))
   );
   const moduleDependencyPattern = new RegExp(
-    `\\/node_modules\\/${escapeRegExp(modulePath)}\\/node_modules`
+    escapeRegExp(path.join('/node_modules', modulePath, 'node_modules'))
   );
 
   return (filePath) =>


### PR DESCRIPTION
On Windows, we’ll get paths with the `\` segment separator. So, our regexps can’t assume the separator will be `/`. Use `path.join` to construct the partial paths that go into the RegExp; this will also change any `/` passed in the `modulePath` argument to `\`, via the `path.normalize` method.