### PR TITLE
Lint code in spec directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+spec/data/**/*.js

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "dev": "yarn install && gulp dev",
     "test": "karma start --single-run --no-auto-watch",
     "autotest": "karma start --no-single-run --auto-watch",
-    "lint": "eslint --ext .js,.jsx --plugin react src",
+    "lint": "eslint --ext .js,.jsx --plugin react src spec",
     "toc": "doctoc README.md --github --title '## Table of Contents'",
     "preview": "rm -rvf static/compiled && gulp build --production && static static"
   },


### PR DESCRIPTION
Realized that `yarn run lint` does not lint specs. Was relying on syntastic to do this for me. This is important!