### PR TITLE
Don’t use lodash get to access process.env

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,5 @@
 /* global process */
 
-import get from 'lodash/get';
-
 const nodeEnv = (process.env.NODE_ENV || 'development');
 
 export default {
@@ -9,16 +7,9 @@ export default {
   logReduxActions: () => process.env.LOG_REDUX_ACTIONS === 'true',
   warnOnDroppedErrors: process.env.WARN_ON_DROPPED_ERRORS === 'true',
 
-  firebaseApp: get(
-    process,
-    'env.FIREBASE_APP',
-    'popcode-development'
-  ),
-  firebaseApiKey: get(
-    process,
-    'env.FIREBASE_API_KEY',
-    'AIzaSyCHlo2RhOkRFFh48g779YSZrLwKjoyCcws'
-  ),
+  firebaseApp: process.env.FIREBASE_APP || 'popcode-development',
+  firebaseApiKey: process.env.FIREBASE_API_KEY ||
+    'AIzaSyCHlo2RhOkRFFh48g779YSZrLwKjoyCcws',
 
   feedbackUrl: 'https://gitreports.com/issue/popcodeorg/popcode',
 


### PR DESCRIPTION
`process.env` is statically evaluated by Webpack, which replaces expressions with literal values in compiled code. Using lodash `get` prevents this static analysis from happening.