### PR TITLE
add specific error message for ie or edge indicating they aren't supported

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -18,6 +18,7 @@
   },
   "bad-browser": {
     "message": "Popcode doesn’t work with your version of {{name}}.",
+    "ie-message": "Popcode doesn’t work with Internet Explorer or IE Edge. Please use another browser.",
     "download": "Click here to download a new version."
   },
   "notifications": {

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -7,6 +7,7 @@ import createApplicationStore from '../createApplicationStore';
 import {includeStoreInBugReports} from '../util/Bugsnag';
 import Workspace from './Workspace';
 import BrowserError from './BrowserError';
+import IEBrowserError from './IEBrowserError';
 
 const supportedBrowsers = JSON.parse(fs.readFileSync(
   path.join(__dirname, '../../config/browsers.json'),
@@ -20,6 +21,10 @@ class Application extends React.Component {
     includeStoreInBugReports(store);
   }
 
+  _isIEOrEdge() {
+    return (bowser.msie || bowser.msedge);
+  }
+
   _isUnsupportedBrowser() {
     return bowser.isUnsupportedBrowser(
       supportedBrowsers,
@@ -29,6 +34,10 @@ class Application extends React.Component {
   }
 
   render() {
+    if (this._isIEOrEdge()) {
+      return <IEBrowserError />;
+    }
+
     if (this._isUnsupportedBrowser()) {
       return <BrowserError browser={bowser} />;
     }

--- a/src/components/IEBrowserError.jsx
+++ b/src/components/IEBrowserError.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {t} from 'i18next';
+
+function IEBrowserError() {
+  return (
+    <div className="unsupported-browser">
+      <p>{t('bad-browser.ie-message')}</p>
+    </div>
+  );
+}
+
+export default IEBrowserError;


### PR DESCRIPTION
This fixes issue #517.  Let me know if you'd like other text, etc.

Again, I didn't add tests for this component-level change because the dependencies aren't there, but will add them when a library is chosen.

sorry to bombard you with pull requests : ) Just trying to get more real-world react experience and this is a neat app.