### PR TITLE
Make search-in-code work

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -5,6 +5,7 @@ import get from 'lodash/get';
 import throttle from 'lodash/throttle';
 import noop from 'lodash/noop';
 
+import 'brace/ext/searchbox';
 import 'brace/mode/html';
 import 'brace/mode/css';
 import 'brace/mode/javascript';


### PR DESCRIPTION
Fixes https://github.com/popcodeorg/popcode/issues/313

It turns out that ACE comes with a bunch of keyboard shortcuts out of the box, including search. It wasn't working because the necessary extension script wasn't being loaded:
![image](https://cloud.githubusercontent.com/assets/1098749/25112794/8ae78472-23c1-11e7-8a26-312c6a5c1151.png)

Making the script available -> instant search capability!
![image](https://cloud.githubusercontent.com/assets/1098749/25112787/7c81fcd2-23c1-11e7-9c31-d3334b8e07d3.png)

I'd imagine that there are some other great shortcuts that we're erroring out on (here's the basic list of commands: https://github.com/ajaxorg/ace/blob/master/lib/ace/commands/default_commands.js)
