### PR TITLE
Statically render "chill" loader while waiting for React

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -566,7 +566,7 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  height: 20%;
+  height: 50%;
   width: 20%;
   margin-left: -10%;
   margin-top: -10%;
@@ -580,6 +580,11 @@ body {
   font-size: 1.5vw;
   padding-left: 1em;
   color: var(--color-dark-gray);
+}
+
+.pop-throbber__image {
+  background: url('../images/pop/thinking.svg') center no-repeat;
+  height: 100%;
 }
 
 .pop-throbber path {
@@ -608,11 +613,4 @@ body {
 
 .u__hidden {
   display: none;
-}
-
-.loading {
-  background: url('../images/large-spinner.gif') center/20vh no-repeat;
-  cursor: not-allowed;
-  height: 100vh;
-  width: 100%;
 }

--- a/static/images/pop/thinking.svg
+++ b/static/images/pop/thinking.svg
@@ -48,7 +48,7 @@
   <defs
      id="defs3">
     <style
-       id="style5">.cls-1{fill:#00ff85;}.cls-2{fill:#fff;}.cls-3{fill:#221f1f;}</style>
+       id="style5">.cls-1{fill:#00ff85;}.cls-2{fill:#eee;}.cls-3{fill:#221f1f;}</style>
   </defs>
   <title
      id="title7">04</title>

--- a/static/index.html
+++ b/static/index.html
@@ -9,7 +9,10 @@
   </head>
   <body>
     <div id="main">
-      <div class="loading"></div>
+      <div class="pop-throbber">
+        <div class="pop-throbber__message">Loading…</div>
+        <div class="pop-throbber__image"></div>
+      </div>
     </div>
     <script src="compiled/application.js"></script>
   </body>


### PR DESCRIPTION
Addresses the startup portion of https://github.com/popcodeorg/popcode/issues/781

Here's a recording of the standard page load from popcode.org
![chillloaderv1](https://cloud.githubusercontent.com/assets/1098749/25211668/4b0d5630-2554-11e7-9f97-6f20901da437.gif)

And here's a recording of a page load of popcode.org with a gist querystring (also shows that the pre-existing chill loader is unchanged)
![chillloaderv2](https://cloud.githubusercontent.com/assets/1098749/25211672/4d2559cc-2554-11e7-8a89-633ec60ec487.gif)
