### PR TITLE
#629 Hide output panel instead of removing it when Output button is clicked

### DIFF
--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -3,6 +3,7 @@ import i18n from 'i18next-client';
 import isEmpty from 'lodash/isEmpty';
 import ErrorList from './ErrorList';
 import Preview from './Preview';
+import classnames from 'classnames';
 
 class Output extends React.Component {
   _renderErrorList(props) {
@@ -59,7 +60,14 @@ class Output extends React.Component {
 
   render() {
     return (
-      <div className="environment__column output">
+      <div
+        className={
+          classnames(
+            'environment__column output',
+            {output_hidden: this.props.isHidden}
+          )
+        }
+      >
         <div
           className="environment__label label"
           onClick={this.props.onMinimize}
@@ -76,6 +84,7 @@ class Output extends React.Component {
 
 Output.propTypes = {
   errors: React.PropTypes.object.isRequired,
+  isHidden: React.PropTypes.bool.isRequired,
   project: React.PropTypes.object,
   runtimeErrors: React.PropTypes.array.isRequired,
   validationState: React.PropTypes.string,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -216,13 +216,10 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
-    if (includes(this.props.ui.minimizedComponents, 'output')) {
-      return null;
-    }
-
     return (
       <Output
         errors={this.props.errors}
+        isHidden={includes(this.props.ui.minimizedComponents, 'output')}
         project={this.props.currentProject}
         runtimeErrors={this.props.runtimeErrors}
         validationState={this._getOverallValidationState()}

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -417,6 +417,10 @@ body {
   position: relative;
 }
 
+.output_hidden {
+  display: none;
+}
+
 .output__item {
   flex: 1 1 auto;
 }


### PR DESCRIPTION
Addresses Issue #629.

Instead of going straight for `style: display-none`, decided to hide the panel using css class `output_hidden`. The `"_hidden"` string is appended to the class when the Output button is clicked.