### PR TITLE
As-you-type validation handled by sagas and reducers

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,7 +12,7 @@ import {
 import {
   createProject,
   changeCurrentProject,
-  projectSourceEdited,
+  updateProjectSource,
 } from './projects';
 
 import {
@@ -82,19 +82,6 @@ export function validateAllSources(project) {
     project.get('sources').forEach((source, language) => {
       dispatch(validateSource(language, source, projectAttributes));
     });
-  };
-}
-
-function updateProjectSource(projectKey, language, newValue) {
-  return (dispatch, getState) => {
-    dispatch(projectSourceEdited(projectKey, language, newValue, Date.now()));
-
-    const state = getState();
-    saveCurrentProject(state);
-
-    const currentProject = getCurrentProject(state);
-    const projectAttributes = new Analyzer(currentProject);
-    dispatch(validateSource(language, newValue, projectAttributes));
   };
 }
 

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -12,10 +12,10 @@ export const changeCurrentProject = createAction(
   projectKey => ({projectKey}),
 );
 
-export const projectSourceEdited = createAction(
-  'PROJECT_SOURCE_EDITED',
+export const updateProjectSource = createAction(
+  'UPDATE_PROJECT_SOURCE',
   (projectKey, language, newValue) => ({projectKey, language, newValue}),
-  (_projectKey, _language, _newValue, timestamp) => ({timestamp}),
+  (_projectKey, _language, _newValue, timestamp = Date.now()) => ({timestamp}),
 );
 
 export const gistImported = createAction(

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -47,7 +47,7 @@ function errors(stateIn, action) {
     case 'GIST_IMPORTED':
       return validatingErrors;
 
-    case 'PROJECT_SOURCE_EDITED':
+    case 'UPDATE_PROJECT_SOURCE':
       return state.set(action.payload.language, validatingLanguageErrors);
 
     case 'VALIDATED_SOURCE':

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -99,7 +99,7 @@ export default function reduceProjects(stateIn, action) {
     case 'PROJECT_LOADED':
       return addProject(state, action.payload.project);
 
-    case 'PROJECT_SOURCE_EDITED':
+    case 'UPDATE_PROJECT_SOURCE':
       return state.setIn(
         [action.payload.projectKey, 'sources', action.payload.language],
         action.payload.newValue,

--- a/src/sagas/errors.js
+++ b/src/sagas/errors.js
@@ -3,7 +3,9 @@ import Analyzer from '../analyzers';
 import validations from '../validations';
 import {validatedSource} from '../actions/errors';
 
-export function* validateSource(language, source, projectAttributes) {
+export function* validateSource({
+  payload: {language, source, projectAttributes},
+}) {
   const errors = yield call(validations[language], source, projectAttributes);
   yield put(validatedSource(language, errors));
 }
@@ -16,7 +18,10 @@ export function* validateCurrentProject() {
   const analyzer = new Analyzer(currentProject);
 
   for (const [language, source] of currentProject.get('sources')) {
-    yield fork(validateSource, language, source, analyzer);
+    yield fork(
+      validateSource,
+      {payload: {language, source, projectAttributes: analyzer}},
+    );
   }
 }
 

--- a/src/sagas/errors.js
+++ b/src/sagas/errors.js
@@ -1,33 +1,67 @@
-import {call, fork, put, select, takeEvery} from 'redux-saga/effects';
+import {
+  call,
+  cancel,
+  fork,
+  join,
+  put,
+  select,
+  takeEvery,
+} from 'redux-saga/effects';
 import Analyzer from '../analyzers';
 import validations from '../validations';
 import {validatedSource} from '../actions/errors';
 
-export function* validateSource({
-  payload: {language, source, projectAttributes},
-}) {
-  const errors = yield call(validations[language], source, projectAttributes);
-  yield put(validatedSource(language, errors));
+function getCurrentProject(state) {
+  return state.getIn([
+    'projects',
+    state.getIn(['currentProject', 'projectKey']),
+  ]);
 }
 
-export function* validateCurrentProject() {
+export function* updateProjectSource(tasks, {payload: {language, newValue}}) {
   const state = yield select();
-  const currentProject = state.getIn(
-    ['projects', state.getIn(['currentProject', 'projectKey'])],
+  const analyzer = new Analyzer(getCurrentProject(state));
+  yield call(
+    validateSource,
+    tasks,
+    {payload: {language, source: newValue, projectAttributes: analyzer}},
   );
+}
+
+export function* validateCurrentProject(tasks) {
+  const state = yield select();
+  const currentProject = getCurrentProject(state);
   const analyzer = new Analyzer(currentProject);
 
   for (const [language, source] of currentProject.get('sources')) {
     yield fork(
       validateSource,
+      tasks,
       {payload: {language, source, projectAttributes: analyzer}},
     );
   }
 }
 
+export function* validateSource(
+  tasks,
+  {payload: {language, source, projectAttributes}},
+) {
+  if (tasks.has(language)) {
+    yield cancel(tasks.get(language));
+  }
+  const task = yield fork(validations[language], source, projectAttributes);
+  tasks.set(language, task);
+  const errors = yield join(task);
+  tasks.delete(language);
+  yield put(validatedSource(language, errors));
+}
+
 export default function* () {
+  const tasks = new Map();
+
   yield [
-    takeEvery('CHANGE_CURRENT_PROJECT', validateCurrentProject),
-    takeEvery('GIST_IMPORTED', validateCurrentProject),
+    takeEvery('CHANGE_CURRENT_PROJECT', validateCurrentProject, tasks),
+    takeEvery('GIST_IMPORTED', validateCurrentProject, tasks),
+    takeEvery('UPDATE_PROJECT_SOURCE', updateProjectSource, tasks),
   ];
 }

--- a/src/sagas/projects.js
+++ b/src/sagas/projects.js
@@ -44,6 +44,11 @@ export function* importGist({payload: {gistId}}) {
   }
 }
 
+export function* updateProjectSource() {
+  const state = yield select();
+  yield call(saveCurrentProject, state);
+}
+
 export function* userAuthenticated() {
   const state = yield select();
   yield fork(saveCurrentProject, state);
@@ -70,6 +75,7 @@ export default function* () {
     takeEvery('APPLICATION_LOADED', applicationLoaded),
     takeEvery('CREATE_PROJECT', createProject),
     takeEvery('CHANGE_CURRENT_PROJECT', changeCurrentProject),
+    takeEvery('UPDATE_PROJECT_SOURCE', updateProjectSource),
     takeEvery('USER_AUTHENTICATED', userAuthenticated),
   ];
 }

--- a/test/unit/reducers/errors.js
+++ b/test/unit/reducers/errors.js
@@ -7,7 +7,7 @@ import {
   changeCurrentProject,
   gistImported,
   projectCreated,
-  projectSourceEdited,
+  updateProjectSource,
 } from '../../../src/actions/projects';
 import {
   validatedSource,
@@ -57,9 +57,9 @@ test('gistImported', reducerTest(
   states.validating,
 ));
 
-test('projectSourceEdited', reducerTest(
+test('updateProjectSource', reducerTest(
   reducer,
   states.noErrors,
-  partial(projectSourceEdited, '12345', 'css', 'bogus', Date.now()),
+  partial(updateProjectSource, '12345', 'css', 'bogus', Date.now()),
   states.noErrors.setIn(['css', 'state'], 'validating'),
 ));

--- a/test/unit/reducers/errors.js
+++ b/test/unit/reducers/errors.js
@@ -5,8 +5,9 @@ import {errors as states} from '../../helpers/referenceStates';
 import {gistData} from '../../helpers/factory';
 import {
   changeCurrentProject,
-  projectCreated,
   gistImported,
+  projectCreated,
+  projectSourceEdited,
 } from '../../../src/actions/projects';
 import {
   validatedSource,
@@ -54,4 +55,11 @@ test('gistImported', reducerTest(
   states.noErrors,
   partial(gistImported, '12345', gistData({html: ''})),
   states.validating,
+));
+
+test('projectSourceEdited', reducerTest(
+  reducer,
+  states.noErrors,
+  partial(projectSourceEdited, '12345', 'css', 'bogus', Date.now()),
+  states.noErrors.setIn(['css', 'state'], 'validating'),
 ));

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -15,7 +15,7 @@ import {
   gistImported,
   projectCreated,
   projectLoaded,
-  projectSourceEdited,
+  updateProjectSource,
 } from '../../../src/actions/projects';
 import {userLoggedOut} from '../../../src/actions/user';
 
@@ -42,10 +42,10 @@ test('projectCreated', (t) => {
   ));
 });
 
-test('projectSourceEdited', reducerTest(
+test('updateProjectSource', reducerTest(
   reducer,
   initProjects({[projectKey]: false}),
-  partial(projectSourceEdited, projectKey, 'css', css, now),
+  partial(updateProjectSource, projectKey, 'css', css, now),
   initProjects({[projectKey]: true}).
     update(
       projectKey,
@@ -157,7 +157,7 @@ function initProjects(map = {}) {
     if (modified) {
       return reducer(
         projects,
-        projectSourceEdited(key, 'css', '', now),
+        updateProjectSource(key, 'css', '', now),
       );
     }
     return projects;

--- a/test/unit/sagas/errors.js
+++ b/test/unit/sagas/errors.js
@@ -23,9 +23,13 @@ test('validateCurrentProject()', (assert) => {
   for (const language of ['html', 'css', 'javascript']) {
     saga.next(args.shift()).fork(
       validateSourceSaga,
-      language,
-      scenario.project.getIn(['sources', language]),
-      scenario.analyzer,
+      {
+        payload: {
+          language,
+          source: scenario.project.getIn(['sources', language]),
+          projectAttributes: scenario.analyzer,
+        },
+      },
     );
   }
   saga.next().isDone();
@@ -38,7 +42,10 @@ test('validateSource()', (assert) => {
   const language = 'javascript';
   const source = 'alert("hi");';
   const errors = [{error: 'test'}];
-  testSaga(validateSourceSaga, language, source, projectAttributes).
+  testSaga(
+    validateSourceSaga,
+    {payload: {language, source, projectAttributes}},
+  ).
     next().call(validations.javascript, source, projectAttributes).
     next(errors).put(validatedSource(language, errors)).
     next().isDone();

--- a/test/unit/sagas/errors.js
+++ b/test/unit/sagas/errors.js
@@ -1,19 +1,23 @@
 import test from 'tape';
 import isEqual from 'lodash/isEqual';
+import {createMockTask} from 'redux-saga/utils';
 import {testSaga} from 'redux-saga-test-plan';
 import Scenario from '../../helpers/Scenario';
 import validations from '../../../src/validations';
+import {updateProjectSource} from '../../../src/actions/projects';
 import {validatedSource} from '../../../src/actions/errors';
 import {
+  updateProjectSource as updateProjectSourceSaga,
   validateCurrentProject as validateCurrentProjectSaga,
   validateSource as validateSourceSaga,
 } from '../../../src/sagas/errors';
 
 test('validateCurrentProject()', (assert) => {
+  const tasks = new Map();
   const scenario = new Scenario();
   let selector;
   assert.ok(isEqual(scenario.analyzer, scenario.analyzer));
-  const saga = testSaga(validateCurrentProjectSaga).
+  const saga = testSaga(validateCurrentProjectSaga, tasks).
     next().inspect((effect) => {
       assert.ok(effect.SELECT, 'invokes select effect');
       selector = effect.SELECT.selector;
@@ -23,6 +27,7 @@ test('validateCurrentProject()', (assert) => {
   for (const language of ['html', 'css', 'javascript']) {
     saga.next(args.shift()).fork(
       validateSourceSaga,
+      tasks,
       {
         payload: {
           language,
@@ -37,17 +42,60 @@ test('validateCurrentProject()', (assert) => {
   assert.end();
 });
 
-test('validateSource()', (assert) => {
+test('validateSource()', (t) => {
   const projectAttributes = {containsExternalScript: false};
   const language = 'javascript';
   const source = 'alert("hi");';
   const errors = [{error: 'test'}];
+  const action = {payload: {language, source, projectAttributes}};
+
+  t.test('validation completes', (assert) => {
+    const tasks = new Map();
+    const task = createMockTask();
+    testSaga(validateSourceSaga, tasks, action).
+      next().fork(validations.javascript, source, projectAttributes).
+      next(task).join(task).
+      next(errors).put(validatedSource(language, errors)).
+      next().isDone();
+    assert.end();
+  });
+
+  t.test('another validation initiated', (assert) => {
+    const tasks = new Map();
+    const firstTask = createMockTask();
+    const secondTask = createMockTask();
+    testSaga(validateSourceSaga, tasks, action).
+      next().fork(validations.javascript, source, projectAttributes).
+      next(firstTask).join(firstTask);
+
+    testSaga(validateSourceSaga, tasks, action).
+      next().cancel(firstTask).
+      next().fork(validations.javascript, source, projectAttributes).
+      next(secondTask).join(secondTask).
+      next(errors).put(validatedSource(language, errors)).
+      next().isDone();
+
+    assert.end();
+  });
+});
+
+test('updateProjectSource()', (assert) => {
+  const tasks = new Map();
+  const scenario = new Scenario();
+  const language = 'javascript';
+  const source = 'alert("hi");';
   testSaga(
-    validateSourceSaga,
-    {payload: {language, source, projectAttributes}},
+    updateProjectSourceSaga,
+    tasks,
+    updateProjectSource(scenario.projectKey, language, source),
   ).
-    next().call(validations.javascript, source, projectAttributes).
-    next(errors).put(validatedSource(language, errors)).
+    next().select().
+    next(scenario.state).call(
+      validateSourceSaga,
+      tasks,
+      {payload: {language, source, projectAttributes: scenario.analyzer}},
+    ).
     next().isDone();
+
   assert.end();
 });

--- a/test/unit/sagas/projects.js
+++ b/test/unit/sagas/projects.js
@@ -8,11 +8,13 @@ import {
   changeCurrentProject as changeCurrentProjectSaga,
   importGist as importGistSaga,
   userAuthenticated as userAuthenticatedSaga,
+  updateProjectSource as updateProjectSourceSaga,
 } from '../../../src/sagas/projects';
 import {
   gistImportError,
   gistNotFound,
   projectLoaded,
+  updateProjectSource,
 } from '../../../src/actions/projects';
 import {userAuthenticated} from '../../../src/actions/user';
 import applicationLoaded from '../../../src/actions/applicationLoaded';
@@ -154,5 +156,17 @@ test('userAuthenticated', (assert) => {
     ).
     next(mockPersistor).apply(mockPersistor, mockPersistor.all).
     next(projects).put(projectLoaded(projects[0]));
+  assert.end();
+});
+
+test('updateProjectSource', (assert) => {
+  const scenario = new Scenario();
+  testSaga(
+    updateProjectSourceSaga,
+    updateProjectSource(scenario.projectKey, 'css', 'p {}'),
+  ).
+    next().select().
+    next(scenario.state).call(saveCurrentProject, scenario.state).
+    next().isDone();
   assert.end();
 });


### PR DESCRIPTION
Another conversion of a thunk action workflow to pure sagas and reducers. This is handling the `UPDATE_PROJECT_SOURCE` action, which is dispatched when the user modifies the source in an editor.

Architecture is as follows:

**Workspace dispatches `PROJECT_SOURCE_EDITED`**

**`projects` reducer consumes `PROJECT_SOURCE_EDITED`

* Updates source accordingly

**`errors` reducer consumes `PROJECT_SOURCE_EDITED`**

* Sets error state for source to `validating`

**`projects` saga consumes `PROJECT_SOURCE_EDITED`**

* Saves the project

**`errors` saga consumes `PROJECT_SOURCE_EDITED`**

* Cancels any in-progress validation for that source
* Initiates validation for the source

One notable thing here is the first use of `redux-saga`’s task cancellation feature. In particular, if a user is typing quickly, we want to make sure to only pay attention to the results of the validation for the last thing they typed in.

More generally, we only want to pay attention to the *last* validation initiated for a given language. To that end, `validateSource()` is given a map of languages to the currently ongoing validation task for that language, if any. This map is maintained inside the root saga and passed to all sagas in the module. If, when `validateSource()` is called, there is a concurrent validation task for the same language, it will cancel that task.  When `validateSource()` completes, it clears its own validation task from the map.