### PR TITLE
Make editor zero-state unselectable, make click focus editor

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -419,6 +419,8 @@ body {
   margin: -1rem 0 0 -5.5rem;
   opacity: 0.4;
   font-family: Roboto;
+  user-select: none;
+  pointer-events: none;
 }
 
 .label {


### PR DESCRIPTION
user-select: none makes the text unselectable and pointer-events: none
makes it so the click event falls through to the editor, which handles
it.

Fixes: #363