### PR TITLE
Migrate library toggle logic from thunk to sagas and reducers

### DIFF
--- a/spec/examples/actions/projects.spec.js
+++ b/spec/examples/actions/projects.spec.js
@@ -1,15 +1,12 @@
 /* eslint-env mocha */
-/* global sinon */
 
 import '../../helper';
 import {assert} from 'chai';
 
-import createAndMutateProject from '../../helpers/createAndMutateProject';
 import createApplicationStore from '../../../src/createApplicationStore';
 
 import {
   createProject,
-  changeCurrentProject,
 } from '../../../src/actions';
 
 import {
@@ -41,30 +38,6 @@ describe('projectActions', () => {
         isPristineProject(getCurrentProject(store.getState())),
         'project should be pristine',
       );
-    });
-  });
-
-  describe('changeCurrentProject', () => {
-    let projectKey, clock;
-
-    beforeEach(() => {
-      clock = sinon.useFakeTimers();
-      projectKey = createAndMutateProject(store);
-      clock.tick(1);
-      createAndMutateProject(store);
-      store.dispatch(changeCurrentProject(projectKey));
-    });
-
-    afterEach(() => {
-      clock.restore();
-    });
-
-    it('changes to the specified project', () => {
-      assert.equal(projectKey, getCurrentProject(store.getState()).projectKey);
-    });
-
-    it('keeps all projects in list', () => {
-      assert.lengthOf(getProjectKeys(store.getState()), 2);
     });
   });
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,6 +12,7 @@ import {
 import {
   createProject,
   changeCurrentProject,
+  toggleLibrary,
   updateProjectSource,
 } from './projects';
 
@@ -81,23 +82,6 @@ export function validateAllSources(project) {
     project.get('sources').forEach((source, language) => {
       dispatch(validateSource(language, source, projectAttributes));
     });
-  };
-}
-
-function toggleLibrary(projectKey, libraryKey) {
-  return (dispatch, getState) => {
-    dispatch({
-      type: 'PROJECT_LIBRARY_TOGGLED',
-      meta: {timestamp: Date.now()},
-      payload: {
-        projectKey,
-        libraryKey,
-      },
-    });
-
-    const state = getState();
-    dispatch(validateAllSources(getCurrentProject(state)));
-    saveCurrentProject(state);
   };
 }
 

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -18,6 +18,12 @@ export const updateProjectSource = createAction(
   (_projectKey, _language, _newValue, timestamp = Date.now()) => ({timestamp}),
 );
 
+export const toggleLibrary = createAction(
+  'TOGGLE_LIBRARY',
+  (projectKey, libraryKey) => ({projectKey, libraryKey}),
+  (_projectKey, _libraryKey, timestamp = Date.now()) => ({timestamp}),
+);
+
 export const gistImported = createAction(
   'GIST_IMPORTED',
   (projectKey, gistData) => ({projectKey, gistData}),

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -43,10 +43,3 @@ export const projectLoaded = createAction(
   'PROJECT_LOADED',
   project => ({project}),
 );
-
-export function loadCurrentProject(project) {
-  return (dispatch) => {
-    dispatch(projectLoaded(project));
-    dispatch(changeCurrentProject(project.projectKey));
-  };
-}

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -47,6 +47,9 @@ function errors(stateIn, action) {
     case 'GIST_IMPORTED':
       return validatingErrors;
 
+    case 'TOGGLE_LIBRARY':
+      return validatingErrors;
+
     case 'UPDATE_PROJECT_SOURCE':
       return state.set(action.payload.language, validatingLanguageErrors);
 

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -124,7 +124,7 @@ export default function reduceProjects(stateIn, action) {
         action.payload.gistData,
       );
 
-    case 'PROJECT_LIBRARY_TOGGLED':
+    case 'TOGGLE_LIBRARY':
       return state.updateIn(
         [action.payload.projectKey, 'enabledLibraries'],
         (enabledLibraries) => {

--- a/src/sagas/errors.js
+++ b/src/sagas/errors.js
@@ -18,6 +18,10 @@ function getCurrentProject(state) {
   ]);
 }
 
+export function* toggleLibrary(tasks) {
+  yield call(validateCurrentProject, tasks);
+}
+
 export function* updateProjectSource(tasks, {payload: {language, newValue}}) {
   const state = yield select();
   const analyzer = new Analyzer(getCurrentProject(state));
@@ -63,5 +67,6 @@ export default function* () {
     takeEvery('CHANGE_CURRENT_PROJECT', validateCurrentProject, tasks),
     takeEvery('GIST_IMPORTED', validateCurrentProject, tasks),
     takeEvery('UPDATE_PROJECT_SOURCE', updateProjectSource, tasks),
+    takeEvery('TOGGLE_LIBRARY', toggleLibrary, tasks),
   ];
 }

--- a/src/sagas/projects.js
+++ b/src/sagas/projects.js
@@ -65,6 +65,12 @@ export function* userAuthenticated() {
   }
 }
 
+export function* toggleLibrary() {
+  const state = yield select();
+
+  yield call(saveCurrentProject, state);
+}
+
 function generateProjectKey() {
   const date = new Date();
   return (date.getTime() * 1000 + date.getMilliseconds()).toString();
@@ -77,5 +83,6 @@ export default function* () {
     takeEvery('CHANGE_CURRENT_PROJECT', changeCurrentProject),
     takeEvery('UPDATE_PROJECT_SOURCE', updateProjectSource),
     takeEvery('USER_AUTHENTICATED', userAuthenticated),
+    takeEvery('TOGGLE_LIBRARY', toggleLibrary),
   ];
 }

--- a/test/unit/reducers/errors.js
+++ b/test/unit/reducers/errors.js
@@ -7,6 +7,7 @@ import {
   changeCurrentProject,
   gistImported,
   projectCreated,
+  toggleLibrary,
   updateProjectSource,
 } from '../../../src/actions/projects';
 import {
@@ -62,4 +63,11 @@ test('updateProjectSource', reducerTest(
   states.noErrors,
   partial(updateProjectSource, '12345', 'css', 'bogus', Date.now()),
   states.noErrors.setIn(['css', 'state'], 'validating'),
+));
+
+test('updateProjectSource', reducerTest(
+  reducer,
+  states.noErrors,
+  partial(toggleLibrary, '12345', 'jquery'),
+  states.validating,
 ));

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -15,6 +15,7 @@ import {
   gistImported,
   projectCreated,
   projectLoaded,
+  toggleLibrary,
   updateProjectSource,
 } from '../../../src/actions/projects';
 import {userLoggedOut} from '../../../src/actions/user';
@@ -148,6 +149,18 @@ tap(initProjects({1: true, 2: true}), projects =>
       currentProject: {projectKey: '1'},
       projects: projects.take(1),
     }),
+  )),
+);
+
+tap(initProjects({1: false}), projects =>
+  test('toggleLibrary', reducerTest(
+    reducer,
+    projects,
+    partial(toggleLibrary, '1', 'jquery', now),
+    projects.update('1', projectIn =>
+      projectIn.set('enabledLibraries', new Immutable.Set(['jquery'])).
+        set('updatedAt', now),
+    ),
   )),
 );
 

--- a/test/unit/sagas/errors.js
+++ b/test/unit/sagas/errors.js
@@ -4,9 +4,13 @@ import {createMockTask} from 'redux-saga/utils';
 import {testSaga} from 'redux-saga-test-plan';
 import Scenario from '../../helpers/Scenario';
 import validations from '../../../src/validations';
-import {updateProjectSource} from '../../../src/actions/projects';
+import {
+  updateProjectSource,
+  toggleLibrary,
+} from '../../../src/actions/projects';
 import {validatedSource} from '../../../src/actions/errors';
 import {
+  toggleLibrary as toggleLibrarySaga,
   updateProjectSource as updateProjectSourceSaga,
   validateCurrentProject as validateCurrentProjectSaga,
   validateSource as validateSourceSaga,
@@ -95,6 +99,20 @@ test('updateProjectSource()', (assert) => {
       tasks,
       {payload: {language, source, projectAttributes: scenario.analyzer}},
     ).
+    next().isDone();
+
+  assert.end();
+});
+
+test('toggleLibrary()', (assert) => {
+  const tasks = new Map();
+  const scenario = new Scenario();
+  testSaga(
+    toggleLibrarySaga,
+    tasks,
+    toggleLibrary(scenario.projectKey, 'jquery'),
+  ).
+    next().call(validateCurrentProjectSaga, tasks).
     next().isDone();
 
   assert.end();

--- a/test/unit/sagas/projects.js
+++ b/test/unit/sagas/projects.js
@@ -7,6 +7,7 @@ import {
   createProject as createProjectSaga,
   changeCurrentProject as changeCurrentProjectSaga,
   importGist as importGistSaga,
+  toggleLibrary as toggleLibrarySaga,
   userAuthenticated as userAuthenticatedSaga,
   updateProjectSource as updateProjectSourceSaga,
 } from '../../../src/sagas/projects';
@@ -14,6 +15,7 @@ import {
   gistImportError,
   gistNotFound,
   projectLoaded,
+  toggleLibrary,
   updateProjectSource,
 } from '../../../src/actions/projects';
 import {userAuthenticated} from '../../../src/actions/user';
@@ -164,6 +166,18 @@ test('updateProjectSource', (assert) => {
   testSaga(
     updateProjectSourceSaga,
     updateProjectSource(scenario.projectKey, 'css', 'p {}'),
+  ).
+    next().select().
+    next(scenario.state).call(saveCurrentProject, scenario.state).
+    next().isDone();
+  assert.end();
+});
+
+test('toggleLibrary', (assert) => {
+  const scenario = new Scenario();
+  testSaga(
+    toggleLibrarySaga,
+    toggleLibrary(scenario.projectKey, 'jquery'),
   ).
     next().select().
     next(scenario.state).call(saveCurrentProject, scenario.state).


### PR DESCRIPTION
**Workspace component issues `TOGGLE_LIBRARY`**

**`projects` reducer consumes `TOGGLE_LIBRARY`**

* Updates library state
* Updates `updatedAt`

**`projects` saga consumes `TOGGLE_LIBRARY`**

* Saves current project

**`errors` saga consumes `TOGGLE_LIBRARY`**

* Initiates validation for project

**`errors` reducer consumes `TOGGLE_LIBRARY`**

* Sets project validation state to validating