### PR TITLE
Use providerData for profile data if available

### DIFF
--- a/spec/examples/actions/user.spec.js
+++ b/spec/examples/actions/user.spec.js
@@ -112,14 +112,14 @@ describe('user actions', () => {
       it('should set display name', () => {
         assert.equal(
           store.getState().getIn(['user', 'displayName']),
-          user.displayName
+          user.providerData[0].displayName
         );
       });
 
       it('should set avatarUrl', () => {
         assert.equal(
           store.getState().getIn(['user', 'avatarUrl']),
-          user.photoURL
+          user.providerData[0].photoURL
         );
       });
 

--- a/spec/helpers/MockFirebase.js
+++ b/spec/helpers/MockFirebase.js
@@ -13,8 +13,8 @@ import {setSessionUid} from '../../src/clients/firebaseAuth';
 
 export function createUser(user) {
   return merge({
-    displayName: 'Popcode User',
-    photoURL: 'https://camo.github.com/popcodeuser.jpg',
+    displayName: null,
+    photoURL: null,
     providerData: [{
       displayName: 'Popcode User',
       email: 'popcodeuser@example.com',

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,4 +1,5 @@
 import Immutable from 'immutable';
+import get from 'lodash/get';
 
 const init = new Immutable.Map({authenticated: false});
 
@@ -9,11 +10,13 @@ function user(stateIn, action) {
     case 'USER_AUTHENTICATED': {
       const {user: userData, credential} = action.payload;
 
+      const profileData = get(userData, ['providerData', 0], userData);
+
       return state.merge({
         authenticated: true,
         id: userData.uid,
-        displayName: userData.displayName,
-        avatarUrl: userData.photoURL,
+        displayName: profileData.displayName,
+        avatarUrl: profileData.photoURL,
         accessTokens: new Immutable.Map().set(
           credential.provider,
           credential.accessToken


### PR DESCRIPTION
Apparently the `displayName` and `photoURL` methods are not consistently available on the root Firebase user object. These properties are still, however, available on the `providerData`, which contains raw information from GitHub. So, prefer the first `providerData` record available as the source of profile data, falling back to the root object.

Fixes bug where avatar and name may not appear in the sidebar in production when users are logged in.