### PR TITLE
Handle third-party cookies disabled error

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -23,6 +23,7 @@
   "notifications": {
     "user-cancelled-auth": "Looks like you didn’t finish linking GitHub to Popcode. Try again, and be sure to click the green “Authorize application” button.",
     "auth-network-error": "Looks like you’re having some internet trouble. Try signing in again.",
+    "auth-third-party-cookies-disabled": "It looks like you have third-party cookies disabled. Please change your browser settings and try to log in again.",
     "auth-error": "Something went wrong trying to sign in. Please try again!",
     "empty-gist": "You need some code in your project to export a gist!",
     "gist-export-error": "Something went wrong trying to create that gist. Please try again.",

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -304,6 +304,11 @@ class Workspace extends React.Component {
           break;
         case 'auth/cancelled-popup-request':
           break;
+        case 'auth/web-storage-unsupported':
+          this.props.dispatch(
+            notificationTriggered('auth-third-party-cookies-disabled')
+          );
+          break;
         default:
           this.props.dispatch(notificationTriggered('auth-error'));
           if (isError(e)) {


### PR DESCRIPTION
Firebase can’t perform login if the user has disabled third-party cookies. Catch this error and display a message asking them to change their browser settings.

Fixes #669 
Fixes #673 