### PR TITLE
Upgrade Firebase client

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "envify": "^3.4.1",
     "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
     "esprima": "^3.0.0",
-    "firebase": "^3.6.9",
+    "firebase": "^3.6.10",
     "github-api": "git+https://github.com/michael/github.git#v2.4.0",
     "html-inspector": "^0.8.2",
     "htmllint": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,9 +2873,9 @@ fined@^1.0.1:
     lodash.pick "^4.2.1"
     parse-filepath "^1.0.1"
 
-firebase@^3.6.9:
-  version "3.6.9"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-3.6.9.tgz#26ad0f6adf2cd829a91e52e44f4867050f3cd2ad"
+firebase@^3.6.10:
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-3.6.10.tgz#1efc0b31ab510eacab353eb11a84869196372ae5"
   dependencies:
     dom-storage "2.0.2"
     faye-websocket "0.9.3"
@@ -4844,11 +4844,11 @@ mout@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mout/-/mout-1.0.0.tgz#9bdf1d4af57d66d47cb353a6335a3281098e1501"
 
-ms@0.7.1, ms@^0.7.1:
+ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
+ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 


### PR DESCRIPTION
In particular, I’m hoping this will fix an issue with an uncaught "Network Error" getting thrown in some circumstances when there should just be a promise rejection (although the release notes do not give me great hope).

If nothing else, we’ll see the errors pop back up.

Fixes #660
Fixes #663
Fixes #675