### PR TITLE
Use Immutable root state for Redux store

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",
     "redux-actions": "^0.12.0",
+    "redux-immutable": "^3.0.11",
     "redux-logger": "^2.5.0",
     "redux-thunk": "^2.1.0",
     "slowparse": "^1.1.4",

--- a/spec/examples/actions/bootstrap.spec.js
+++ b/spec/examples/actions/bootstrap.spec.js
@@ -32,7 +32,9 @@ describe('bootstrap', () => {
       beforeEach(() => dispatchBootstrap());
 
       it('should have no current project by default', () => {
-        assert.isNull(store.getState().currentProject.get('projectKey'));
+        assert.isNull(
+          store.getState().getIn(['currentProject', 'projectKey'])
+        );
       });
     });
 
@@ -43,11 +45,13 @@ describe('bootstrap', () => {
       });
 
       it('should create a new current project', () => {
-        assert.isNotNull(store.getState().currentProject.get('projectKey'));
+        assert.isNotNull(
+          store.getState().getIn(['currentProject', 'projectKey'])
+        );
       });
 
       it('should set user to logged out', () => {
-        assert.isNotTrue(store.getState().user.authenticated);
+        assert.isNotTrue(store.getState().getIn(['user', 'authenticated']));
       });
     });
 
@@ -62,12 +66,12 @@ describe('bootstrap', () => {
         });
 
         it('should log the user in', () => {
-          assert.isTrue(store.getState().user.get('authenticated'));
+          assert.isTrue(store.getState().getIn(['user', 'authenticated']));
         });
 
         it('should create a new current project', () =>
           assert.eventually.isNotNull(Promise.resolve().then(() =>
-            store.getState().currentProject.get('projectKey'))
+            store.getState().getIn(['currentProject', 'projectKey']))
           )
         );
       });
@@ -84,14 +88,14 @@ describe('bootstrap', () => {
 
         it('should set current project from Firebase', () => {
           assert.equal(
-            store.getState().currentProject.get('projectKey'),
+            store.getState().getIn(['currentProject', 'projectKey']),
             project.projectKey
           );
         });
 
         it('should validate the project', () => {
           assert.notEqual(
-            store.getState().errors.first().get('state'),
+            store.getState().get('errors').first().get('state'),
             'passed'
           );
         });
@@ -106,7 +110,9 @@ describe('bootstrap', () => {
       beforeEach(() => dispatchBootstrap(gistId));
 
       it('should have no current project', () => {
-        assert.isNull(store.getState().currentProject.get('projectKey'));
+        assert.isNull(
+          store.getState().getIn(['currentProject', 'projectKey'])
+        );
       });
     });
 
@@ -117,7 +123,9 @@ describe('bootstrap', () => {
       });
 
       it('should have no current project', () => {
-        assert.isNull(store.getState().currentProject.get('projectKey'));
+        assert.isNull(
+          store.getState().getIn(['currentProject', 'projectKey'])
+        );
       });
     });
 
@@ -128,7 +136,9 @@ describe('bootstrap', () => {
       });
 
       it('should have no current project', () => {
-        assert.isNull(store.getState().currentProject.get('projectKey'));
+        assert.isNull(
+          store.getState().getIn(['currentProject', 'projectKey'])
+        );
       });
     });
 
@@ -146,7 +156,9 @@ describe('bootstrap', () => {
         });
 
         it('should have a current project', () => {
-          assert.isNotNull(store.getState().currentProject.get('projectKey'));
+          assert.isNotNull(
+            store.getState().getIn(['currentProject', 'projectKey'])
+          );
         });
 
         it('should use the gist data in the current project', () => {
@@ -165,7 +177,9 @@ describe('bootstrap', () => {
         });
 
         it('should have a current project', () => {
-          assert.isNotNull(store.getState().currentProject.get('projectKey'));
+          assert.isNotNull(
+            store.getState().getIn(['currentProject', 'projectKey'])
+          );
         });
 
         it('should use the gist data in the current project', () => {
@@ -219,12 +233,14 @@ describe('bootstrap', () => {
         });
 
         it('should create a new project', () => {
-          assert.isNotNull(store.getState().currentProject.get('projectKey'));
+          assert.isNotNull(
+            store.getState().getIn(['currentProject', 'projectKey'])
+          );
         });
 
         it('should add a notification', () => {
           assert.include(
-            store.getState().ui.get('notifications').toJS().
+            store.getState().getIn(['ui', 'notifications']).toJS().
             map(property('type')),
             'gist-import-not-found'
           );
@@ -239,12 +255,14 @@ describe('bootstrap', () => {
         });
 
         it('should create a new project', () => {
-          assert.isNotNull(store.getState().currentProject.get('projectKey'));
+          assert.isNotNull(
+            store.getState().getIn(['currentProject', 'projectKey'])
+          );
         });
 
         it('should add a notification', () => {
           assert.include(
-            store.getState().ui.get('notifications').toJS().
+            store.getState().getIn(['ui', 'notifications']).toJS().
             map(property('type')),
             'gist-import-error'
           );

--- a/spec/examples/actions/clients.spec.js
+++ b/spec/examples/actions/clients.spec.js
@@ -18,7 +18,7 @@ describe('clients', () => {
       const gistExportComplete = new Promise(() => {});
       store.dispatch(exportingGist(gistExportComplete));
       assert.isTrue(
-        store.getState().clients.getIn(['gists', 'exportInProgress'])
+        store.getState().getIn(['clients', 'gists', 'exportInProgress'])
       );
     });
 
@@ -26,8 +26,8 @@ describe('clients', () => {
       () => {
         const gistExportComplete = Promise.resolve();
         store.dispatch(exportingGist(gistExportComplete));
-        return assert.eventually.isFalse(gistExportComplete.then(
-          () => store.getState().clients.getIn(['gists', 'exportInProgress'])
+        return assert.eventually.isFalse(gistExportComplete.then(() =>
+          store.getState().getIn(['clients', 'gists', 'exportInProgress'])
         ));
       }
     );
@@ -36,8 +36,8 @@ describe('clients', () => {
       () => {
         const gistExportComplete = Promise.reject();
         store.dispatch(exportingGist(gistExportComplete));
-        return assert.eventually.isFalse(gistExportComplete.catch(
-          () => store.getState().clients.getIn(['gists', 'exportInProgress'])
+        return assert.eventually.isFalse(gistExportComplete.catch(() =>
+          store.getState().getIn(['clients', 'gists', 'exportInProgress'])
         ));
       }
     );

--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -35,20 +35,20 @@ describe('interfaceStateActions', () => {
     beforeEach(() => store.dispatch(userTyped()));
 
     it('sets typing state to true', () => {
-      assert.isTrue(store.getState().ui.getIn(['editors', 'typing']));
+      assert.isTrue(store.getState().getIn(['ui', 'editors', 'typing']));
     });
 
     it('keeps typing state true before timeout expires', () =>
       assert.eventually.isTrue(
         waitFor(TYPING_DEBOUNCE_DELAY / 2, clock).
-          then(() => store.getState().ui.getIn(['editors', 'typing']))
+          then(() => store.getState().getIn(['ui', 'editors', 'typing']))
       )
     );
 
     it('sets typing state to false after timeout expires', () =>
       assert.eventually.isFalse(
         waitFor(TYPING_DEBOUNCE_DELAY, clock).
-          then(() => store.getState().ui.getIn(['editors', 'typing']))
+          then(() => store.getState().getIn(['ui', 'editors', 'typing']))
       )
     );
 
@@ -57,7 +57,7 @@ describe('interfaceStateActions', () => {
         waitFor(TYPING_DEBOUNCE_DELAY * 0.8, clock).then(() => {
           store.dispatch(userTyped());
           return waitFor(TYPING_DEBOUNCE_DELAY * 0.9, clock).then(() =>
-            store.getState().ui.getIn(['editors', 'typing'])
+            store.getState().getIn(['ui', 'editors', 'typing'])
           );
         })
       )
@@ -71,7 +71,9 @@ describe('interfaceStateActions', () => {
 
     it('sets requestedFocusedLine to given value', () => {
       assert.deepEqual(
-        store.getState().ui.getIn(['editors', 'requestedFocusedLine']).toJS(),
+        store.getState().getIn(
+          ['ui', 'editors', 'requestedFocusedLine']
+        ).toJS(),
         {language: 'javascript', line: 4, column: 2}
       );
     });
@@ -85,7 +87,7 @@ describe('interfaceStateActions', () => {
 
     it('sets requestedFocusedLine to null', () => {
       assert.isNull(
-        store.getState().ui.getIn(['editors', 'requestedFocusedLine']),
+        store.getState().getIn(['ui', 'editors', 'requestedFocusedLine']),
       );
     });
   });
@@ -95,7 +97,7 @@ describe('interfaceStateActions', () => {
       store.dispatch(notificationTriggered('some-error', 'error'));
 
       assert.include(
-        store.getState().ui.get('notifications').toJSON(),
+        store.getState().getIn(['ui', 'notifications']).toJSON(),
         {type: 'some-error', severity: 'error', payload: {}},
       );
     });
@@ -108,7 +110,7 @@ describe('interfaceStateActions', () => {
       );
 
       assert.include(
-        store.getState().ui.get('notifications').toJSON(),
+        store.getState().getIn(['ui', 'notifications']).toJSON(),
         {type: 'some-error', severity: 'error', payload: {spooky: true}},
       );
     });
@@ -122,7 +124,7 @@ describe('interfaceStateActions', () => {
 
     it('removes notifications of given type', () => {
       assert.notInclude(
-        store.getState().ui.get('notifications').map(
+        store.getState().getIn(['ui', 'notifications']).map(
           (notification) => notification.get('type')
         ),
         'some-error'

--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -97,41 +97,41 @@ describe('user actions', () => {
 
     function itShouldLogUserIn() {
       it('should set user state to authenticated', () => {
-        assert.isTrue(store.getState().user.get('authenticated'));
+        assert.isTrue(store.getState().getIn(['user', 'authenticated']));
       });
 
       it('should set user id to uid', () => {
-        assert.equal(store.getState().user.get('id'), userData.uid);
+        assert.equal(store.getState().getIn(['user', 'id']), userData.uid);
       });
 
       it('should set provider to github', () => {
-        assert.equal(store.getState().user.get('provider'), 'github');
+        assert.equal(store.getState().getIn(['user', 'provider']), 'github');
       });
 
       it('should set display name', () => {
         assert.equal(
-          store.getState().user.get('displayName'),
+          store.getState().getIn(['user', 'displayName']),
           userData.github.displayName
         );
       });
 
       it('should set username', () => {
         assert.equal(
-          store.getState().user.get('username'),
+          store.getState().getIn(['user', 'username']),
           userData.github.username
         );
       });
 
       it('should set avatarUrl', () => {
         assert.equal(
-          store.getState().user.get('avatarUrl'),
+          store.getState().getIn(['user', 'avatarUrl']),
           userData.github.profileImageURL
         );
       });
 
       it('should set auth token', () => {
         assert.equal(
-          store.getState().user.getIn(['accessTokens', 'github']),
+          store.getState().getIn(['user', 'accessTokens', 'github']),
           userData.github.accessToken,
         );
       });
@@ -152,11 +152,11 @@ describe('user actions', () => {
     });
 
     it('should set authenticated to false', () => {
-      assert.isFalse(store.getState().user.get('authenticated'));
+      assert.isFalse(store.getState().getIn(['user', 'authenticated']));
     });
 
     it('should set user id to null', () => {
-      assert.isUndefined(store.getState().user.get('id'));
+      assert.isUndefined(store.getState().getIn(['user', 'id']));
     });
 
     it('should create a fresh project', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -29,7 +29,7 @@ import {
 import Analyzer from '../analyzers';
 
 function getCurrentPersistor(state) {
-  const currentUser = state.user;
+  const currentUser = state.get('user');
   if (currentUser.get('authenticated')) {
     return new FirebasePersistor(currentUser.get('id'));
   }
@@ -37,9 +37,9 @@ function getCurrentPersistor(state) {
 }
 
 export function getCurrentProject(state) {
-  const projectKey = state.currentProject.get('projectKey');
+  const projectKey = state.getIn(['currentProject', 'projectKey']);
   if (projectKey) {
-    return state.projects.get(projectKey);
+    return state.getIn(['projects', projectKey]);
   }
 
   return null;

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -67,19 +67,19 @@ const spinnerPage = base64.fromByteArray(
 
 function mapStateToProps(state) {
   const projects = sortBy(
-    values(state.projects.toJS()),
+    values(state.get('projects').toJS()),
     (project) => -project.updatedAt
   );
 
   return {
     allProjects: projects,
     currentProject: getCurrentProject(state),
-    errors: state.errors.toJS(),
-    runtimeErrors: state.runtimeErrors.toJS(),
-    isUserTyping: state.ui.getIn(['editors', 'typing']),
-    currentUser: state.user.toJS(),
-    ui: state.ui.toJS(),
-    clients: state.clients.toJS(),
+    errors: state.get('errors').toJS(),
+    runtimeErrors: state.get('runtimeErrors').toJS(),
+    isUserTyping: state.getIn(['ui', 'editors', 'typing']),
+    currentUser: state.get('user').toJS(),
+    ui: state.get('ui').toJS(),
+    clients: state.get('clients').toJS(),
   };
 }
 

--- a/src/createApplicationStore.js
+++ b/src/createApplicationStore.js
@@ -1,3 +1,4 @@
+import Immutable from 'immutable';
 import {createStore, applyMiddleware} from 'redux';
 import reducers from './reducers';
 import thunkMiddleware from 'redux-thunk';
@@ -16,7 +17,7 @@ createStoreWithMiddleware =
   applyMiddleware(thunkMiddleware)(createStoreWithMiddleware);
 
 function createApplicationStore() {
-  return createStoreWithMiddleware(reducers);
+  return createStoreWithMiddleware(reducers, new Immutable.Map());
 }
 
 export default createApplicationStore;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,4 @@
-import {combineReducers} from 'redux';
+import {combineReducers} from 'redux-immutable';
 import user from './user';
 import projects from './projects';
 import currentProject from './currentProject';

--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -1,4 +1,5 @@
 import 'bugsnag-js';
+import getCurrentProject from './projectUtils';
 import isError from 'lodash/isError';
 import isString from 'lodash/isString';
 import config from '../config';
@@ -11,15 +12,15 @@ Bugsnag.appVersion = config.gitRevision;
 export function includeStoreInBugReports(store) {
   Bugsnag.beforeNotify = (payload) => {
     const state = store.getState();
-    if (state.user) {
-      payload.user = state.user.toJS();
+    if (state.get('user')) {
+      payload.user = state.get('user').toJS();
     } else {
       payload.user = {id: 'anonymous'};
     }
 
-    if (state.currentProject && state.currentProject.get('projectKey')) {
-      payload.metaData.currentProject =
-        state.projects.get(state.currentProject.get('projectKey')).toJS();
+    const currentProject = getCurrentProject(state);
+    if (currentProject) {
+      payload.metaData.currentProject = currentProject;
     }
   };
 }

--- a/src/util/projectUtils.js
+++ b/src/util/projectUtils.js
@@ -1,13 +1,13 @@
 import {Map} from 'immutable';
 
 export function getProjectKeys(state) {
-  return Array.from(state.projects.keys());
+  return Array.from(state.get('projects').keys());
 }
 
 export function getCurrentProject(state) {
-  const projectKey = state.currentProject.get('projectKey');
+  const projectKey = state.getIn(['currentProject', 'projectKey']);
   if (projectKey) {
-    return state.projects.get(projectKey).toJS();
+    return state.getIn(['projects', projectKey]).toJS();
   }
   return null;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,7 +3636,7 @@ immutable-devtools@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/immutable-devtools/-/immutable-devtools-0.0.7.tgz#da0fbdd860c3a8a598967fc544bb0329ec3ad26e"
 
-immutable@3.8.1, immutable@^3.7.5, immutable@^3.7.6:
+immutable@3.8.1, immutable@^3.7.5, immutable@^3.7.6, immutable@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
 
@@ -6150,6 +6150,12 @@ redux-actions@^0.12.0:
   dependencies:
     lodash "^4.13.1"
     reduce-reducers "^0.1.0"
+
+redux-immutable@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/redux-immutable/-/redux-immutable-3.0.11.tgz#ba7b00361904f2034e7841741bd4a6be66eea1ac"
+  dependencies:
+    immutable "^3.8.1"
 
 redux-logger@^2.5.0:
   version "2.7.4"


### PR DESCRIPTION
To date we have used the built-in `combineReducers` from Redux to put together the output of different reducers into the single top-level store state. However, this creates an awkward shape for the state, namely that the top-level state is a plain JavaScript object, and all of its properties are Immutable objects.

Instead, use `redux-immutable`, which provides an implementation of `combineReducers` that merges subtrees into an Immutable Map, rather than a plain object. This creates a much more consistent situation where the entire state tree is Immutable.

This has been bothering me for a while.