### PR TITLE
Don’t attempt to retain current project on reset if there isn’t one

### DIFF
--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -1,5 +1,6 @@
 import Immutable from 'immutable';
 import {readFileSync} from 'fs';
+import isNil from 'lodash/isNil';
 import path from 'path';
 
 import {isPristineProject} from '../util/projectUtils';
@@ -66,6 +67,10 @@ function projects(stateIn, action) {
       ));
 
     case 'RESET_WORKSPACE':
+      if (isNil(action.payload.currentProjectKey)) {
+        return emptyMap;
+      }
+
       return new Immutable.Map().set(
         action.payload.currentProjectKey,
         state.get(action.payload.currentProjectKey)


### PR DESCRIPTION
During bootstrap, we may invoke a logout before the environment is completely set up (specifically, if there is an active Firebase session but the session heartbeat cookie has expired). In this case, a `RESET_WORKSPACE` action is triggered by the auth state handler, previously causing the `projects` reducer to incorrectly set its state to a map of `null` to `undefined`.

Now, the `RESET_WORKSPACE` handler checks to see if its input project key is nil, and if so, it just returns an empty map.

This isn’t an entirely satisfying solution—in particular, we really shouldn’t be firing the auth state change handler for a logout that is performed as part of bootstrap. That logic should only be run for auth state changes that occur after bootstrap. But I need to spend a bit more time thinking about the right way to ensure that; for now, this fixes the immediate problem (which causes the environment to be totally broken if you access it after having been previously logged in).

Fixes #653 
Fixes #656 