### PR TITLE
Ignore auth/cancelled-popup-request error on sign in

### DIFF
--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -302,6 +302,8 @@ class Workspace extends React.Component {
         case 'auth/network-request-failed':
           this.props.dispatch(notificationTriggered('auth-network-error'));
           break;
+        case 'auth/cancelled-popup-request':
+          break;
         default:
           this.props.dispatch(notificationTriggered('auth-error'));
           if (isError(e)) {


### PR DESCRIPTION
If the student clicks “Sign In”, then clicks it again without closing the first pop-up or completing sign-in, Firebase will throw an error.

In this case, the best approach is to just let the student continue login via the new popup. The original one will still be orphaned in the background, but there’s nothing we can do about this (we don’t get a reference to the window that we can use to close it).

The main alternative would be to disable the Sign In button while sign-in is outstanding, but I think this would be a worse experience, since the student has probably lost track of the original pop-up and it would be unclear why the link was disabled.

Fixes #650 
Fixes #661 
Fixes #665
Fixes #668