### PR TITLE
Shim DOMParser.parseFromString to support HTML parsing on old browsers

### DIFF
--- a/config/browsers.json
+++ b/config/browsers.json
@@ -1,5 +1,5 @@
 {
   "firefox": "28",
-  "chrome": "30",
+  "chrome": "22",
   "safari": "7.1"
 }

--- a/src/init/DOMParserShim.js
+++ b/src/init/DOMParserShim.js
@@ -1,0 +1,27 @@
+const proto = DOMParser.prototype;
+const nativeParse = proto.parseFromString;
+
+function isParsingNativelySupported() {
+  try {
+    return Boolean(new DOMParser().parseFromString('', 'text/html'));
+  } catch (e) {
+    return false;
+  }
+}
+
+if (!isParsingNativelySupported()) {
+  proto.parseFromString = function(markup, type, ...rest) {
+    if (/^\s*text\/html\s*(?:;|$)/i.test(type)) {
+      const doc = document.implementation.createHTMLDocument('');
+      if (markup.toLowerCase().indexOf('<!doctype') > -1) {
+        doc.documentElement.innerHTML = markup;
+      } else {
+        doc.body.innerHTML = markup;
+      }
+      return doc;
+    }
+    return Reflect.apply(nativeParse, this, [markup, type, ...rest]);
+  };
+}
+
+export default {};

--- a/src/init/index.js
+++ b/src/init/index.js
@@ -1,2 +1,3 @@
 import 'babel-polyfill';
 import 'es6-set/implement';
+import './DOMParserShim';

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -5,7 +5,6 @@ import loopProtect from 'loop-protect';
 import libraries from '../config/libraries';
 import previewFrameLibraries from '../config/previewFrameLibraries';
 
-const DOMParser = window.DOMParser;
 const parser = new DOMParser();
 
 const sourceDelimiter = '/*__POPCODESTART__*/';


### PR DESCRIPTION
Chrome 30 does not support `DOMParser.parseFromString` for HTML, even though [MDN says it does](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#Browser_compatibility). So, adapt the polyfill from that selfsame article to provide a working parser in older browsers.

This allows us to support Chrome versions as old as 22 (the first version to have a working implementation of standard flexbox).

Fixes #722