### PR TITLE
Close active submenu on workspace reset

### DIFF
--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -80,6 +80,12 @@ function ui(stateIn, action) {
         )
       );
 
+    case 'RESET_WORKSPACE':
+      return state.setIn(
+        ['dashboard', 'activeSubmenu'],
+        null
+      );
+
     default:
       return state;
   }


### PR DESCRIPTION
The proximate motivation for this is that if the load project submenu is open when you sign out, the component will no longer be able to render at the moment the workspace is reset. This is because the projects list expects a current project, but at the moment there is not one.

So, the reducer for UI state consumes a `RESET_WORKSPACE` action and closes any active submenu.

This does brush up against a general ambivalence in the Redux world about whether complexity should live in action creators or reducers. For instance, in this case, another option would be for the action dispatcher that dispatches `RESET_WORKSPACE` to also dispatch a `DASHBOARD_SUBMENU_TOGGLED` action.

In general, my instinct is to encode that complexity in the action dispatchers, because it’s easier to follow the logic there: if a dispatcher is a composite of a few actions, that knowledge all lives in the dispatcher itself. When a bunch of different reducers consume the same action to do not-obviously-related things, it’s harder to keep the overall behavior of the system in your head.

There are certainly counterarguments to this—imperative code is brittle and error-prone; the system is most easily understood as a series of state transitions in response to events. So far, though, I’ve found that the imperative approach yields overall easier-to-understand behavior.

That said, I think it’s reasonable to package up behaviors under a single store-level action if those state changes are more-or-less irreducible—i.e., they wouldn’t make sense decomposed from one another.  I think one can make an argument in this case that closing the submenu is an irreducible part of the workspace reset.

Fixes #579