### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ for all the sordid details.
 * [Jeremy Schrader](http://www.pattern-factory.com/)
 * [Katie Conneally](http://www.katieconneally.com/) created the name Popcode
 * Logo design, "Pop" concept, and UI by the team at
-  [http://redpeakgroup.com](Red Peak): Andrew Haug, Aya Kawabata, Jieun Lee,
+  [Red Peak](http://redpeakgroup.com): Andrew Haug, Aya Kawabata, Jieun Lee,
   Achu Fones, Iwona Waluk, Stewart Devlin, and Katie Conneally
 
 ## Thanks to ##


### PR DESCRIPTION
Probably related to the recent Github markdown parser changes - the URL and display text were reversed.