### PR TITLE
add jshint rule to allow function hoisting

### DIFF
--- a/spec/examples/validations/javascript.spec.js
+++ b/spec/examples/validations/javascript.spec.js
@@ -47,4 +47,13 @@ describe('javascript', () => {
       'TinyTurtle.whatever();',
       [analyzerWithExternalScript]);
   });
+
+  it('should pass when a function is used before it is declared', () => {
+    assertPassesValidation(javascript,
+        `myFunction();
+        function myFunction() {
+            return true;   
+        }`,
+      [analyzer]);
+  });
 });

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -14,7 +14,7 @@ const jshintrc = {
   curly: true,
   devel: true,
   eqeqeq: true,
-  latedef: true,
+  latedef: 'nofunc',
   nonew: true,
   predef: [],
   shadow: 'outer',


### PR DESCRIPTION
This fixes issue #719.

This looks to have to been a design decision by JSLint to consider use of "hoisting" a bad practice. JSHint has added the option to override it if you want to.  

http://jshint.com/docs/options/#latedef

