### PR TITLE
Always keep current project on login

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -39,8 +39,8 @@ parts that seem relevant to your code changes.
 
 ### Login
 
-* Open a fresh Popcode environment, and log in. Verify that the project that
-  appears is the last one you were working on while logged in.
+* Open a fresh Popcode environment, and log in. Verify that current project is
+  still a new, blank template.
 * Open a fresh Popcode environment, and add something to the HTML. Then log in.
   Verify that the code you were just working on is still on screen.
 * Log out, then log back in. Verify that after logging back in, the code on

--- a/spec/examples/actions/bootstrap.spec.js
+++ b/spec/examples/actions/bootstrap.spec.js
@@ -86,17 +86,10 @@ describe('bootstrap', () => {
           return dispatchBootstrap();
         });
 
-        it('should set current project from Firebase', () => {
-          assert.equal(
+        it('should create a new current project', () => {
+          assert.notEqual(
             store.getState().getIn(['currentProject', 'projectKey']),
             project.projectKey
-          );
-        });
-
-        it('should validate the project', () => {
-          assert.notEqual(
-            store.getState().get('errors').first().get('state'),
-            'passed'
           );
         });
       });

--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -28,7 +28,7 @@ describe('user actions', () => {
   const userData = createUser();
 
   describe('logIn', () => {
-    let storedProject;
+    let storedProject, localProjectKey;
 
     beforeEach(() => {
       storedProject = buildProject({sources: {html: 'bogus<'}});
@@ -38,6 +38,7 @@ describe('user actions', () => {
 
     context('with locally pristine project', () => {
       beforeEach(() => {
+        localProjectKey = getCurrentProject(store.getState()).projectKey;
         mockFirebase.logIn(userData.uid);
       });
 
@@ -49,10 +50,10 @@ describe('user actions', () => {
 
         itShouldLogUserIn();
 
-        it('should set project to stored project', () => {
+        it('should keep pristine project in scope', () => {
           assert.equal(
             getCurrentProject(store.getState()).projectKey,
-            storedProject.projectKey
+            localProjectKey
           );
         });
       });
@@ -63,15 +64,18 @@ describe('user actions', () => {
           return dispatchAndWait(store, logIn(userData));
         });
 
-        it('should create fresh project', () => {
-          assert.isNotNull(getCurrentProject(store.getState()).projectKey);
+        itShouldLogUserIn();
+
+        it('should keep pristine project in scope', () => {
+          assert.equal(
+            getCurrentProject(store.getState()).projectKey,
+            localProjectKey
+          );
         });
       });
     });
 
     context('with locally modified project', () => {
-      let localProjectKey;
-
       beforeEach(() => {
         mockFirebase.logIn(userData.uid);
         createAndMutateProject(store);
@@ -86,7 +90,7 @@ describe('user actions', () => {
 
         itShouldLogUserIn();
 
-        it('should set project to stored project', () => {
+        it('should keep local project in scope', () => {
           assert.equal(
             getCurrentProject(store.getState()).projectKey,
             localProjectKey

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -1,8 +1,7 @@
 import {createAction} from 'redux-actions';
 import identity from 'lodash/identity';
-import FirebasePersistor from '../persistors/FirebasePersistor';
 import {loadAllProjects, saveCurrentProject} from '.';
-import {createProject, loadCurrentProject} from './projects';
+import {createProject} from './projects';
 
 export const userAuthenticated = createAction(
   'USER_AUTHENTICATED',
@@ -16,12 +15,7 @@ const userLoggedOut = createAction('USER_LOGGED_OUT');
 export function logIn(userData) {
   return (dispatch, getState) => {
     dispatch(userAuthenticated({userData}));
-
-    if (!saveCurrentProject(getState())) {
-      dispatch(resetWorkspace());
-      dispatch(setCurrentProjectAfterLogin(userData.uid));
-    }
-
+    saveCurrentProject(getState());
     dispatch(loadAllProjects());
   };
 }
@@ -31,18 +25,5 @@ export function logOut() {
     dispatch(resetWorkspace());
     dispatch(userLoggedOut());
     dispatch(createProject());
-  };
-}
-
-function setCurrentProjectAfterLogin(uid) {
-  return (dispatch) => {
-    const persistor = new FirebasePersistor(uid);
-    persistor.loadCurrentProject().then((project) => {
-      if (project) {
-        dispatch(loadCurrentProject(project));
-      } else {
-        dispatch(createProject());
-      }
-    });
   };
 }


### PR DESCRIPTION
As the first step in introducing an invariant that changing login state does not affect the current project, remove the logic that under some circumstances changes the current project when logging in. In particular, if no changes had been made to the blank current project before logging in, Popcode would automatically load the last project the user had worked on as the current project.

Now, if you open Popcode and are already logged in, you will always see a blank project. If you log in explicitly, you will always see the project that was on the screen before logging in, even if it is an
untouched blank project.

This simplifies the behavior and code, and makes for an easier mental model of Popcode’s behavior.

See #635 for further discussion and motivation