### PR TITLE
Retry asynchronous module load if first time fails

### DIFF
--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -1,4 +1,5 @@
 import Validator from '../Validator';
+import importLinters from '../importLinters';
 
 const errorMap = {
   'missing \'{\'': () => ({reason: 'missing-opening-curly'}),
@@ -22,7 +23,7 @@ class CssValidator extends Validator {
   }
 
   _getRawErrors() {
-    System.import('../linters').then(({css}) =>
+    importLinters().then(({css}) =>
       css.parse(this._source, {silent: true}).stylesheet.parsingErrors
     );
   }

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -2,6 +2,7 @@ import Validator from '../Validator';
 import trim from 'lodash/trim';
 import startsWith from 'lodash/startsWith';
 import endsWith from 'lodash/endsWith';
+import importLinters from '../importLinters';
 
 const RADIAL_GRADIENT_EXPR =
   /^(?:(?:-(?:ms|moz|o|webkit)-)?radial-gradient|-webkit-gradient)/;
@@ -121,7 +122,7 @@ class PrettyCssValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(({prettyCSS}) => {
+    return importLinters().then(({prettyCSS}) => {
       try {
         const result = prettyCSS.parse(this._source);
         return result.getProblems();

--- a/src/validations/css/stylelint.js
+++ b/src/validations/css/stylelint.js
@@ -1,4 +1,5 @@
 import Validator from '../Validator';
+import importLinters from '../importLinters';
 
 const errorMap = {
   'syntaxError/Unclosed block': () => ({
@@ -20,7 +21,7 @@ class StyleLintValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(
+    return importLinters().then(
       ({stylelint}) => stylelint(
         this._source
       ).then(

--- a/src/validations/html/htmlInspector.js
+++ b/src/validations/html/htmlInspector.js
@@ -1,6 +1,7 @@
 import last from 'lodash/last';
 import isNull from 'lodash/isNull';
 import {localizedArrayToSentence} from '../../util/arrayToSentence';
+import importLinters from '../importLinters';
 import Validator from '../Validator';
 
 const specialCases = {
@@ -50,7 +51,7 @@ class HtmlInspectorValidator extends Validator {
       return Promise.resolve([]);
     }
 
-    return System.import('../linters').then(({HTMLInspector}) =>
+    return importLinters().then(({HTMLInspector}) =>
       new Promise((resolve) => {
         HTMLInspector.inspect({
           domRoot: this._doc.documentElement,

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -1,4 +1,5 @@
 import Validator from '../Validator';
+import importLinters from '../importLinters';
 
 const errorMap = {
   E001: (error) => {
@@ -115,7 +116,7 @@ class HtmllintValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(
+    return importLinters().then(
       ({htmllint}) => htmllint(this._source, htmlLintOptions).catch(() => [])
     );
   }

--- a/src/validations/importLinters.js
+++ b/src/validations/importLinters.js
@@ -1,0 +1,17 @@
+import isNil from 'lodash/isNil';
+import promiseRetry from 'promise-retry';
+
+let promisedLinters;
+
+export default function importLinters() {
+  if (isNil(promisedLinters)) {
+    promisedLinters = promiseRetry(
+      (retry) => System.import('./linters').catch(retry)
+    ).catch((error) => {
+      promisedLinters = null;
+      return Promise.reject(error);
+    });
+  }
+
+  return promisedLinters;
+}

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -1,6 +1,8 @@
+import importLinters from './importLinters';
 import html from './html.js';
 import css from './css.js';
 import javascript from './javascript.js';
-System.import('./linters');
+
+importLinters();
 
 export default {html, css, javascript};

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -1,6 +1,7 @@
 import Validator from '../Validator';
 import find from 'lodash/find';
 import inRange from 'lodash/inRange';
+import importLinters from '../importLinters';
 
 const UNEXPECTED_TOKEN_EXPR = /^Unexpected token (.+)$/;
 
@@ -78,7 +79,7 @@ class EsprimaValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(({esprima}) => {
+    return importLinters().then(({esprima}) => {
       try {
         esprima.parse(this._source);
       } catch (error) {

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -7,6 +7,7 @@ import defaults from 'lodash/defaults';
 import find from 'lodash/find';
 import includes from 'lodash/includes';
 import libraries from '../../config/libraries';
+import importLinters from '../importLinters';
 
 const jshintrc = {
   browser: true,
@@ -157,7 +158,7 @@ class JsHintValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(({jshint}) => {
+    return importLinters().then(({jshint}) => {
       try {
         jshint(this._source, this._jshintOptions);
       } catch (e) {


### PR DESCRIPTION
One of the most common uncaught errors reported for Popcode is that it fails to load the asynchronous module that contains the linter libraries used for validations. To guard against this, we introduce an `importLinters()` function, which has the following safeguards:

* Wrap the `System.import` call in a `promiseRetry`, so we retry loading several times with exponential backoff
* If even after retrying the operation has still totally failed, reject the promise, but also null it out so that, next time we need the linters, we’ll start the process all over again.

Fixes #541