### PR TITLE
Upgrade to Firebase SDK 3

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -43,9 +43,12 @@ parts that seem relevant to your code changes.
   still a new, blank template.
 * Open a fresh Popcode environment, and add something to the HTML. Then log in.
   Verify that the code you were just working on is still on screen.
-* Log out, then log back in. Verify that after logging back in, the code on
-  screen is as you left it.
-* Create a new project. Verify that the code on screen is now the defaults.
+* Open a second Popcode tab. Verify that you are are logged in, and looking at
+  a fresh project.
+* Modify the project, and then log out. Verify that you are logged out in both
+  tabs, and both tabs still have the same project as before.
+* Log back in. Create a new project. Verify that the code on screen is now the
+  defaults.
 * Click on “Load Project”, and verify that you can go back to the project you
   were working on before you clicked “New Project”
 

--- a/config/firebase-auth.json
+++ b/config/firebase-auth.json
@@ -5,6 +5,12 @@
         ".read": "$user_id === auth.uid",
         ".write": "$user_id === auth.uid"
       }
+    },
+    "authTokens": {
+      "$user_id": {
+        ".read": "$user_id === auth.uid",
+        ".write": "$user_id === auth.uid"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "htmllint": "^0.4.0",
     "i18next-client": "^1.10.2",
     "immutable": "^3.7.5",
+    "js-cookie": "^2.1.3",
     "jshint": "^2.9.3",
     "keymirror": "^0.1.1",
     "lodash": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "envify": "^3.4.1",
     "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
     "esprima": "^3.0.0",
-    "firebase": "^2.4.1",
+    "firebase": "^3.6.9",
     "github-api": "git+https://github.com/michael/github.git#v2.4.0",
     "html-inspector": "^0.8.2",
     "htmllint": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "redux-immutable": "^3.0.11",
     "redux-logger": "^2.5.0",
     "redux-thunk": "^2.1.0",
+    "rxjs": "^5.0.2",
     "slowparse": "^1.1.4",
     "stylelint": "^7.5.0",
     "text-encoding": "^0.6.0"

--- a/spec/examples/actions/bootstrap.spec.js
+++ b/spec/examples/actions/bootstrap.spec.js
@@ -58,7 +58,7 @@ describe('bootstrap', () => {
     context('when auth resolves logged in', () => {
       const uid = '123';
 
-      context('no credential in sessionStorage', () => {
+      context('no credential in Firebase', () => {
         beforeEach(() => {
           mockFirebase.logIn(uid);
           mockFirebase._setValue(`authTokens/${uid}/github_com`, null);
@@ -77,18 +77,7 @@ describe('bootstrap', () => {
         );
       });
 
-      context('current project in Firebase', () => {
-        let project;
-
-        beforeEach(() => {
-          project = buildProject({sources: {html: 'bogus<'}});
-          mockFirebase.logIn(uid);
-          mockFirebase.setCurrentProject(project);
-          return dispatchBootstrap();
-        });
-      });
-
-      context('credential in sessionStorage', () => {
+      context('credential in Firebase', () => {
         let credential;
 
         context('no current project in Firebase', () => {

--- a/spec/examples/actions/bootstrap.spec.js
+++ b/spec/examples/actions/bootstrap.spec.js
@@ -9,7 +9,7 @@ import MockFirebase from '../../helpers/MockFirebase';
 import MockGitHub from '../../helpers/MockGitHub';
 import buildProject from '../../helpers/buildProject';
 import buildGist from '../../helpers/buildGist';
-import promiseTicks from '../../helpers/promiseTicks';
+import waitForAsync from '../../helpers/waitForAsync';
 import {getCurrentProject} from '../../../src/util/projectUtils';
 import createApplicationStore from '../../../src/createApplicationStore';
 
@@ -266,6 +266,6 @@ describe('bootstrap', () => {
 
   function dispatchBootstrap(gistId) {
     store.dispatch(bootstrap(gistId));
-    return promiseTicks(20);
+    return waitForAsync();
   }
 });

--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -3,7 +3,7 @@
 
 import '../../helper';
 import MockFirebase from '../../helpers/MockFirebase';
-import {createUser} from '../../helpers/MockFirebase';
+import {createUser, createCredentials} from '../../helpers/MockFirebase';
 import {assert} from 'chai';
 import dispatchAndWait from '../../helpers/dispatchAndWait';
 import buildProject from '../../helpers/buildProject';
@@ -26,6 +26,7 @@ describe('user actions', () => {
   });
 
   const userData = createUser();
+  const credentials = createCredentials();
 
   describe('logIn', () => {
     let storedProject, localProjectKey;
@@ -45,7 +46,7 @@ describe('user actions', () => {
       context('with stored project', () => {
         beforeEach(() => {
           mockFirebase.setCurrentProject(storedProject);
-          return dispatchAndWait(store, logIn(userData));
+          return dispatchAndWait(store, logIn(userData, credentials));
         });
 
         itShouldLogUserIn();
@@ -61,7 +62,7 @@ describe('user actions', () => {
       context('without stored project', () => {
         beforeEach(() => {
           mockFirebase.setCurrentProject(null);
-          return dispatchAndWait(store, logIn(userData));
+          return dispatchAndWait(store, logIn(userData, credentials));
         });
 
         itShouldLogUserIn();
@@ -85,7 +86,7 @@ describe('user actions', () => {
       context('with stored project', () => {
         beforeEach(() => {
           mockFirebase.setCurrentProject(storedProject);
-          return dispatchAndWait(store, logIn(userData));
+          return dispatchAndWait(store, logIn(userData, credentials));
         });
 
         itShouldLogUserIn();
@@ -108,35 +109,24 @@ describe('user actions', () => {
         assert.equal(store.getState().getIn(['user', 'id']), userData.uid);
       });
 
-      it('should set provider to github', () => {
-        assert.equal(store.getState().getIn(['user', 'provider']), 'github');
-      });
-
       it('should set display name', () => {
         assert.equal(
           store.getState().getIn(['user', 'displayName']),
-          userData.github.displayName
-        );
-      });
-
-      it('should set username', () => {
-        assert.equal(
-          store.getState().getIn(['user', 'username']),
-          userData.github.username
+          userData.displayName
         );
       });
 
       it('should set avatarUrl', () => {
         assert.equal(
           store.getState().getIn(['user', 'avatarUrl']),
-          userData.github.profileImageURL
+          userData.photoURL
         );
       });
 
       it('should set auth token', () => {
         assert.equal(
-          store.getState().getIn(['user', 'accessTokens', 'github']),
-          userData.github.accessToken,
+          store.getState().getIn(['user', 'accessTokens', 'github.com']),
+          credentials.accessToken
         );
       });
     }

--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -3,7 +3,7 @@
 
 import '../../helper';
 import MockFirebase from '../../helpers/MockFirebase';
-import {createUser, createCredentials} from '../../helpers/MockFirebase';
+import {createUser, createCredential} from '../../helpers/MockFirebase';
 import {assert} from 'chai';
 import dispatchAndWait from '../../helpers/dispatchAndWait';
 import buildProject from '../../helpers/buildProject';
@@ -25,8 +25,8 @@ describe('user actions', () => {
     sandbox.restore();
   });
 
-  const userData = createUser();
-  const credentials = createCredentials();
+  const user = createUser();
+  const credential = createCredential();
 
   describe('logIn', () => {
     let storedProject, localProjectKey;
@@ -40,13 +40,13 @@ describe('user actions', () => {
     context('with locally pristine project', () => {
       beforeEach(() => {
         localProjectKey = getCurrentProject(store.getState()).projectKey;
-        mockFirebase.logIn(userData.uid);
+        mockFirebase.logIn(user.uid);
       });
 
       context('with stored project', () => {
         beforeEach(() => {
           mockFirebase.setCurrentProject(storedProject);
-          return dispatchAndWait(store, logIn(userData, credentials));
+          return dispatchAndWait(store, logIn(user, credential));
         });
 
         itShouldLogUserIn();
@@ -62,7 +62,7 @@ describe('user actions', () => {
       context('without stored project', () => {
         beforeEach(() => {
           mockFirebase.setCurrentProject(null);
-          return dispatchAndWait(store, logIn(userData, credentials));
+          return dispatchAndWait(store, logIn(user, credential));
         });
 
         itShouldLogUserIn();
@@ -78,7 +78,7 @@ describe('user actions', () => {
 
     context('with locally modified project', () => {
       beforeEach(() => {
-        mockFirebase.logIn(userData.uid);
+        mockFirebase.logIn(user.uid);
         createAndMutateProject(store);
         localProjectKey = getCurrentProject(store.getState()).projectKey;
       });
@@ -86,7 +86,7 @@ describe('user actions', () => {
       context('with stored project', () => {
         beforeEach(() => {
           mockFirebase.setCurrentProject(storedProject);
-          return dispatchAndWait(store, logIn(userData, credentials));
+          return dispatchAndWait(store, logIn(user, credential));
         });
 
         itShouldLogUserIn();
@@ -106,27 +106,27 @@ describe('user actions', () => {
       });
 
       it('should set user id to uid', () => {
-        assert.equal(store.getState().getIn(['user', 'id']), userData.uid);
+        assert.equal(store.getState().getIn(['user', 'id']), user.uid);
       });
 
       it('should set display name', () => {
         assert.equal(
           store.getState().getIn(['user', 'displayName']),
-          userData.displayName
+          user.displayName
         );
       });
 
       it('should set avatarUrl', () => {
         assert.equal(
           store.getState().getIn(['user', 'avatarUrl']),
-          userData.photoURL
+          user.photoURL
         );
       });
 
       it('should set auth token', () => {
         assert.equal(
           store.getState().getIn(['user', 'accessTokens', 'github.com']),
-          credentials.accessToken
+          credential.accessToken
         );
       });
     }
@@ -136,7 +136,7 @@ describe('user actions', () => {
     let loggedInProjectKey;
 
     beforeEach(() => {
-      mockFirebase.logIn(userData.uid);
+      mockFirebase.logIn(user.uid);
       mockFirebase.setCurrentProject(null);
       return dispatchAndWait(store, bootstrap()).then(() => {
         createAndMutateProject(store);

--- a/spec/helpers/MockFirebase.js
+++ b/spec/helpers/MockFirebase.js
@@ -9,6 +9,7 @@ import {
   database,
   githubAuthProvider,
 } from '../../src/services/appFirebase';
+import {setSessionUid} from '../../src/clients/firebaseAuth';
 
 export function createUser(user) {
   return merge({
@@ -77,13 +78,16 @@ export default class MockFirebase {
     const credential = createCredential();
     this._currentUid = uid;
     this.setCurrentUserCredential();
+    Reflect.defineProperty(auth, 'currentUser', {value: user});
     auth.onAuthStateChanged.yieldsAsync(user);
+    setSessionUid();
     return {user, credential};
   }
 
   logOut() {
     this._currentUid = null;
     auth.onAuthStateChanged.yieldsAsync(null);
+    Reflect.defineProperty(auth, 'currentUser', {value: null});
   }
 
   setCurrentUserCredential(credential = createCredential()) {

--- a/spec/helpers/MockFirebase.js
+++ b/spec/helpers/MockFirebase.js
@@ -25,7 +25,7 @@ export function createUser(user) {
   }, user);
 }
 
-export function createCredentials() {
+export function createCredential() {
   return {
     accessToken: '0123456789abcdef',
     provider: 'github.com',
@@ -69,16 +69,25 @@ export default class MockFirebase {
     const rootRef = new MockRef(this._data);
     sandbox.stub(database, 'ref', (path) => rootRef.child(path));
     auth.onAuthStateChanged.returns(sinon.stub());
+    auth.signOut.returns(Promise.resolve());
   }
 
   logIn(uid) {
+    const user = createUser({uid});
+    const credential = createCredential();
     this._currentUid = uid;
-    auth.onAuthStateChanged.yieldsAsync(createUser({uid}));
+    this.setCurrentUserCredential();
+    auth.onAuthStateChanged.yieldsAsync(user);
+    return {user, credential};
   }
 
   logOut() {
     this._currentUid = null;
     auth.onAuthStateChanged.yieldsAsync(null);
+  }
+
+  setCurrentUserCredential(credential = createCredential()) {
+    this._setValue(`authTokens/${this._currentUid}/github_com`, credential);
   }
 
   setCurrentProject(currentProject) {

--- a/spec/helpers/MockFirebase.js
+++ b/spec/helpers/MockFirebase.js
@@ -1,65 +1,106 @@
 /* global sinon */
 
-import appFirebase from '../../src/services/appFirebase';
+import get from 'lodash/get';
 import merge from 'lodash/merge';
+import noop from 'lodash/noop';
+import setWith from 'lodash/setWith';
+import {
+  auth,
+  database,
+  githubAuthProvider,
+} from '../../src/services/appFirebase';
 
 export function createUser(user) {
   return merge({
-    github: {
-      accessToken: 'abc123',
+    displayName: 'Popcode User',
+    photoURL: 'https://camo.github.com/popcodeuser.jpg',
+    providerData: [{
       displayName: 'Popcode User',
-      profileImageURL: 'https://camo.github.com/popcodeuser.jpg',
-      username: 'popcodeuser',
-    },
-    provider: 'github',
-    uid: '123',
+      email: 'popcodeuser@example.com',
+      photoURL: 'https://camo.github.com/popcodeuser.jpg',
+      providerId: 'github.com',
+      uid: '345',
+    }],
+    uid: 'abc123',
   }, user);
+}
+
+export function createCredentials() {
+  return {
+    accessToken: '0123456789abcdef',
+    provider: 'github.com',
+  };
+}
+
+class MockRef {
+  constructor(rootTree, path = []) {
+    this._rootTree = rootTree;
+    this._path = path;
+    Object.assign(this, {
+      set: sinon.mock(),
+      setWithPriority: sinon.mock(),
+    });
+  }
+
+  child(pathString) {
+    return new MockRef(
+      this._rootTree,
+      this._path.concat(pathString.split('/'))
+    );
+  }
+
+  once(event) {
+    if (event === 'value') {
+      return Promise.resolve({val: () => this._value});
+    }
+    return new Promise(noop);
+  }
+
+  get _value() {
+    return get(this._rootTree, this._path);
+  }
 }
 
 export default class MockFirebase {
   constructor(sandbox) {
-    sandbox.stub(appFirebase);
+    sandbox.stub(auth);
+    sandbox.stub(githubAuthProvider);
+    this._data = {};
+    const rootRef = new MockRef(this._data);
+    sandbox.stub(database, 'ref', (path) => rootRef.child(path));
+    auth.onAuthStateChanged.returns(sinon.stub());
   }
 
   logIn(uid) {
-    this._userSpace = addChild(appFirebase, `workspaces/${uid}`);
-    addChild(this._userSpace, 'currentProjectKey');
-    addChild(this._userSpace, 'projects');
-    appFirebase.onAuth.yields(createUser({uid}));
+    this._currentUid = uid;
+    auth.onAuthStateChanged.yieldsAsync(createUser({uid}));
   }
 
   logOut() {
-    this._userSpace = null;
-    appFirebase.onAuth.yields(null);
+    this._currentUid = null;
+    auth.onAuthStateChanged.yieldsAsync(null);
   }
 
   setCurrentProject(currentProject) {
+    let workspace;
     if (currentProject === null) {
-      yieldsValue(this._userSpace.child('currentProjectKey'), null);
-      return;
+      workspace = {
+        currentProjectKey: null,
+        projects: {},
+      };
+    } else {
+      workspace = {
+        currentProjectKey: currentProject.projectKey,
+        projects: {
+          [currentProject.projectKey]: currentProject,
+        },
+      };
     }
 
-    const storedProjectKey =
-      addChild(this._userSpace.child('projects'), currentProject.projectKey);
-
-    yieldsValue(
-      this._userSpace.child('currentProjectKey'),
-      currentProject.projectKey
-    );
-    yieldsValue(storedProjectKey, currentProject);
+    this._setValue(`workspaces/${this._currentUid}`, workspace);
   }
-}
 
-function addChild(firebaseKey, childName) {
-  const childKey = {
-    child: sinon.stub(),
-    once: sinon.stub(),
-  };
-  firebaseKey.child.withArgs(childName).returns(childKey);
-  return childKey;
-}
-
-function yieldsValue(firebaseKey, value) {
-  firebaseKey.once.withArgs('value').callsArgWith(1, {val: () => value});
-  return Promise.resolve(value);
+  _setValue(path, value) {
+    setWith(this._data, path.split('/'), value, Object);
+  }
 }

--- a/spec/helpers/dispatchAndWait.js
+++ b/spec/helpers/dispatchAndWait.js
@@ -1,7 +1,7 @@
-import promiseTicks from './promiseTicks';
+import waitForAsync from './waitForAsync';
 
 export default function dispatchAndWait(store, action) {
   store.dispatch(action);
-  return promiseTicks(20);
+  return waitForAsync();
 }
 

--- a/spec/helpers/promiseTicks.js
+++ b/spec/helpers/promiseTicks.js
@@ -1,6 +1,0 @@
-export default function promiseTicks(n) {
-  if (n === 0) {
-    return Promise.resolve();
-  }
-  return Promise.resolve().then(() => promiseTicks(n - 1));
-}

--- a/spec/helpers/waitForAsync.js
+++ b/spec/helpers/waitForAsync.js
@@ -1,0 +1,3 @@
+export default function waitForAsync() {
+  return new Promise((resolve) => setTimeout(resolve));
+}

--- a/src/actions/bootstrap.js
+++ b/src/actions/bootstrap.js
@@ -12,13 +12,12 @@ import {notificationTriggered} from './ui';
 
 export default function bootstrap(gistId) {
   return (dispatch) => {
-    const userStateResolved =
-      getInitialUserState().then((userCredential) => {
-        if (userCredential) {
-          dispatch(userAuthenticated(userCredential));
-          dispatch(loadAllProjects());
-        }
-      });
+    const userStateResolved = getInitialUserState().then((userCredential) => {
+      if (userCredential) {
+        dispatch(userAuthenticated(userCredential));
+        dispatch(loadAllProjects());
+      }
+    });
 
     const promisedGist = retrieveGist(gistId).catch((error) => {
       dispatch(notificationTriggered(error, 'error', {gistId}));

--- a/src/actions/bootstrap.js
+++ b/src/actions/bootstrap.js
@@ -1,5 +1,5 @@
 import get from 'lodash/get';
-import appFirebase from '../services/appFirebase';
+import {auth} from '../services/appFirebase';
 import Gists from '../services/Gists';
 import Bugsnag from '../util/Bugsnag';
 import {
@@ -51,10 +51,9 @@ function retrieveGist(gistId) {
 
 function oneAuth() {
   return new Promise((resolve) => {
-    function handleAuth(userData) {
+    const offAuth = auth.onAuthStateChanged((userData) => {
       resolve(userData);
-      appFirebase.offAuth(handleAuth);
-    }
-    appFirebase.onAuth(handleAuth);
+      offAuth();
+    });
   });
 }

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -11,9 +11,9 @@ const resetWorkspace = createAction('RESET_WORKSPACE', identity);
 
 const userLoggedOut = createAction('USER_LOGGED_OUT');
 
-export function logIn(userData, credentials) {
+export function logIn(user, credential) {
   return (dispatch, getState) => {
-    dispatch(userAuthenticated({userData, credentials}));
+    dispatch(userAuthenticated({user, credential}));
     saveCurrentProject(getState());
     dispatch(loadAllProjects());
   };

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -11,9 +11,9 @@ const resetWorkspace = createAction('RESET_WORKSPACE', identity);
 
 const userLoggedOut = createAction('USER_LOGGED_OUT');
 
-export function logIn(userData) {
+export function logIn(userData, credentials) {
   return (dispatch, getState) => {
-    dispatch(userAuthenticated({userData}));
+    dispatch(userAuthenticated({userData, credentials}));
     saveCurrentProject(getState());
     dispatch(loadAllProjects());
   };

--- a/src/clients/firebaseAuth.js
+++ b/src/clients/firebaseAuth.js
@@ -1,0 +1,69 @@
+import isNil from 'lodash/isNil';
+import isNull from 'lodash/isNull';
+import {Observable} from '../services/rxjs';
+import {auth, database, githubAuthProvider} from '../services/appFirebase';
+
+const loginStateSource = Observable.create((observer) => {
+  auth.onAuthStateChanged(observer.next.bind(observer));
+}).switchMap((user) => {
+  if (isNull(user)) {
+    return Observable.of(null);
+  }
+
+  return Observable.fromPromise(userCredentialForUserData(user));
+});
+
+const [logOutSource, logInSource] = loginStateSource.skip(1).partition(isNull);
+
+function userCredentialForUserData(user) {
+  return database.ref(`authTokens/${user.uid}/github_com`).
+    once('value').then((snapshot) => {
+      const credential = snapshot.val();
+      if (isNil(credential)) {
+        return auth.signOut().then(() => null);
+      }
+
+      return {user, credential};
+    });
+}
+
+export function getInitialUserState() {
+  return oneAuth().then((userCredential) => {
+    if (!isNull(userCredential) && isNull(userCredential.credential)) {
+      return auth.signOut().then(() => null);
+    }
+
+    return userCredential;
+  });
+}
+
+export function onSignedIn(handler) {
+  logInSource.subscribe(handler);
+}
+
+export function onSignedOut(handler) {
+  logOutSource.subscribe(handler);
+}
+
+export function signIn() {
+  return auth.signInWithPopup(githubAuthProvider).then(
+    (userCredential) => {
+      saveCredentials(userCredential.user.uid, userCredential.credential);
+      return userCredential;
+    }
+  );
+}
+
+export function signOut() {
+  return auth.signOut();
+}
+
+export function saveCredentials(uid, credential) {
+  database.
+    ref(`authTokens/${uid}/${credential.provider.replace('.', '_')}`).
+    set(credential);
+}
+
+function oneAuth() {
+  return loginStateSource.first().toPromise();
+}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -12,7 +12,7 @@ class Dashboard extends React.Component {
     const currentUser = this.props.currentUser;
 
     if (currentUser.authenticated) {
-      const name = currentUser.displayName || currentUser.username;
+      const name = currentUser.displayName;
 
       return (
         <div className="dashboard__session">

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -17,8 +17,13 @@ import path from 'path';
 import base64 from 'base64-js';
 import {TextEncoder} from 'text-encoding';
 import Bugsnag from '../util/Bugsnag';
-import {auth, githubAuthProvider} from '../services/appFirebase';
 import Gists from '../services/Gists';
+import {
+  onSignedIn,
+  onSignedOut,
+  signIn,
+  signOut,
+} from '../clients/firebaseAuth';
 import {EmptyGistError} from '../services/Gists';
 import {openWindowWithWorkaroundForChromeClosingBug} from '../util';
 
@@ -116,6 +121,7 @@ class Workspace extends React.Component {
     }
     history.replaceState({}, '', location.pathname);
     this.props.dispatch(bootstrap(gistId));
+    this._listenForAuthChange();
   }
 
   componentDidMount() {
@@ -278,28 +284,29 @@ class Workspace extends React.Component {
     this.props.dispatch(toggleDashboard());
   }
 
+  _listenForAuthChange() {
+    onSignedIn(({user, credential}) =>
+      this.props.dispatch(logIn(user, credential))
+    );
+    onSignedOut(() => this.props.dispatch(logOut()));
+  }
+
   _handleStartLogIn() {
-    auth.signInWithPopup(githubAuthProvider).then(
-      ({user, credential}) => {
-        this.props.dispatch(logIn(user, credential));
-      },
-      (e) => {
-        switch (e.code) {
-          case 'USER_CANCELLED':
-            this.props.dispatch(
-              notificationTriggered('user-cancelled-auth')
-            );
-            break;
-          default:
-            this.props.dispatch(notificationTriggered('auth-error'));
-            if (isError(e)) {
-              Bugsnag.notifyException(e, e.code);
-            } else if (isString(e)) {
-              Bugsnag.notifyException(new Error(e));
-            }
-            break;
-        }
-      });
+    signIn().catch((e) => {
+      switch (e.code) {
+        case 'auth/popup-closed-by-user':
+          this.props.dispatch(notificationTriggered('user-cancelled-auth'));
+          break;
+        default:
+          this.props.dispatch(notificationTriggered('auth-error'));
+          if (isError(e)) {
+            Bugsnag.notifyException(e, e.code);
+          } else if (isString(e)) {
+            Bugsnag.notifyException(new Error(e));
+          }
+          break;
+      }
+    });
   }
 
   _handleNotificationDismissed(error) {
@@ -307,7 +314,7 @@ class Workspace extends React.Component {
   }
 
   _handleLogOut() {
-    auth.signOut().then(() => this.props.dispatch(logOut()));
+    signOut();
   }
 
   _handleRequestedLineFocused() {

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -17,7 +17,7 @@ import path from 'path';
 import base64 from 'base64-js';
 import {TextEncoder} from 'text-encoding';
 import Bugsnag from '../util/Bugsnag';
-import appFirebase from '../services/appFirebase';
+import {auth, githubAuthProvider} from '../services/appFirebase';
 import Gists from '../services/Gists';
 import {EmptyGistError} from '../services/Gists';
 import {openWindowWithWorkaroundForChromeClosingBug} from '../util';
@@ -279,12 +279,9 @@ class Workspace extends React.Component {
   }
 
   _handleStartLogIn() {
-    appFirebase.authWithOAuthPopup(
-      'github',
-      {remember: 'sessionOnly', scope: 'gist'}
-    ).then(
-      (authData) => {
-        this.props.dispatch(logIn(authData));
+    auth.signInWithPopup(githubAuthProvider).then(
+      ({user, credential}) => {
+        this.props.dispatch(logIn(user, credential));
       },
       (e) => {
         switch (e.code) {
@@ -310,7 +307,7 @@ class Workspace extends React.Component {
   }
 
   _handleLogOut() {
-    appFirebase.unauth().then(() => this.props.dispatch(logOut()));
+    auth.signOut().then(() => this.props.dispatch(logOut()));
   }
 
   _handleRequestedLineFocused() {

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -23,6 +23,7 @@ import {
   onSignedOut,
   signIn,
   signOut,
+  startSessionHeartbeat,
 } from '../clients/firebaseAuth';
 import {EmptyGistError} from '../services/Gists';
 import {openWindowWithWorkaroundForChromeClosingBug} from '../util';
@@ -122,6 +123,7 @@ class Workspace extends React.Component {
     history.replaceState({}, '', location.pathname);
     this.props.dispatch(bootstrap(gistId));
     this._listenForAuthChange();
+    startSessionHeartbeat();
   }
 
   componentDidMount() {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
 /* global process */
 
+import get from 'lodash/get';
+
 const nodeEnv = (process.env.NODE_ENV || 'development');
 
 export default {
@@ -7,7 +9,16 @@ export default {
   logReduxActions: () => process.env.LOG_REDUX_ACTIONS === 'true',
   warnOnDroppedErrors: process.env.WARN_ON_DROPPED_ERRORS === 'true',
 
-  firebaseApp: process.env.FIREBASE_APP || 'blistering-inferno-9896',
+  firebaseApp: get(
+    process,
+    'env.FIREBASE_APP',
+    'popcode-development'
+  ),
+  firebaseApiKey: get(
+    process,
+    'env.FIREBASE_API_KEY',
+    'AIzaSyCHlo2RhOkRFFh48g779YSZrLwKjoyCcws'
+  ),
 
   feedbackUrl: 'https://gitreports.com/issue/popcodeorg/popcode',
 

--- a/src/persistors/FirebasePersistor.js
+++ b/src/persistors/FirebasePersistor.js
@@ -1,46 +1,28 @@
 import values from 'lodash/values';
-import appFirebase from '../services/appFirebase';
+import {database} from '../services/appFirebase';
 
 class FirebasePersistor {
   constructor(uid) {
-    this.firebase = appFirebase.child(`workspaces/${uid}`);
+    this.firebase = database.ref(`workspaces/${uid}`);
   }
 
   getCurrentProjectKey() {
-    return new Promise((resolve) => {
-      this.firebase.child('currentProjectKey').once('value', (snapshot) => {
-        resolve(snapshot.val());
-      });
-    });
+    return this.firebase.child('currentProjectKey').once('value').
+      then((snapshot) => snapshot.val());
   }
 
   setCurrentProjectKey(projectKey) {
-    return new Promise((resolve, reject) => {
-      this.firebase.child('currentProjectKey').set(projectKey, (error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    });
+    return this.firebase.child('currentProjectKey').set(projectKey);
   }
 
   all() {
-    return new Promise((resolve) => {
-      this.firebase.child('projects').once('value', (projects) => {
-        resolve(values(projects.val() || {}));
-      });
-    });
+    return this.firebase.child('projects').once('value').
+      then((projects) => values(projects.val() || {}));
   }
 
   load(projectKey) {
-    return new Promise((resolve) => {
-      this.firebase.child('projects').child(projectKey).
-        once('value', (snapshot) => {
-          resolve(snapshot.val());
-        });
-    });
+    return this.firebase.child('projects').child(projectKey).once('value').
+      then((snapshot) => snapshot.val());
   }
 
   loadCurrentProject() {
@@ -53,16 +35,8 @@ class FirebasePersistor {
   }
 
   save(project) {
-    return new Promise((resolve, reject) => {
-      this.firebase.child('projects').child(project.projectKey).
-        setWithPriority(project, -Date.now(), (error) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve();
-          }
-        });
-    });
+    return this.firebase.child('projects').child(project.projectKey).
+      setWithPriority(project, -Date.now());
   }
 
   saveCurrentProject(project) {

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -7,7 +7,7 @@ function user(stateIn, action) {
 
   switch (action.type) {
     case 'USER_AUTHENTICATED': {
-      const {userData, credentials} = action.payload;
+      const {user: userData, credential} = action.payload;
 
       return state.merge({
         authenticated: true,
@@ -15,8 +15,8 @@ function user(stateIn, action) {
         displayName: userData.displayName,
         avatarUrl: userData.photoURL,
         accessTokens: new Immutable.Map().set(
-          credentials.provider,
-          credentials.accessToken
+          credential.provider,
+          credential.accessToken
         ),
       });
     }

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -7,20 +7,17 @@ function user(stateIn, action) {
 
   switch (action.type) {
     case 'USER_AUTHENTICATED': {
-      const {userData} = action.payload;
-      const provider = userData.provider;
-      const profile = userData[provider];
+      const {userData, credentials} = action.payload;
 
       return state.merge({
         authenticated: true,
-        provider,
         id: userData.uid,
-        displayName: profile.displayName,
-        username: profile.username,
-        avatarUrl: profile.profileImageURL,
-        accessTokens: new Immutable.Map({
-          [provider]: profile.accessToken,
-        }),
+        displayName: userData.displayName,
+        avatarUrl: userData.photoURL,
+        accessTokens: new Immutable.Map().set(
+          credentials.provider,
+          credentials.accessToken
+        ),
       });
     }
 

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -1,5 +1,6 @@
 import assign from 'lodash/assign';
 import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
 import trim from 'lodash/trim';
 import promiseRetry from 'promise-retry';
 import gitHub from './gitHub';
@@ -63,15 +64,20 @@ export function createGistFromProject(project) {
 }
 
 function clientForUser(user) {
-  if (user.authenticated && user.provider === 'github') {
-    return gitHub.withAccessToken(user.accessTokens.github);
+  const githubToken = getGithubToken(user);
+  if (githubToken) {
+    return gitHub.withAccessToken(githubToken);
   }
 
   return gitHub.anonymous();
 }
 
+function getGithubToken(user) {
+  return get(user, ['accessTokens', 'github.com']);
+}
+
 function canUpdateGist(user) {
-  return user.authenticated && user.provider === 'github';
+  return Boolean(getGithubToken(user));
 }
 
 function updateGistWithImportUrl(github, gistData) {

--- a/src/services/appFirebase.js
+++ b/src/services/appFirebase.js
@@ -1,8 +1,17 @@
-import Firebase from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/database';
 import config from '../config';
 
-const appFirebase = new Firebase(
-  `https://${config.firebaseApp}.firebaseio.com`
-);
+const appFirebase = firebase.initializeApp({
+  apiKey: config.firebaseApiKey,
+  authDomain: `${config.firebaseApp}.firebaseapp.com`,
+  databaseURL: `https://${config.firebaseApp}.firebaseio.com`,
+});
 
-export default appFirebase;
+const auth = firebase.auth(appFirebase);
+const database = firebase.database(appFirebase);
+const githubAuthProvider = new firebase.auth.GithubAuthProvider();
+githubAuthProvider.addScope('gist');
+
+export {auth, database, githubAuthProvider};

--- a/src/services/rxjs.js
+++ b/src/services/rxjs.js
@@ -1,0 +1,11 @@
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/fromPromise';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/first';
+import 'rxjs/add/operator/partition';
+import 'rxjs/add/operator/skip';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/toPromise';
+
+export {Observable};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6553,6 +6553,12 @@ rx@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+rxjs@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.0.2.tgz#cc6513756daa93cab4085c1b5a19a3e28fb6c6bf"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -7199,7 +7205,7 @@ svgo@^0.7.2:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.2:
+symbol-observable@^1.0.1, symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,6 +845,10 @@ base64id@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-0.1.0.tgz#02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
 
+base64url@2.0.0, base64url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
+
 batch@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.5.3.tgz#3f3414f380321743bfc1042f9a83ff1d5824d464"
@@ -1136,6 +1140,10 @@ browserstacktunnel-wrapper@~1.4.2:
 bs-recipes@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.2.tgz#aebff3bfc9dca4cab3c2938d91e43473cf41b6c1"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
 
 buffer-equal@0.0.1:
   version "0.0.1"
@@ -2138,6 +2146,10 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-storage@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.0.2.tgz#ed17cbf68abd10e0aef8182713e297c5e4b500b0"
+
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -2212,6 +2224,13 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+ecdsa-sig-formatter@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz#4bc926274ec3b5abb5016e7e1d60921ac262b2a1"
+  dependencies:
+    base64url "^2.0.0"
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2743,9 +2762,9 @@ fast-levenshtein@~2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz#bd33145744519ab1c36c3ee9f31f08e9079b67f2"
 
-faye-websocket@>=0.6.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.0.tgz#d9ccf0e789e7db725d74bc4877d23aa42972ac50"
+faye-websocket@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.9.3.tgz#482a505b0df0ae626b969866d3bd740cdb962e83"
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -2848,11 +2867,15 @@ fined@^1.0.1:
     lodash.pick "^4.2.1"
     parse-filepath "^1.0.1"
 
-firebase@^2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-2.4.2.tgz#4e1119ec0396ca561d8a7acbff1630feac6c0a31"
+firebase@^3.6.9:
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-3.6.9.tgz#26ad0f6adf2cd829a91e52e44f4867050f3cd2ad"
   dependencies:
-    faye-websocket ">=0.6.0"
+    dom-storage "2.0.2"
+    faye-websocket "0.9.3"
+    jsonwebtoken "7.1.9"
+    rsvp "3.2.1"
+    xmlhttprequest "1.8.0"
 
 first-chunk-stream@^1.0.0:
   version "1.0.0"
@@ -3958,6 +3981,10 @@ isbinaryfile@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.1.tgz#6e99573675372e841a0520c036b41513d783e79e"
 
+isemail@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
+
 isemail@2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
@@ -3995,6 +4022,15 @@ jodid25519@^1.0.0:
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
   dependencies:
     jsbn "~0.1.0"
+
+joi@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
+  dependencies:
+    hoek "2.x.x"
+    isemail "1.x.x"
+    moment "2.x.x"
+    topo "1.x.x"
 
 joi@^7.0.1:
   version "7.3.0"
@@ -4113,6 +4149,16 @@ jsonpointer@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.0.tgz#6661e161d2fc445f19f98430231343722e1fcbd5"
 
+jsonwebtoken@7.1.9:
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.1.9.tgz#847804e5258bec5a9499a8dc4a5e7a3bae08d58a"
+  dependencies:
+    joi "^6.10.1"
+    jws "^3.1.3"
+    lodash.once "^4.0.0"
+    ms "^0.7.1"
+    xtend "^4.0.1"
+
 jsprim@^1.2.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.3.1.tgz#2a7256f70412a29ee3670aaca625994c4dcff252"
@@ -4137,6 +4183,23 @@ jsx-ast-utils@^1.3.3:
   dependencies:
     acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
+
+jwa@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.5.tgz#a0552ce0220742cd52e153774a32905c30e756e5"
+  dependencies:
+    base64url "2.0.0"
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.9"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.4.tgz#f9e8b9338e8a847277d6444b1464f61880e050a2"
+  dependencies:
+    base64url "^2.0.0"
+    jwa "^1.1.4"
+    safe-buffer "^5.0.1"
 
 karma-browserstack-launcher@^1.1.1:
   version "1.1.1"
@@ -4446,6 +4509,10 @@ lodash.mapvalues@^4.4.0:
 lodash.memoize@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
 lodash.pick@^4.2.1:
   version "4.4.0"
@@ -4788,7 +4855,7 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
+ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
@@ -6468,6 +6535,10 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
+rsvp@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -6481,6 +6552,10 @@ rx-lite@^3.1.2:
 rx@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
 samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
@@ -7258,6 +7333,12 @@ to-vfile@^1.0.0:
   dependencies:
     vfile "^1.0.0"
 
+topo@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
+  dependencies:
+    hoek "2.x.x"
+
 topo@2.x.x:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
@@ -7882,6 +7963,10 @@ xmlbuilder@^4.1.0:
 xmlhttprequest-ssl@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz#3b7741fea4a86675976e908d296d4445961faa67"
+
+xmlhttprequest@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4045,6 +4045,10 @@ js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
+js-cookie@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.1.3.tgz#48071625217ac9ecfab8c343a13d42ec09ff0526"
+
 js-tokens@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-1.0.3.tgz#14e56eb68c8f1a92c43d59f5014ec29dc20f2ae1"


### PR DESCRIPTION
Version 2 of the Firebase SDK has been deprecated for some time in favor of Firebase 3. It’s important that we stay up to date, especially as a large number of the uncaught errors in production are inscrutable authentication errors coming from Firebase.

There are some fairly superficial differences between the versions in terms of the API and the shape of the data returned from it. There are also two very significant changes in Firebase 3:

* Credentials are no longer retained between browser sessions. So, even if the user is currently logged in to Firebase when Popcode bootstraps, it won’t give you the user’s GitHub auth credentials.
* All login sessions are long-lived and global. If you are logged in to Firebase in one tab, you are permanently logged in, and you’re logged in in all tabs. This makes Popcode’s old behavior—in which each tab is an isolated Popcode login environment—impossible.

Dealing with credential storage is pretty straightforward—we simply store the user’s GitHub credentials in their Firebase account when they explicitly auth. We can then retain the credentials when Firebase automatically logs them in from a sticky session.

Dealing with universal long-lived sessions is a stickier pickle. First, this means that logging into Popcode in one tab logs you in in all tabs; similarly, logging out in one tab logs you out in all tabs. This was the chief motivation for #640 and #635, which introduce an invariant that changing login state never changes the state of the current project.

We also very much do not want long-lived sessions for Popcode—many students use Popcode on shared laptops, so it’s important that when a student opens up a laptop for the day, they’re not logged in to another student’s account (ahem GitHub).

However, we can’t simply log out of Firebase when Popcode bootstraps, because sessions are universal. Opening Popcode in a new tab while you are logged in to Popcode in another tab should result in you being logged into both tabs.

So, we introduce the concept of the “session heartbeat”. As soon as Popcode starts, it sets a cookie containing the current user’s ID (if any). This cookie is refreshed every second as long as Popcode is open. It is, however, set to expire after five minutes.

When bootstrapping, we look for the existence of that cookie, and check Firebase’s reported login state against it. If Firebase says we’re logged in, but the cookie isn’t there, we log out of Firebase and start Popcode in an unauthed state.

The effect is that, as long as you’re logged in to Popcode in any tab, you’ll be logged in in all tabs, including new ones. However, five minutes after closing all Popcode tabs, your session expires and a new Popcode instance will be logged out.

Beyond those considerations, the rest of the changes in this pull request just involve wrangling tests.