### PR TITLE
Upgrade brace

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "array-to-sentence": "^1.1.0",
     "base64-js": "^1.0.2",
     "bowser": "^1.4.5",
-    "brace": "^0.8.0",
+    "brace": "^0.10.0",
     "bugsnag-js": "^3.0.1",
     "classnames": "^2.1.5",
     "css": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,9 +962,9 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
-brace@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/brace/-/brace-0.8.0.tgz#e826c6d5054cae5f607ad7b1c81236dd2cf01978"
+brace@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.10.0.tgz#edef4eb9b0928ba1ee5f717ffc157749a6dd5d76"
   dependencies:
     w3c-blob "0.0.1"
 


### PR DESCRIPTION
Updates ACE from 1.2.3 to 1.2.6 (not sure why brace doesn’t use the same versions)