### PR TITLE
Tests for logIn/logOut actions

### DIFF
--- a/spec/examples/actions/projects.spec.js
+++ b/spec/examples/actions/projects.spec.js
@@ -4,12 +4,12 @@
 import '../../helper';
 import {assert} from 'chai';
 
+import createAndMutateProject from '../../helpers/createAndMutateProject';
 import createApplicationStore from '../../../src/createApplicationStore';
 
 import {
   createProject,
   changeCurrentProject,
-  toggleLibrary,
 } from '../../../src/actions';
 
 import {
@@ -49,9 +49,9 @@ describe('projectActions', () => {
 
     beforeEach(() => {
       clock = sinon.useFakeTimers();
-      projectKey = createAndMutateProject();
+      projectKey = createAndMutateProject(store);
       clock.tick(1);
-      createAndMutateProject();
+      createAndMutateProject(store);
       store.dispatch(changeCurrentProject(projectKey));
     });
 
@@ -67,11 +67,4 @@ describe('projectActions', () => {
       assert.lengthOf(getProjectKeys(store.getState()), 2);
     });
   });
-
-  function createAndMutateProject() {
-    store.dispatch(createProject());
-    const projectKey = getCurrentProject(store.getState()).projectKey;
-    store.dispatch(toggleLibrary(projectKey, 'jquery'));
-    return projectKey;
-  }
 });

--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -1,0 +1,148 @@
+/* eslint-env mocha */
+/* global sinon */
+
+import '../../helper';
+import MockFirebase from '../../helpers/MockFirebase';
+import {assert} from 'chai';
+import dispatchAndWait from '../../helpers/dispatchAndWait';
+import buildProject from '../../helpers/buildProject';
+import createAndMutateProject from '../../helpers/createAndMutateProject';
+import {getCurrentProject} from '../../../src/util/projectUtils';
+import {bootstrap, logIn} from '../../../src/actions';
+import createApplicationStore from '../../../src/createApplicationStore';
+
+describe('user actions', () => {
+  let store, sandbox, mockFirebase;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    mockFirebase = new MockFirebase(sandbox);
+    store = createApplicationStore();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('logIn', () => {
+    const userData = {
+      auth: {uid: '123', provider: 'github'},
+      github: {
+        accessToken: 'abc123',
+        displayName: 'Popcode User',
+        profileImageURL: 'https://camo.github.com/popcodeuser.jpg',
+        username: 'popcodeuser',
+      },
+      provider: 'github',
+    };
+
+    let storedProject;
+
+    beforeEach(() => {
+      storedProject = buildProject({sources: {html: 'bogus<'}});
+      mockFirebase.logOut();
+      return dispatchAndWait(store, bootstrap());
+    });
+
+    context('with locally pristine project', () => {
+      beforeEach(() => {
+        mockFirebase.logIn(userData.auth.uid);
+      });
+
+      context('with stored project', () => {
+        beforeEach(() => {
+          mockFirebase.setCurrentProject(storedProject);
+          return dispatchAndWait(store, logIn(userData));
+        });
+
+        itShouldLogUserIn();
+
+        it('should set project to stored project', () => {
+          assert.equal(
+            getCurrentProject(store.getState()).projectKey,
+            storedProject.projectKey
+          );
+        });
+      });
+
+      context('without stored project', () => {
+        beforeEach(() => {
+          mockFirebase.setCurrentProject(null);
+          return dispatchAndWait(store, logIn(userData));
+        });
+
+        it('should create fresh project', () => {
+          assert.isNotNull(getCurrentProject(store.getState()).projectKey);
+        });
+      });
+    });
+
+    context('with locally modified project', () => {
+      let localProjectKey;
+
+      beforeEach(() => {
+        mockFirebase.logIn(userData.auth.uid);
+        createAndMutateProject(store);
+        localProjectKey = getCurrentProject(store.getState()).projectKey;
+      });
+
+      context('with stored project', () => {
+        beforeEach(() => {
+          mockFirebase.setCurrentProject(storedProject);
+          return dispatchAndWait(store, logIn(userData));
+        });
+
+        itShouldLogUserIn();
+
+        it('should set project to stored project', () => {
+          assert.equal(
+            getCurrentProject(store.getState()).projectKey,
+            localProjectKey
+          );
+        });
+      });
+    });
+
+    function itShouldLogUserIn() {
+      it('should set user state to authenticated', () => {
+        assert.isTrue(store.getState().user.get('authenticated'));
+      });
+
+      it('should set user id to uid', () => {
+        assert.equal(store.getState().user.get('id'), userData.auth.uid);
+      });
+
+      it('should set provider to github', () => {
+        assert.equal(store.getState().user.get('provider'), 'github');
+      });
+
+      it('should set display name', () => {
+        assert.equal(
+          store.getState().user.getIn(['info', 'displayName']),
+          userData.github.displayName
+        );
+      });
+
+      it('should set username', () => {
+        assert.equal(
+          store.getState().user.getIn(['info', 'username']),
+          userData.github.username
+        );
+      });
+
+      it('should set imageURL', () => {
+        assert.equal(
+          store.getState().user.getIn(['info', 'imageURL']),
+          userData.github.imageURL
+        );
+      });
+
+      it('should set auth token', () => {
+        assert.equal(
+          store.getState().user.getIn(['info', 'accessToken']),
+          userData.github.accessToken,
+        );
+      });
+    }
+  });
+});

--- a/spec/helpers/createAndMutateProject.js
+++ b/spec/helpers/createAndMutateProject.js
@@ -1,0 +1,14 @@
+import {getCurrentProject} from '../../src/util/projectUtils';
+
+import {
+  createProject,
+  toggleLibrary,
+} from '../../src/actions';
+
+export default function createAndMutateProject(store) {
+  store.dispatch(createProject());
+  const projectKey = getCurrentProject(store.getState()).projectKey;
+  store.dispatch(toggleLibrary(projectKey, 'jquery'));
+  return projectKey;
+}
+

--- a/spec/helpers/dispatchAndWait.js
+++ b/spec/helpers/dispatchAndWait.js
@@ -1,0 +1,7 @@
+import promiseTicks from './promiseTicks';
+
+export default function dispatchAndWait(store, action) {
+  store.dispatch(action);
+  return promiseTicks(20);
+}
+

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -23,6 +23,7 @@ import {
 
 import {
   logIn,
+  logOut,
 } from './user';
 
 function getCurrentPersistor(state) {
@@ -154,22 +155,6 @@ function addRuntimeError(error) {
 function clearRuntimeErrors() {
   return {
     type: 'RUNTIME_ERRORS_CLEARED',
-  };
-}
-
-function resetWorkspace() {
-  return {type: 'RESET_WORKSPACE'};
-}
-
-function userLoggedOut() {
-  return {type: 'USER_LOGGED_OUT'};
-}
-
-function logOut() {
-  return (dispatch) => {
-    dispatch(resetWorkspace());
-    dispatch(userLoggedOut());
-    dispatch(createProject());
   };
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,7 +11,6 @@ import {
 import {
   createProject,
   changeCurrentProject,
-  loadCurrentProject,
 } from './projects';
 
 import {
@@ -21,6 +20,10 @@ import {
   notificationTriggered,
   userDismissedNotification,
 } from './ui';
+
+import {
+  logIn,
+} from './user';
 
 function getCurrentPersistor(state) {
   const currentUser = state.user;
@@ -82,19 +85,6 @@ export function validateAllSources(project) {
   };
 }
 
-function setCurrentProjectAfterLogin(authData) {
-  return (dispatch) => {
-    const persistor = new FirebasePersistor(authData.auth.uid);
-    persistor.loadCurrentProject().then((project) => {
-      if (project) {
-        dispatch(loadCurrentProject(project));
-      } else {
-        dispatch(createProject());
-      }
-    });
-  };
-}
-
 function updateProjectSource(projectKey, language, newValue) {
   return (dispatch, getState) => {
     dispatch({
@@ -136,7 +126,7 @@ function toggleLibrary(projectKey, libraryKey) {
   };
 }
 
-function loadAllProjects() {
+export function loadAllProjects() {
   return (dispatch, getState) => {
     const persistor = getCurrentPersistor(getState());
     if (persistor === null) {
@@ -169,23 +159,6 @@ function clearRuntimeErrors() {
 
 function resetWorkspace() {
   return {type: 'RESET_WORKSPACE'};
-}
-
-function userAuthenticated(authData) {
-  return {type: 'USER_AUTHENTICATED', payload: authData};
-}
-
-function logIn(authData) {
-  return (dispatch, getState) => {
-    dispatch(userAuthenticated(authData));
-
-    if (!saveCurrentProject(getState())) {
-      dispatch(resetWorkspace());
-      dispatch(setCurrentProjectAfterLogin(authData));
-    }
-
-    dispatch(loadAllProjects());
-  };
 }
 
 function userLoggedOut() {
@@ -225,7 +198,6 @@ function toggleDashboardSubmenu(submenu) {
 export {
   createProject,
   changeCurrentProject,
-  loadAllProjects,
   updateProjectSource,
   toggleLibrary,
   logIn,

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,7 +1,40 @@
 import {createAction} from 'redux-actions';
 import identity from 'lodash/identity';
+import FirebasePersistor from '../persistors/FirebasePersistor';
+import {loadAllProjects, saveCurrentProject} from '.';
+import {createProject, loadCurrentProject} from './projects';
 
 export const userAuthenticated = createAction(
   'USER_AUTHENTICATED',
   identity
 );
+
+export function logIn(authData) {
+  return (dispatch, getState) => {
+    dispatch(userAuthenticated(authData));
+
+    if (!saveCurrentProject(getState())) {
+      dispatch(resetWorkspace());
+      dispatch(setCurrentProjectAfterLogin(authData));
+    }
+
+    dispatch(loadAllProjects());
+  };
+}
+
+function resetWorkspace() {
+  return {type: 'RESET_WORKSPACE'};
+}
+
+function setCurrentProjectAfterLogin(authData) {
+  return (dispatch) => {
+    const persistor = new FirebasePersistor(authData.auth.uid);
+    persistor.loadCurrentProject().then((project) => {
+      if (project) {
+        dispatch(loadCurrentProject(project));
+      } else {
+        dispatch(createProject());
+      }
+    });
+  };
+}

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -9,6 +9,10 @@ export const userAuthenticated = createAction(
   identity
 );
 
+const resetWorkspace = createAction('RESET_WORKSPACE');
+
+const userLoggedOut = createAction('USER_LOGGED_OUT');
+
 export function logIn(authData) {
   return (dispatch, getState) => {
     dispatch(userAuthenticated(authData));
@@ -22,8 +26,12 @@ export function logIn(authData) {
   };
 }
 
-function resetWorkspace() {
-  return {type: 'RESET_WORKSPACE'};
+export function logOut() {
+  return (dispatch) => {
+    dispatch(resetWorkspace());
+    dispatch(userLoggedOut());
+    dispatch(createProject());
+  };
 }
 
 function setCurrentProjectAfterLogin(authData) {


### PR DESCRIPTION
Adds test coverage for `logIn` and `logOut` actions, and moves them and their private function dependencies into the `actions/user` submodule.

This is done in anticipation of upgrading Firebase; the new SDK has a substantially new API, and we’ll need to change some action creator code to accommodate that, so first I wanted to make sure that code has good test coverage.