### PR TITLE
More descriptive error when auth fails because of network error

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -22,6 +22,7 @@
   },
   "notifications": {
     "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
+    "auth-network-error": "Looks like you’re having some internet trouble. Try signing in again.",
     "auth-error": "Something went wrong trying to sign in. Please try again!",
     "empty-gist": "You need some code in your project to export a gist!",
     "gist-export-error": "Something went wrong trying to create that gist. Please try again.",

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -299,6 +299,9 @@ class Workspace extends React.Component {
         case 'auth/popup-closed-by-user':
           this.props.dispatch(notificationTriggered('user-cancelled-auth'));
           break;
+        case 'auth/network-request-failed':
+          this.props.dispatch(notificationTriggered('auth-network-error'));
+          break;
         default:
           this.props.dispatch(notificationTriggered('auth-error'));
           if (isError(e)) {


### PR DESCRIPTION
Ideally, we’d like to retry sign in if a network error causes it to fail. However, our only interface to signing in is to call the `signInWithPopup()` method of Firebase, which results in a blocked popup if it’s not called in an execution context that was initiated by a user action.

So, just fail with a slightly more descriptive error, and don’t send the error on to Bugsnag.

Fixes #659