### PR TITLE
Loop-breaker take 2

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -188,7 +188,7 @@
       "set-property-of-undefined_with-property": "You are trying to set the property {{property}} on something that doesn't have a value.",
 
       "set-property-of-null_with-property": "You are trying to set the property {{property}} on a null value.",
-      "infinite-loop": "There is a loop on this line that looks like it might run forever. Check the loop to make sure it has the right stopping condition."
+      "infinite-loop": "There is a loop in your code that looks like it might run forever. Check the loop to make sure it has the right stopping condition."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jshint": "^2.9.3",
     "keymirror": "^0.1.1",
     "lodash": "^4.15.0",
-    "loop-protect": "git+https://github.com/jsbin/loop-protect.git#v1.0.1",
+    "loop-breaker": "^0.1.0-alpha.7",
     "moment": "^2.14.1",
     "pify": "^2.3.0",
     "promise-retry": "^1.1.1",

--- a/src/components/ErrorItem.jsx
+++ b/src/components/ErrorItem.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import partial from 'lodash/partial';
 
 function ErrorItem(props) {
+  const lineLabel = props.row >= 0 ?
+    <div>On line {props.row + 1}:</div> :
+    null;
+
   return (
     <li
       className="error-list__error"
@@ -12,7 +16,7 @@ function ErrorItem(props) {
         props.column,
       )}
     >
-      <div>On line {props.row + 1}:</div>
+      {lineLabel}
       <div className="error-list__message">{props.text}</div>
     </li>
   );

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -60,12 +60,14 @@ class PreviewFrame extends React.Component {
       return;
     }
 
-    if (data.type === 'org.popcode.infinite-loop') {
-      this._handleInfiniteLoop(data.line);
+    if (data.type !== 'org.popcode.error') {
       return;
     }
 
-    if (data.type !== 'org.popcode.error') {
+    let line = data.error.line - this._runtimeErrorLineOffset();
+
+    if (data.error.message === 'Loop Broken!') {
+      this._handleInfiniteLoop(line);
       return;
     }
 
@@ -73,7 +75,6 @@ class PreviewFrame extends React.Component {
     const error = new ErrorConstructor(data.error.message);
 
     const normalizedError = normalizeError(error);
-    let line = data.error.line - this._runtimeErrorLineOffset();
 
     if (Bowser.safari) {
       line = 1;

--- a/src/config/previewFrameLibraries.js
+++ b/src/config/previewFrameLibraries.js
@@ -2,16 +2,6 @@ import fs from 'fs';
 import path from 'path';
 
 const previewFrameLibraries = {
-  loopProtect: {
-    name: 'loopProtect',
-    javascript: fs.readFileSync(
-      path.join(
-        __dirname,
-        '../../node_modules/loop-protect/dist/loop-protect.min.js',
-      ),
-    ),
-  },
-
   sweetalert: {
     name: 'sweetalert',
     javascript: fs.readFileSync(

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -1,7 +1,7 @@
 import castArray from 'lodash/castArray';
 import pick from 'lodash/pick';
 import base64 from 'base64-js';
-import loopProtect from 'loop-protect';
+import loopBreaker from 'loop-breaker';
 import libraries from '../config/libraries';
 import previewFrameLibraries from '../config/previewFrameLibraries';
 
@@ -36,15 +36,6 @@ const errorHandlerScript = `(${(() => {
       },
     }), '*');
   };
-
-  if ('loopProtect' in window) {
-    window.loopProtect.hit = function(line) {
-      window.parent.postMessage(JSON.stringify({
-        type: 'org.popcode.infinite-loop',
-        line,
-      }), '*');
-    };
-  }
 }).toString()}());`;
 
 const alertAndPromptReplacementScript = `(${(() => {
@@ -78,7 +69,7 @@ class PreviewGenerator {
 
     this.previewText = (this.previewBody.innerText || '').trim();
     this._attachLibraries(
-      pick(options, ['nonBlockingAlertsAndPrompts', 'breakLoops']),
+      pick(options, ['nonBlockingAlertsAndPrompts']),
     );
 
     if (options.targetBaseTop) {
@@ -132,17 +123,12 @@ class PreviewGenerator {
   }
 
   _addJavascript({breakLoops = false}) {
-    let source = this._project.sources.javascript;
+    let source = `\n${sourceDelimiter}\n${this._project.sources.javascript}`;
     if (breakLoops) {
-      try {
-        source = loopProtect(source);
-      } catch (e) {
-        return '';
-      }
+      source = loopBreaker(source);
     }
     const scriptTag = this.previewDocument.createElement('script');
-    scriptTag.innerHTML =
-      `\n${sourceDelimiter}\n${source}`;
+    scriptTag.innerHTML = source;
     this.previewBody.appendChild(scriptTag);
 
     return this.previewDocument.documentElement.outerHTML;
@@ -160,7 +146,7 @@ class PreviewGenerator {
     this.previewBody.appendChild(scriptTag);
   }
 
-  _attachLibraries({nonBlockingAlertsAndPrompts = false, breakLoops = false}) {
+  _attachLibraries({nonBlockingAlertsAndPrompts = false}) {
     this._project.enabledLibraries.forEach((libraryKey) => {
       if (!(libraryKey in libraries)) {
         return;
@@ -172,10 +158,6 @@ class PreviewGenerator {
 
     if (nonBlockingAlertsAndPrompts) {
       this._attachLibrary(previewFrameLibraries.sweetalert);
-    }
-
-    if (breakLoops) {
-      this._attachLibrary(previewFrameLibraries.loopProtect);
     }
   }
 

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -116,7 +116,7 @@ class EsprimaValidator extends Validator {
       };
     }
 
-    return null;
+    return {reason: 'tokenize-error'};
   }
 
   _locationForError(error) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,13 +103,6 @@ module.exports = {
         loader: 'babel-loader',
       },
       {
-        test: /\.js$/,
-        include: [
-          path.resolve(__dirname, 'node_modules/loop-protect'),
-        ],
-        loader: 'imports-loader?define=>false',
-      },
-      {
         include: [
           path.resolve(
             __dirname,

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,6 +245,10 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
 async-each-series@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/async-each-series/-/async-each-series-0.1.1.tgz#7617c1917401fd8ca4a28aadce3dbae98afeb432"
@@ -2704,7 +2708,7 @@ esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.0.0, esprima@^3.1.1:
+esprima@^3.0.0, esprima@^3.1.1, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -4772,9 +4776,11 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-"loop-protect@git+https://github.com/jsbin/loop-protect.git#v1.0.1":
-  version "1.0.1"
-  resolved "git+https://github.com/jsbin/loop-protect.git#335856f37ee4a805704bfcd1d7429ab94620bf6d"
+loop-breaker@^0.1.0-alpha.7:
+  version "0.1.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/loop-breaker/-/loop-breaker-0.1.0-alpha.7.tgz#b374dff54289c8f5b621eb4656bc1f09b24e16c7"
+  dependencies:
+    recast "^0.11.22"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.3.1"
@@ -6139,7 +6145,7 @@ pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
 
-private@^0.1.6:
+private@^0.1.6, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
@@ -6422,6 +6428,15 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+recast@^0.11.22:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -7072,7 +7087,7 @@ source-map@0.1.x, source-map@^0.1.38, source-map@^0.1.41, source-map@~0.1.33:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@0.X, "source-map@>= 0.1.2", source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.X, "source-map@>= 0.1.2", source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 


### PR DESCRIPTION
Restores the [switch to loop-breaker](https://github.com/popcodeorg/popcode/pull/726), which I had to revert because certain JavaScript inputs were causing the environment to throw an uncaught exception.

It turns out that the main problem was code that had a single slash at the beginning of the line (this was likely intended to be a double-slash for a comment). This causes esprima to throw an “invalid regular expression” error.

```js
// Tiny Turtle Setup. Avoid modifying these lines of code!
var adjCanvasSize = document.getElementsByTagName('canvas')[0];
adjCanvasSize.width  = 400;
adjCanvasSize.height = 400;
TinyTurtle.apply(window);

// Start writing code here
function rectangle(x, y){
forward(x);
right(90);
forward(y);
right(90);
forward(x);
right(90);
forward(y);
}

function house(x){
forward( x);
  right(90);
  forward(x);
  right(90);
  forward(x);
  right(90);
  forward(x);
  right(30);
  forward(x);
  right(120);
  forward(x);
}

house(100);

/rectangle(200, 150);

stamp();
```

In order to fix the problem, modify the esprima validator to *always* return an error if the source did not successfully parse. Unlike with a linter, we can safely assume that any error thrown by esprima should be reported as a validation error, however vague, by Popcode.

Fixes #727 
Fixes #729 
Fixes #730 
Fixes #731 
Fixes #732 
Fixes #733