### PR TITLE
Retry asynchronous module load if first time fails, take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "test": "karma start --single-run --no-auto-watch",
     "autotest": "karma start --no-single-run --auto-watch",
     "lint": "eslint --ext .js,.jsx --plugin react src",
-    "toc": "doctoc README.md --github --title '## Table of Contents'"
+    "toc": "doctoc README.md --github --title '## Table of Contents'",
+    "preview": "rm -rvf static/compiled && gulp build --production && static static"
   },
   "devDependencies": {
     "babel-core": "^6.14.0",
@@ -137,6 +138,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.8.0",
     "mocha": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
+    "node-static": "^0.7.9",
     "npm-check": "^5.2.1",
     "null-loader": "^0.1.1",
     "phantomjs-prebuilt": "^2.1.7",

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -1,4 +1,5 @@
 import Validator from '../Validator';
+import importLinters from '../importLinters';
 
 const errorMap = {
   'missing \'{\'': () => ({reason: 'missing-opening-curly'}),
@@ -22,7 +23,7 @@ class CssValidator extends Validator {
   }
 
   _getRawErrors() {
-    System.import('../linters').then(({css}) =>
+    importLinters().then(({css}) =>
       css.parse(this._source, {silent: true}).stylesheet.parsingErrors
     );
   }

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -2,6 +2,7 @@ import Validator from '../Validator';
 import trim from 'lodash/trim';
 import startsWith from 'lodash/startsWith';
 import endsWith from 'lodash/endsWith';
+import importLinters from '../importLinters';
 
 const RADIAL_GRADIENT_EXPR =
   /^(?:(?:-(?:ms|moz|o|webkit)-)?radial-gradient|-webkit-gradient)/;
@@ -121,7 +122,7 @@ class PrettyCssValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(({prettyCSS}) => {
+    return importLinters().then(({prettyCSS}) => {
       try {
         const result = prettyCSS.parse(this._source);
         return result.getProblems();

--- a/src/validations/css/stylelint.js
+++ b/src/validations/css/stylelint.js
@@ -1,4 +1,5 @@
 import Validator from '../Validator';
+import importLinters from '../importLinters';
 
 const errorMap = {
   'syntaxError/Unclosed block': () => ({
@@ -20,7 +21,7 @@ class StyleLintValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(
+    return importLinters().then(
       ({stylelint}) => stylelint(
         this._source
       ).then(

--- a/src/validations/html/htmlInspector.js
+++ b/src/validations/html/htmlInspector.js
@@ -1,6 +1,7 @@
 import last from 'lodash/last';
 import isNull from 'lodash/isNull';
 import {localizedArrayToSentence} from '../../util/arrayToSentence';
+import importLinters from '../importLinters';
 import Validator from '../Validator';
 
 const specialCases = {
@@ -50,7 +51,7 @@ class HtmlInspectorValidator extends Validator {
       return Promise.resolve([]);
     }
 
-    return System.import('../linters').then(({HTMLInspector}) =>
+    return importLinters().then(({HTMLInspector}) =>
       new Promise((resolve) => {
         HTMLInspector.inspect({
           domRoot: this._doc.documentElement,

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -1,4 +1,5 @@
 import Validator from '../Validator';
+import importLinters from '../importLinters';
 
 const errorMap = {
   E001: (error) => {
@@ -115,7 +116,7 @@ class HtmllintValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(
+    return importLinters().then(
       ({htmllint}) => htmllint(this._source, htmlLintOptions).catch(() => [])
     );
   }

--- a/src/validations/importLinters.js
+++ b/src/validations/importLinters.js
@@ -1,0 +1,17 @@
+import isNil from 'lodash/isNil';
+import promiseRetry from 'promise-retry';
+
+let promisedLinters;
+
+export default function importLinters() {
+  if (isNil(promisedLinters)) {
+    promisedLinters = promiseRetry(
+      (retry) => System.import('./linters').catch(retry)
+    ).catch((error) => {
+      promisedLinters = null;
+      return Promise.reject(error);
+    });
+  }
+
+  return promisedLinters;
+}

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -1,6 +1,8 @@
+import importLinters from './importLinters';
 import html from './html.js';
 import css from './css.js';
 import javascript from './javascript.js';
-System.import('./linters');
+
+importLinters();
 
 export default {html, css, javascript};

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -1,6 +1,7 @@
 import Validator from '../Validator';
 import find from 'lodash/find';
 import inRange from 'lodash/inRange';
+import importLinters from '../importLinters';
 
 const UNEXPECTED_TOKEN_EXPR = /^Unexpected token (.+)$/;
 
@@ -78,7 +79,7 @@ class EsprimaValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(({esprima}) => {
+    return importLinters().then(({esprima}) => {
       try {
         esprima.parse(this._source);
       } catch (error) {

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -7,6 +7,7 @@ import defaults from 'lodash/defaults';
 import find from 'lodash/find';
 import includes from 'lodash/includes';
 import libraries from '../../config/libraries';
+import importLinters from '../importLinters';
 
 const jshintrc = {
   browser: true,
@@ -157,7 +158,7 @@ class JsHintValidator extends Validator {
   }
 
   _getRawErrors() {
-    return System.import('../linters').then(({jshint}) => {
+    return importLinters().then(({jshint}) => {
       try {
         jshint(this._source, this._jshintOptions);
       } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,7 +1559,7 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@*, colors@^1.1.0, colors@~1.1.2:
+colors@*, colors@>=0.6.0, colors@^1.1.0, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -4693,7 +4693,7 @@ mime@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.4.tgz#11b5fdaf29c2509255176b80ad520294f5de92b7"
 
-mime@1.3.4, "mime@>= 0.0.1", mime@^1.3.4:
+mime@1.3.4, "mime@>= 0.0.1", mime@>=1.2.9, mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
@@ -4878,6 +4878,14 @@ node-pre-gyp@^0.6.29:
     semver "~5.3.0"
     tar "~2.2.1"
     tar-pack "~3.3.0"
+
+node-static@^0.7.9:
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/node-static/-/node-static-0.7.9.tgz#9bb69fce2281f7ae3cd1fb983e9ea0ec0cd9fecb"
+  dependencies:
+    colors ">=0.6.0"
+    mime ">=1.2.9"
+    optimist ">=0.3.4"
 
 node-status-codes@^1.0.0:
   version "1.0.0"
@@ -5084,7 +5092,7 @@ opn@4.0.2:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
 
-optimist@^0.6.1:
+optimist@>=0.3.4, optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:


### PR DESCRIPTION
Re-run of #587, which was reverted because of tons of uncaught errors getting thrown in production. Original PR description follows.

---

One of the most common uncaught errors reported for Popcode is that it fails to load the asynchronous module that contains the linter libraries used for validations. To guard against this, we introduce an `importLinters()` function, which has the following safeguards:

* Wrap the `System.import` call in a `promiseRetry`, so we retry loading several times with exponential backoff
* If even after retrying the operation has still totally failed, reject the promise, but also null it out so that, next time we need the linters, we’ll start the process all over again.

Fixes #541