### PR TITLE
Keep project when logging out if locally modified

### DIFF
--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -163,8 +163,8 @@ describe('user actions', () => {
       assert.isUndefined(store.getState().getIn(['user', 'id']));
     });
 
-    it('should create a fresh project', () => {
-      assert.notEqual(
+    it('should retain current project', () => {
+      assert.equal(
         getCurrentProject(store.getState()).projectKey,
         loggedInProjectKey
       );

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,14 +1,13 @@
 import {createAction} from 'redux-actions';
 import identity from 'lodash/identity';
 import {loadAllProjects, saveCurrentProject} from '.';
-import {createProject} from './projects';
 
 export const userAuthenticated = createAction(
   'USER_AUTHENTICATED',
   identity
 );
 
-const resetWorkspace = createAction('RESET_WORKSPACE');
+const resetWorkspace = createAction('RESET_WORKSPACE', identity);
 
 const userLoggedOut = createAction('USER_LOGGED_OUT');
 
@@ -21,9 +20,10 @@ export function logIn(userData) {
 }
 
 export function logOut() {
-  return (dispatch) => {
-    dispatch(resetWorkspace());
+  return (dispatch, getState) => {
+    const currentProjectKey =
+      getState().getIn(['currentProject', 'projectKey']);
+    dispatch(resetWorkspace({currentProjectKey}));
     dispatch(userLoggedOut());
-    dispatch(createProject());
   };
 }

--- a/src/reducers/currentProject.js
+++ b/src/reducers/currentProject.js
@@ -15,8 +15,6 @@ function currentProject(stateIn, action) {
       return state.set('projectKey', action.payload.projectKey);
     case 'PROJECT_CREATED':
       return state.set('projectKey', action.payload.projectKey);
-    case 'RESET_WORKSPACE':
-      return noCurrentProject;
     default:
       return state;
   }

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -56,9 +56,6 @@ function errors(stateIn, action) {
       }
       return state.set(action.payload.language, passedLanguageErrors);
 
-    case 'RESET_WORKSPACE':
-      return emptyErrors;
-
     default:
       return state;
   }

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -66,7 +66,10 @@ function projects(stateIn, action) {
       ));
 
     case 'RESET_WORKSPACE':
-      return emptyMap;
+      return new Immutable.Map().set(
+        action.payload.currentProjectKey,
+        state.get(action.payload.currentProjectKey)
+      );
 
     case 'PROJECT_LIBRARY_TOGGLED':
       return state.updateIn(


### PR DESCRIPTION
The following scenario is fairly common:

* Student logs in to Popcode
* Student does some work
* Student then realizes they are logged in to the wrong account (because the browser was logged in to a different GitHub)
* Student “loses” their work because logging out resets the workspace

While the work the student did was, in fact, still available in the account they were logged in to, they may not have access to it, and this is generally an inconvenient situation.

We thus change the logic to only reset the workspace on logout if the current project was not locally modified.

This is particularly important because the forthcoming Firebase upgrade will mean that Popcode sessions are shared between all browser tabs. So, logging out of one tab will log you out of all tabs. This would add a particular edge to the situation described above.