### PR TITLE
Handle edge cases in heuristic detection of missing CSS semicolons

### DIFF
--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -142,7 +142,7 @@ describe('css', function() {
       assertFailsValidationWith(css, stylesheet, 'extra-tokens-after-value')
     );
 
-    it('fails at the line missing the semicolon', () =>
+    it('fails at the line with the extra value', () =>
       assertFailsValidationAtLine(css, stylesheet, 2)
     );
   });
@@ -153,6 +153,18 @@ describe('css', function() {
 
     it('gives extra tokens error', () =>
       assertFailsValidationWith(css, stylesheet, 'extra-tokens-after-value'));
+  });
+
+  context('extra token that is a prefix of the beginning of the line', () => {
+    const stylesheet = `
+      p {
+        border: 20px solid b;
+      }
+    `;
+
+    it('gives extra tokens error', () =>
+      assertFailsValidationWith(css, stylesheet, 'extra-tokens-after-value')
+    );
   });
 
   context('thoroughly unparseable CSS', () => {

--- a/spec/examples/validations/css.spec.js
+++ b/spec/examples/validations/css.spec.js
@@ -147,6 +147,14 @@ describe('css', function() {
     );
   });
 
+  context('potentially missing semicolon before first line', () => {
+    const stylesheet = `button{border:20px solid b;
+    }`;
+
+    it('gives extra tokens error', () =>
+      assertFailsValidationWith(css, stylesheet, 'extra-tokens-after-value'));
+  });
+
   context('thoroughly unparseable CSS', () => {
     const stylesheet = '<a href=\"http;.facebook.com>';
 

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -1,6 +1,5 @@
 import Validator from '../Validator';
 import trim from 'lodash/trim';
-import startsWith from 'lodash/startsWith';
 import endsWith from 'lodash/endsWith';
 import importLinters from '../importLinters';
 
@@ -61,7 +60,7 @@ const errorMap = {
       const thisLine = lines[lineNumber - 1];
 
       if (
-        startsWith(trim(thisLine), error.token.content) &&
+        error.token.charNum - 1 === /\S/.exec(thisLine).index &&
         !endsWith(trim(previousLine), ';')
       ) {
         return {

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -54,19 +54,22 @@ const errorMap = {
 
   'extra-tokens-after-value': (error, source) => {
     const lineNumber = error.token.line;
-    const lines = source.split('\n');
-    const previousLine = lines[lineNumber - 2];
-    const thisLine = lines[lineNumber - 1];
 
-    if (
-      startsWith(trim(thisLine), error.token.content) &&
+    if (lineNumber > 1) {
+      const lines = source.split('\n');
+      const previousLine = lines[lineNumber - 2];
+      const thisLine = lines[lineNumber - 1];
+
+      if (
+        startsWith(trim(thisLine), error.token.content) &&
         !endsWith(trim(previousLine), ';')
-    ) {
-      return {
-        reason: 'missing-semicolon',
-        row: lineNumber - 2,
-        column: previousLine.length - 1,
-      };
+      ) {
+        return {
+          reason: 'missing-semicolon',
+          row: lineNumber - 2,
+          column: previousLine.length - 1,
+        };
+      }
     }
 
     return ({


### PR DESCRIPTION
A particular bit of CSS exposes two errors in the heuristic detection of missing semicolons in CSS:

```css
button{border:20px solid b;
}
```

While none of our linters directly reports a missing semicolon, we use a heuristic to interpret PrettyCSS’s `extra-tokens-after-value` as a missing semicolon if the following is true:

1. The line with the error begins with the token reported as extraneous
2. The previous line does not end with a semicolon

However, the logic for each of these conditions was flawed:

1. The check for whether the line started with the bad token used a simple prefix substring match (so the extraneous `b` above matches the beginning of `button`)
2. We checked the previous line for a semicolon even if there was no previous line (i.e. the error occurred on the first line of the stylesheet)

Together, these bugs caused an uncaught error to occur when attempting to validate the stylesheet above, although the first error on its own can also cause generally nonsensical error messages.

Fixed both bugs:

1. Use the reported position of the extraneous token to directly compare it to the position of the first non-whitespace character of the line
2. Skip the entire missing semicolon heuristic if the error is reported on the first line

Fixes #678