### PR TITLE
Try harder to pass reason for unhandled rejection to Bugsnag

### DIFF
--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -33,8 +33,7 @@ window.addEventListener('unhandledrejection', ({reason}) => {
   } else {
     Bugsnag.notify(
       'UnhandledRejection',
-      'Unhandled rejection in promise',
-      reason
+      JSON.stringify(reason) || 'No reason given'
     );
   }
 });


### PR DESCRIPTION
Passing a rejection reason of arbitrary type as metadata doesn’t help much because the metadata is expected to be an object. Instead, stringify the reason as JSON and pass it as the error message.

Fixes #670