### PR TITLE
Display a specific error for an empty <title> tag

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -96,6 +96,7 @@
       "duplicated-title": "You have more than one <title> tag in your document; you should only have one",
       "attribute-in-closing-tag": "You have an attribute in your closing </{{tag}}> tag. Attributes always belong in the opening <{{tag}}> tag.",
       "close-tag-for-void-element": "You don’t need a closing </{{tag}}> tag. The <{{tag}}> tag closes itself.",
+      "empty-title-element": "You have an empty <title> tag. A <title> tag should always contain text.",
       "html-in-css-block": "It looks like you typed some HTML code inside a <style> tag. Remember that only CSS code can go inside a <style> tag.",
       "invalid-attribute-name": "{{attribute}} isn’t allowed as an attribute name.",
       "mismatched-close-tag": "Your <{{open}}> tag needs a closing tag, but instead there’s a </{{close}}> tag where the </{{open}}> tag should be.",

--- a/spec/examples/validations/html.spec.js
+++ b/spec/examples/validations/html.spec.js
@@ -18,6 +18,15 @@ function htmlWithBody(body) {
 `;
 }
 
+function htmlWithHead(head) {
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    ${head}
+  </head>
+</html>`;
+}
+
 describe('html', () => {
   it('allows valid HTML', () =>
     assertPassesValidation(html, htmlWithBody('')),
@@ -171,6 +180,38 @@ describe('html', () => {
   it('produces an error for a malformed DOCTYPE that doesn’t parse', () =>
     assertFailsValidationWith(html, '<!DOCT\n', 'doctype'),
   );
+
+  describe('title', () => {
+    it('generates specific error when empty', () =>
+      assertFailsValidationWith(
+        html,
+        htmlWithHead(''),
+        'missing-title',
+      ),
+    );
+
+    it('generates specific error when missing', () =>
+      assertFailsValidationWith(
+        html,
+        htmlWithHead('<title></title>'),
+        'empty-title-element',
+      ),
+    );
+
+    it('allows with text', () =>
+      assertPassesValidation(
+        html,
+        htmlWithHead('<title>test</title>'),
+      ),
+    );
+
+    it('allows with child elements', () =>
+      assertPassesValidation(
+        html,
+        htmlWithHead('<title><span></span></title>'),
+      ),
+    );
+  });
 
   assertPassesAcceptance(html, 'html');
 });


### PR DESCRIPTION
Addresses https://github.com/popcodeorg/popcode/issues/347

I checked `htmllint` and `slowparse` and neither had a built in error for this case, hence the fallback to the custom error detector.

I tried to match the tone of the other error messages, but please let me know if I can make the messaging clearer.

![image](https://cloud.githubusercontent.com/assets/1098749/25064728/8bbab634-21ce-11e7-8c27-10acd2b820e5.png)
