### PR TITLE
Move <Workspace>._renderEditors into new <EditorsColumn> component

### DIFF
--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import isEmpty from 'lodash/isEmpty';
+import includes from 'lodash/includes';
+import partial from 'lodash/partial';
+
+import EditorContainer from './EditorContainer';
+import Editor from './Editor';
+
+function allErrorsFor(language, errors, runtimeErrors) {
+  if (language === 'javascript') {
+    return errors.javascript.items.concat(runtimeErrors);
+  }
+  return errors[language].items;
+}
+
+export default function EditorsColumn({
+  currentProject,
+  errors,
+  onComponentMinimize,
+  onEditorInput,
+  onRequestedLineFocused,
+  runtimeErrors,
+  ui,
+}) {
+  const editors = [];
+  ['html', 'css', 'javascript'].forEach((language) => {
+    if (includes(ui.minimizedComponents, `editor.${language}`)) {
+      return;
+    }
+
+    editors.push(
+      <EditorContainer
+        key={language}
+        language={language}
+        source={currentProject.sources[language]}
+        onMinimize={
+          partial(onComponentMinimize, `editor.${language}`)
+        }
+      >
+        <Editor
+          errors={allErrorsFor(language, errors, runtimeErrors)}
+          key={language}
+          language={language}
+          percentageOfHeight={1 / editors.length}
+          projectKey={currentProject.projectKey}
+          requestedFocusedLine={ui.editors.requestedFocusedLine}
+          source={currentProject.sources[language]}
+          onInput={partial(onEditorInput, language)}
+          onRequestedLineFocused={onRequestedLineFocused}
+        />
+      </EditorContainer>,
+    );
+  });
+
+  if (isEmpty(editors)) {
+    return null;
+  }
+
+  return (
+    <div className="environment__column">
+      <div className="environment__columnContents editors">{editors}</div>
+    </div>
+  );
+}
+
+EditorsColumn.propTypes = {
+  currentProject: React.PropTypes.object.isRequired,
+  errors: React.PropTypes.object.isRequired,
+  runtimeErrors: React.PropTypes.array.isRequired,
+  ui: React.PropTypes.shape({
+    editors: React.PropTypes.object.isRequired,
+    minimizedComponents: React.PropTypes.array.isRequired,
+  }).isRequired,
+  onComponentMinimize: React.PropTypes.func.isRequired,
+  onEditorInput: React.PropTypes.func.isRequired,
+  onRequestedLineFocused: React.PropTypes.func.isRequired,
+};


### PR DESCRIPTION
As suggested in https://github.com/popcodeorg/popcode/issues/302#issuecomment-297600122.

This is mostly cut/copypasta from `Workspace.jsx`, with some minor tweaks (using destructuring and `connect` a bit more aggressively).

@outoftime I'm going to file a PR (probably this weekend) against this branch (or `master` if this gets merged first) with an updated version of the demo also mentioned in https://github.com/popcodeorg/popcode/issues/302#issuecomment-297600122.