### PR TITLE
More reliable location of error tokens

### DIFF
--- a/spec/assertions/validations.js
+++ b/spec/assertions/validations.js
@@ -12,7 +12,7 @@ export function assertPassesValidation(validate, source, validatorArgs = []) {
 
 export function assertFailsValidationWith(validate, source, ...reasons) {
   return assert.eventually.sameMembers(
-    validate(source).then((errors) => map(errors, 'reason')),
+    validate(source, []).then((errors) => map(errors, 'reason')),
     reasons,
     `source fails validation with reasons: ${reasons.join(', ')}`
   );

--- a/spec/examples/validations/javascript.spec.js
+++ b/spec/examples/validations/javascript.spec.js
@@ -1,10 +1,20 @@
 /* eslint-env mocha */
 
 import '../../helper';
+import {
+  assertFailsValidationWith,
+} from '../../assertions/validations';
 
 import javascript from '../../../src/validations/javascript';
 import assertPassesAcceptance from './assertPassesAcceptance';
 
 describe('javascript', () => {
+  it('should handle invalid LHS error followed by comment', () =>
+    assertFailsValidationWith(javascript, `alert(--"str"
+// comment`,
+      'invalid-left-hand-string',
+      'missing-token'
+    )
+  );
   assertPassesAcceptance(javascript, 'javascript', ['jquery']);
 });


### PR DESCRIPTION
Found a case in which the Esprima validator was unable to identify a token at the location of a parse error. Upon further investigation, it turned out that in this case the `row` and `column` reported in the error identified a location in the source that did not actually exist. However, it’s possible to have the tokenizer output tokens with the index of the token start and end in the overall source, rather than line/column information; the corresponding `index` reported in the error object appears to be more reliable.

As a bonus, the logic for locating the token is a bit simpler.

So, switch to using index rather than line/column to match up the error location to a token.

Fixes #576