### PR TITLE
Flatten user data structure in store

### DIFF
--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -3,6 +3,7 @@
 
 import '../../helper';
 import MockFirebase from '../../helpers/MockFirebase';
+import {createUser} from '../../helpers/MockFirebase';
 import {assert} from 'chai';
 import dispatchAndWait from '../../helpers/dispatchAndWait';
 import buildProject from '../../helpers/buildProject';
@@ -24,16 +25,7 @@ describe('user actions', () => {
     sandbox.restore();
   });
 
-  const userData = {
-    auth: {uid: '123', provider: 'github'},
-    github: {
-      accessToken: 'abc123',
-      displayName: 'Popcode User',
-      profileImageURL: 'https://camo.github.com/popcodeuser.jpg',
-      username: 'popcodeuser',
-    },
-    provider: 'github',
-  };
+  const userData = createUser();
 
   describe('logIn', () => {
     let storedProject;
@@ -46,7 +38,7 @@ describe('user actions', () => {
 
     context('with locally pristine project', () => {
       beforeEach(() => {
-        mockFirebase.logIn(userData.auth.uid);
+        mockFirebase.logIn(userData.uid);
       });
 
       context('with stored project', () => {
@@ -81,7 +73,7 @@ describe('user actions', () => {
       let localProjectKey;
 
       beforeEach(() => {
-        mockFirebase.logIn(userData.auth.uid);
+        mockFirebase.logIn(userData.uid);
         createAndMutateProject(store);
         localProjectKey = getCurrentProject(store.getState()).projectKey;
       });
@@ -109,7 +101,7 @@ describe('user actions', () => {
       });
 
       it('should set user id to uid', () => {
-        assert.equal(store.getState().user.get('id'), userData.auth.uid);
+        assert.equal(store.getState().user.get('id'), userData.uid);
       });
 
       it('should set provider to github', () => {
@@ -118,28 +110,28 @@ describe('user actions', () => {
 
       it('should set display name', () => {
         assert.equal(
-          store.getState().user.getIn(['info', 'displayName']),
+          store.getState().user.get('displayName'),
           userData.github.displayName
         );
       });
 
       it('should set username', () => {
         assert.equal(
-          store.getState().user.getIn(['info', 'username']),
+          store.getState().user.get('username'),
           userData.github.username
         );
       });
 
-      it('should set imageURL', () => {
+      it('should set avatarUrl', () => {
         assert.equal(
-          store.getState().user.getIn(['info', 'imageURL']),
-          userData.github.imageURL
+          store.getState().user.get('avatarUrl'),
+          userData.github.profileImageURL
         );
       });
 
       it('should set auth token', () => {
         assert.equal(
-          store.getState().user.getIn(['info', 'accessToken']),
+          store.getState().user.getIn(['accessTokens', 'github']),
           userData.github.accessToken,
         );
       });

--- a/spec/helpers/MockFirebase.js
+++ b/spec/helpers/MockFirebase.js
@@ -1,6 +1,20 @@
 /* global sinon */
 
 import appFirebase from '../../src/services/appFirebase';
+import merge from 'lodash/merge';
+
+export function createUser(user) {
+  return merge({
+    github: {
+      accessToken: 'abc123',
+      displayName: 'Popcode User',
+      profileImageURL: 'https://camo.github.com/popcodeuser.jpg',
+      username: 'popcodeuser',
+    },
+    provider: 'github',
+    uid: '123',
+  }, user);
+}
 
 export default class MockFirebase {
   constructor(sandbox) {
@@ -11,7 +25,7 @@ export default class MockFirebase {
     this._userSpace = addChild(appFirebase, `workspaces/${uid}`);
     addChild(this._userSpace, 'currentProjectKey');
     addChild(this._userSpace, 'projects');
-    appFirebase.onAuth.yields({auth: {uid}});
+    appFirebase.onAuth.yields(createUser({uid}));
   }
 
   logOut() {

--- a/src/actions/bootstrap.js
+++ b/src/actions/bootstrap.js
@@ -15,9 +15,9 @@ import {notificationTriggered} from './ui';
 export default function bootstrap(gistId) {
   return (dispatch) => {
     const promisedProjectFromStorage =
-      getCurrentUserState().then(({user, project}) => {
-        if (user) {
-          dispatch(userAuthenticated(user));
+      getCurrentUserState().then(({userData, project}) => {
+        if (userData) {
+          dispatch(userAuthenticated({userData}));
           dispatch(loadAllProjects());
         }
 
@@ -58,20 +58,20 @@ function retrieveGist(gistId) {
 }
 
 function getCurrentUserState() {
-  return oneAuth().then((authData) => {
-    if (authData === null) {
-      return {user: null, project: null};
+  return oneAuth().then((userData) => {
+    if (userData === null) {
+      return {userData: null, project: null};
     }
 
-    return new FirebasePersistor(authData.auth.uid).loadCurrentProject().
-      then((project) => ({user: authData, project}));
+    return new FirebasePersistor(userData.uid).loadCurrentProject().
+      then((project) => ({userData, project}));
   });
 }
 
 function oneAuth() {
   return new Promise((resolve) => {
-    function handleAuth(authData) {
-      resolve(authData);
+    function handleAuth(userData) {
+      resolve(userData);
       appFirebase.offAuth(handleAuth);
     }
     appFirebase.onAuth(handleAuth);

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -13,13 +13,13 @@ const resetWorkspace = createAction('RESET_WORKSPACE');
 
 const userLoggedOut = createAction('USER_LOGGED_OUT');
 
-export function logIn(authData) {
+export function logIn(userData) {
   return (dispatch, getState) => {
-    dispatch(userAuthenticated(authData));
+    dispatch(userAuthenticated({userData}));
 
     if (!saveCurrentProject(getState())) {
       dispatch(resetWorkspace());
-      dispatch(setCurrentProjectAfterLogin(authData));
+      dispatch(setCurrentProjectAfterLogin(userData.uid));
     }
 
     dispatch(loadAllProjects());
@@ -34,9 +34,9 @@ export function logOut() {
   };
 }
 
-function setCurrentProjectAfterLogin(authData) {
+function setCurrentProjectAfterLogin(uid) {
   return (dispatch) => {
-    const persistor = new FirebasePersistor(authData.auth.uid);
+    const persistor = new FirebasePersistor(uid);
     persistor.loadCurrentProject().then((project) => {
       if (project) {
         dispatch(loadCurrentProject(project));

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -12,13 +12,13 @@ class Dashboard extends React.Component {
     const currentUser = this.props.currentUser;
 
     if (currentUser.authenticated) {
-      const name = currentUser.info.displayName || currentUser.info.username;
+      const name = currentUser.displayName || currentUser.username;
 
       return (
         <div className="dashboard__session">
           <img
             className="dashboard__avatar"
-            src={currentUser.info.profileImageURL}
+            src={currentUser.avatarUrl}
           />
           <span className="dashboard__username">{name}</span>
           <span

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -7,13 +7,20 @@ function user(stateIn, action) {
 
   switch (action.type) {
     case 'USER_AUTHENTICATED': {
-      const payload = action.payload;
+      const {userData} = action.payload;
+      const provider = userData.provider;
+      const profile = userData[provider];
 
       return state.merge({
         authenticated: true,
-        id: payload.auth.uid,
-        provider: payload.auth.provider,
-        info: Immutable.fromJS(payload.github),
+        provider,
+        id: userData.uid,
+        displayName: profile.displayName,
+        username: profile.username,
+        avatarUrl: profile.profileImageURL,
+        accessTokens: new Immutable.Map({
+          [provider]: profile.accessToken,
+        }),
       });
     }
 

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -64,7 +64,7 @@ export function createGistFromProject(project) {
 
 function clientForUser(user) {
   if (user.authenticated && user.provider === 'github') {
-    return gitHub.withAccessToken(user.info.accessToken);
+    return gitHub.withAccessToken(user.accessTokens.github);
   }
 
   return gitHub.anonymous();


### PR DESCRIPTION
Until now, we’ve been directly storing the profile information in the `github` key of the Firebase response in the `info` key of our own user representation in the store. This means that knowledge of the particular structure of the Firebase user representation leaks throughout the application.

Now, instead, the user reducer maps the Firebase structure on to a normalized, flat user representation for internal use. Most relevant information is now a key in the top-level user object; the only exception is `accessTokens`, which is a map of provider to access token, in the unlikely(?) event we’ll be supporting authentication with other providers in the future.

This is in preparation for the Firebase SDK upgrade, which will in fact give us a different structure of the Firebase user representation.

Also reads the `uid` from the top-level Firebase response rather than the `auth.uid` key, because this seems more correct (it’s a top-level fact about the Firebase user).