### PR TITLE
Absolutely position column contents

### DIFF
--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -62,22 +62,22 @@ class Output extends React.Component {
   render() {
     return (
       <div
-        className={
-          classnames(
-            'environment__column output',
-            {output_hidden: this.props.isHidden},
-          )
-        }
+        className={classnames(
+          'environment__column',
+          {u__hidden: this.props.isHidden},
+        )}
       >
-        <div
-          className="environment__label label"
-          onClick={this.props.onMinimize}
-        >
-          {t('workspace.components.output')}
+        <div className="environment__columnContents output">
+          <div
+            className="environment__label label"
+            onClick={this.props.onMinimize}
+          >
+            {t('workspace.components.output')}
+          </div>
+          {this._renderErrors()}
+          {this._renderPreview()}
+          {this._renderRuntimeErrorList()}
         </div>
-        {this._renderErrors()}
-        {this._renderPreview()}
-        {this._renderRuntimeErrorList()}
       </div>
     );
   }

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -277,7 +277,9 @@ class Workspace extends React.Component {
     }
 
     return (
-      <div className="environment__column editors">{editors}</div>
+      <div className="environment__column">
+        <div className="environment__columnContents editors">{editors}</div>
+      </div>
     );
   }
 

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -349,7 +349,18 @@ body {
 }
 
 .environment__column {
-  flex: 1 1 0;
+  flex: 1 0 0;
+  position: relative;
+}
+
+.environment__columnContents {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 .environment__label {
@@ -414,11 +425,6 @@ body {
 .output {
   display: flex;
   flex-direction: column;
-  position: relative;
-}
-
-.output_hidden {
-  display: none;
 }
 
 .output__item {
@@ -495,6 +501,7 @@ body {
 .error-list__error {
   padding: 0.5rem 0;
   cursor: pointer;
+  overflow-wrap: break-word;
 }
 
 .notification-list__notification {


### PR DESCRIPTION
If a very long token (e.g. a data URI) appears in an error message, [the column will expand to fit its contents, causing it to consume the entire width of the container, and causing the editors to disappear](https://github.com/popcodeorg/popcode/issues/548).

I couldn’t find a completely satisfactory solution using flex all the way down; the interaction between the contents size and the flex properties is not well-documented, but it is certainly sensitive to the size of the content.

By wrapping the contents of each column in an absolutely positioned div that fills its container horizontally and vertically, we can get exactly the behavior we want.  The use of absolute positioning here means that the contents of the columns cannot affect the layout of the columns; it breaks them out of the flow. Instead, the columns’ width is determined solely by the flex arrangement, and the contents are forced to stay within the confines of the columns.

With this in place, a simple `overflow-wrap: break-word` gives us the exact wrapping behavior we want for the long tokens.

![image](https://cloud.githubusercontent.com/assets/14214/24571763/6069b2ac-1641-11e7-9606-86f61c1db7ff.png)

Fixes #548 
Fixes #742 
Closes #549 
Closes #611 