### PR TITLE
Sticky editor open/close state

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,6 +13,8 @@ import {
   createProject,
   changeCurrentProject,
   toggleLibrary,
+  minimizeComponent,
+  maximizeComponent,
   updateProjectSource,
 } from './projects';
 
@@ -112,20 +114,6 @@ function addRuntimeError(error) {
 function clearRuntimeErrors() {
   return {
     type: 'RUNTIME_ERRORS_CLEARED',
-  };
-}
-
-function minimizeComponent(componentName) {
-  return {
-    type: 'COMPONENT_MINIMIZED',
-    payload: {componentName},
-  };
-}
-
-function maximizeComponent(componentName) {
-  return {
-    type: 'COMPONENT_MAXIMIZED',
-    payload: {componentName},
   };
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,8 +13,8 @@ import {
   createProject,
   changeCurrentProject,
   toggleLibrary,
-  minimizeComponent,
-  maximizeComponent,
+  hideComponent,
+  unhideComponent,
   updateProjectSource,
 } from './projects';
 
@@ -134,8 +134,8 @@ export {
   userLoggedOut,
   addRuntimeError,
   clearRuntimeErrors,
-  minimizeComponent,
-  maximizeComponent,
+  hideComponent,
+  unhideComponent,
   toggleDashboard,
   toggleDashboardSubmenu,
   userRequestedFocusedLine,

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -24,14 +24,14 @@ export const toggleLibrary = createAction(
   (_projectKey, _libraryKey, timestamp = Date.now()) => ({timestamp}),
 );
 
-export const minimizeComponent = createAction(
-  'MINIMIZE_COMPONENT',
+export const hideComponent = createAction(
+  'HIDE_COMPONENT',
   (projectKey, componentName) => ({projectKey, componentName}),
   (_projectKey, _componentName, timestamp = Date.now()) => ({timestamp}),
 );
 
-export const maximizeComponent = createAction(
-  'MAXIMIZE_COMPONENT',
+export const unhideComponent = createAction(
+  'UNHIDE_COMPONENT',
   (projectKey, componentName) => ({projectKey, componentName}),
   (_projectKey, _componentName, timestamp = Date.now()) => ({timestamp}),
 );

--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -24,6 +24,18 @@ export const toggleLibrary = createAction(
   (_projectKey, _libraryKey, timestamp = Date.now()) => ({timestamp}),
 );
 
+export const minimizeComponent = createAction(
+  'MINIMIZE_COMPONENT',
+  (projectKey, componentName) => ({projectKey, componentName}),
+  (_projectKey, _componentName, timestamp = Date.now()) => ({timestamp}),
+);
+
+export const maximizeComponent = createAction(
+  'MAXIMIZE_COMPONENT',
+  (projectKey, componentName) => ({projectKey, componentName}),
+  (_projectKey, _componentName, timestamp = Date.now()) => ({timestamp}),
+);
+
 export const gistImported = createAction(
   'GIST_IMPORTED',
   (projectKey, gistData) => ({projectKey, gistData}),

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -19,7 +19,7 @@ function EditorContainer(props) {
     <div className="editors__editor-container">
       <div
         className="environment__label label"
-        onClick={props.onMinimize}
+        onClick={props.onHide}
       >
         {t(`languages.${props.language}`)}
       </div>
@@ -33,7 +33,7 @@ EditorContainer.propTypes = {
   children: React.PropTypes.node.isRequired,
   language: React.PropTypes.string.isRequired,
   source: React.PropTypes.string.isRequired,
-  onMinimize: React.PropTypes.func.isRequired,
+  onHide: React.PropTypes.func.isRequired,
 };
 
 export default EditorContainer;

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -16,7 +16,7 @@ function allErrorsFor(language, errors, runtimeErrors) {
 export default function EditorsColumn({
   currentProject,
   errors,
-  onComponentMinimize,
+  onComponentHide,
   onEditorInput,
   onRequestedLineFocused,
   runtimeErrors,
@@ -33,8 +33,8 @@ export default function EditorsColumn({
         key={language}
         language={language}
         source={currentProject.sources[language]}
-        onMinimize={
-          partial(onComponentMinimize, `editor.${language}`)
+        onHide={
+          partial(onComponentHide, `editor.${language}`)
         }
       >
         <Editor
@@ -70,7 +70,7 @@ EditorsColumn.propTypes = {
   ui: React.PropTypes.shape({
     editors: React.PropTypes.object.isRequired,
   }).isRequired,
-  onComponentMinimize: React.PropTypes.func.isRequired,
+  onComponentHide: React.PropTypes.func.isRequired,
   onEditorInput: React.PropTypes.func.isRequired,
   onRequestedLineFocused: React.PropTypes.func.isRequired,
 };

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -24,7 +24,7 @@ export default function EditorsColumn({
 }) {
   const editors = [];
   ['html', 'css', 'javascript'].forEach((language) => {
-    if (includes(currentProject.minimizedComponents, `editor.${language}`)) {
+    if (includes(currentProject.hiddenUIComponents, `editor.${language}`)) {
       return;
     }
 
@@ -69,7 +69,6 @@ EditorsColumn.propTypes = {
   runtimeErrors: React.PropTypes.array.isRequired,
   ui: React.PropTypes.shape({
     editors: React.PropTypes.object.isRequired,
-    minimizedComponents: React.PropTypes.array.isRequired,
   }).isRequired,
   onComponentMinimize: React.PropTypes.func.isRequired,
   onEditorInput: React.PropTypes.func.isRequired,

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -24,7 +24,7 @@ export default function EditorsColumn({
 }) {
   const editors = [];
   ['html', 'css', 'javascript'].forEach((language) => {
-    if (includes(ui.minimizedComponents, `editor.${language}`)) {
+    if (includes(currentProject.minimizedComponents, `editor.${language}`)) {
       return;
     }
 

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -70,7 +70,7 @@ class Output extends React.Component {
         <div className="environment__columnContents output">
           <div
             className="environment__label label"
-            onClick={this.props.onMinimize}
+            onClick={this.props.onHide}
           >
             {t('workspace.components.output')}
           </div>
@@ -91,7 +91,7 @@ Output.propTypes = {
   validationState: React.PropTypes.string.isRequired,
   onClearRuntimeErrors: React.PropTypes.func.isRequired,
   onErrorClick: React.PropTypes.func.isRequired,
-  onMinimize: React.PropTypes.func.isRequired,
+  onHide: React.PropTypes.func.isRequired,
   onRuntimeError: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,13 +5,13 @@ import partial from 'lodash/partial';
 import WordmarkVertical from '../../static/images/wordmark-vertical.svg';
 
 class Sidebar extends React.Component {
-  _renderMinimizedComponents() {
-    const components = this.props.minimizedComponents.
+  _renderHiddenComponents() {
+    const components = this.props.hiddenComponents.
       map(componentName => (
         <div
           className="sidebar__minimized-component"
           key={componentName}
-          onClick={partial(this.props.onComponentMaximized, componentName)}
+          onClick={partial(this.props.onComponentUnhide, componentName)}
         >
           {t(`workspace.components.${componentName}`)}
         </div>
@@ -48,7 +48,7 @@ class Sidebar extends React.Component {
           )}
           onClick={this.props.onToggleDashboard}
         />
-        {this._renderMinimizedComponents()}
+        {this._renderHiddenComponents()}
       </div>
     );
   }
@@ -56,9 +56,9 @@ class Sidebar extends React.Component {
 
 Sidebar.propTypes = {
   dashboardIsOpen: React.PropTypes.bool.isRequired,
-  minimizedComponents: React.PropTypes.array.isRequired,
+  hiddenComponents: React.PropTypes.array.isRequired,
   validationState: React.PropTypes.string.isRequired,
-  onComponentMaximized: React.PropTypes.func.isRequired,
+  onComponentUnhide: React.PropTypes.func.isRequired,
   onToggleDashboard: React.PropTypes.func.isRequired,
 };
 

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -35,8 +35,8 @@ import {
   userAuthenticated,
   userLoggedOut,
   toggleLibrary,
-  minimizeComponent,
-  maximizeComponent,
+  hideComponent,
+  unhideComponent,
   toggleDashboard,
   toggleDashboardSubmenu,
   userRequestedFocusedLine,
@@ -92,8 +92,8 @@ class Workspace extends React.Component {
       this,
       '_confirmUnload',
       '_handleClearRuntimeErrors',
-      '_handleComponentMaximized',
-      '_handleComponentMinimized',
+      '_handleComponentUnhide',
+      '_handleComponentHide',
       '_handleDashboardSubmenuToggled',
       '_handleEditorInput',
       '_handleErrorClick',
@@ -139,18 +139,18 @@ class Workspace extends React.Component {
     }
   }
 
-  _handleComponentMinimized(componentName) {
+  _handleComponentHide(componentName) {
     this.props.dispatch(
-      minimizeComponent(
+      hideComponent(
         this.props.currentProject.projectKey,
         componentName,
       ),
     );
   }
 
-  _handleComponentMaximized(componentName) {
+  _handleComponentUnhide(componentName) {
     this.props.dispatch(
-      maximizeComponent(
+      unhideComponent(
         this.props.currentProject.projectKey,
         componentName,
       ),
@@ -158,7 +158,7 @@ class Workspace extends React.Component {
   }
 
   _handleErrorClick(language, line, column) {
-    this.props.dispatch(maximizeComponent(`editor.${language}`));
+    this.props.dispatch(unhideComponent(`editor.${language}`));
     this.props.dispatch(userRequestedFocusedLine(language, line, column));
   }
 
@@ -229,8 +229,8 @@ class Workspace extends React.Component {
         validationState={this._getOverallValidationState()}
         onClearRuntimeErrors={this._handleClearRuntimeErrors}
         onErrorClick={this._handleErrorClick}
-        onMinimize={
-          partial(this._handleComponentMinimized,
+        onHide={
+          partial(this._handleComponentHide,
             'output')
         }
         onRuntimeError={this._handleRuntimeError}
@@ -367,17 +367,17 @@ class Workspace extends React.Component {
   }
 
   _renderSidebar() {
-    let minimizedComponents = [];
+    let hiddenComponents = [];
     if (!isNull(this.props.currentProject)) {
-      minimizedComponents = this.props.currentProject.hiddenUIComponents;
+      hiddenComponents = this.props.currentProject.hiddenUIComponents;
     }
     return (
       <div className="layout__sidebar">
         <Sidebar
           dashboardIsOpen={this.props.ui.dashboard.isOpen}
-          minimizedComponents={minimizedComponents}
+          hiddenComponents={hiddenComponents}
           validationState={this._getOverallValidationState()}
-          onComponentMaximized={this._handleComponentMaximized}
+          onComponentUnhide={this._handleComponentUnhide}
           onToggleDashboard={this._handleToggleDashboard}
         />
       </div>
@@ -397,7 +397,7 @@ class Workspace extends React.Component {
           errors={this.props.errors}
           runtimeErrors={this.props.runtimeErrors}
           ui={this.props.ui}
-          onComponentMinimize={this._handleComponentMinimized}
+          onComponentHide={this._handleComponentHide}
           onEditorInput={this._handleEditorInput}
           onRequestedLineFocused={this._handleRequestedLineFocused}
         />

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -219,11 +219,11 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
-    const minimizedComponents = this.props.currentProject.minimizedComponents;
+    const {hiddenUIComponents} = this.props.currentProject;
     return (
       <Output
         errors={this.props.errors}
-        isHidden={includes(minimizedComponents, 'output')}
+        isHidden={includes(hiddenUIComponents, 'output')}
         project={this.props.currentProject}
         runtimeErrors={this.props.runtimeErrors}
         validationState={this._getOverallValidationState()}
@@ -369,7 +369,7 @@ class Workspace extends React.Component {
   _renderSidebar() {
     let minimizedComponents = [];
     if (!isNull(this.props.currentProject)) {
-      minimizedComponents = this.props.currentProject.minimizedComponents;
+      minimizedComponents = this.props.currentProject.hiddenUIComponents;
     }
     return (
       <div className="layout__sidebar">

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -140,11 +140,21 @@ class Workspace extends React.Component {
   }
 
   _handleComponentMinimized(componentName) {
-    this.props.dispatch(minimizeComponent(componentName));
+    this.props.dispatch(
+      minimizeComponent(
+        this.props.currentProject.projectKey,
+        componentName,
+      ),
+    );
   }
 
   _handleComponentMaximized(componentName) {
-    this.props.dispatch(maximizeComponent(componentName));
+    this.props.dispatch(
+      maximizeComponent(
+        this.props.currentProject.projectKey,
+        componentName,
+      ),
+    );
   }
 
   _handleErrorClick(language, line, column) {
@@ -209,10 +219,11 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
+    const minimizedComponents = this.props.currentProject.minimizedComponents;
     return (
       <Output
         errors={this.props.errors}
-        isHidden={includes(this.props.ui.minimizedComponents, 'output')}
+        isHidden={includes(minimizedComponents, 'output')}
         project={this.props.currentProject}
         runtimeErrors={this.props.runtimeErrors}
         validationState={this._getOverallValidationState()}
@@ -356,11 +367,15 @@ class Workspace extends React.Component {
   }
 
   _renderSidebar() {
+    let minimizedComponents = [];
+    if (!isNull(this.props.currentProject)) {
+      minimizedComponents = this.props.currentProject.minimizedComponents;
+    }
     return (
       <div className="layout__sidebar">
         <Sidebar
           dashboardIsOpen={this.props.ui.dashboard.isOpen}
-          minimizedComponents={this.props.ui.minimizedComponents}
+          minimizedComponents={minimizedComponents}
           validationState={this._getOverallValidationState()}
           onComponentMaximized={this._handleComponentMaximized}
           onToggleDashboard={this._handleToggleDashboard}

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -141,7 +141,7 @@ export default function reduceProjects(stateIn, action) {
         action.meta.timestamp,
       );
 
-    case 'MINIMIZE_COMPONENT':
+    case 'HIDE_COMPONENT':
       return state.updateIn(
         [action.payload.projectKey, 'hiddenUIComponents'],
         hiddenUIComponents =>
@@ -151,7 +151,7 @@ export default function reduceProjects(stateIn, action) {
         action.meta.timestamp,
       );
 
-    case 'MAXIMIZE_COMPONENT':
+    case 'UNHIDE_COMPONENT':
       return state.updateIn(
         [action.payload.projectKey, 'hiddenUIComponents'],
         hiddenUIComponents =>

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -144,9 +144,8 @@ export default function reduceProjects(stateIn, action) {
     case 'MINIMIZE_COMPONENT':
       return state.updateIn(
         [action.payload.projectKey, 'minimizedComponents'],
-        (minimizedComponents) => {
-          return minimizedComponents.add(action.payload.componentName);
-        },
+        minimizedComponents =>
+          minimizedComponents.add(action.payload.componentName),
       ).setIn(
         [action.payload.projectKey, 'updatedAt'],
         action.meta.timestamp,
@@ -155,9 +154,8 @@ export default function reduceProjects(stateIn, action) {
     case 'MAXIMIZE_COMPONENT':
       return state.updateIn(
         [action.payload.projectKey, 'minimizedComponents'],
-        (minimizedComponents) => {
-          return minimizedComponents.delete(action.payload.componentName);
-        },
+        minimizedComponents =>
+          minimizedComponents.delete(action.payload.componentName),
       ).setIn(
         [action.payload.projectKey, 'updatedAt'],
         action.meta.timestamp,

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -25,13 +25,14 @@ const newProject = Immutable.fromJS({
     javascript: '',
   },
   enabledLibraries: new Immutable.Set(),
+  minimizedComponents: new Immutable.Set(),
 });
 
 function projectToImmutable(project) {
-  return Immutable.fromJS(project).set(
-    'enabledLibraries',
-    new Immutable.Set(project.enabledLibraries),
-  );
+  return Immutable.fromJS(project).merge({
+    enabledLibraries: new Immutable.Set(project.enabledLibraries),
+    minimizedComponents: new Immutable.Set(project.minimizedComponents),
+  });
 }
 
 function addProject(state, project) {
@@ -60,6 +61,7 @@ function importGist(state, projectKey, gistData) {
         join('\n\n'),
       },
       enabledLibraries: popcodeJson.enabledLibraries || [],
+      minimizedComponents: popcodeJson.minimizedComponents || [],
     },
   );
 }
@@ -133,6 +135,28 @@ export default function reduceProjects(stateIn, action) {
             return enabledLibraries.delete(libraryKey);
           }
           return enabledLibraries.add(libraryKey);
+        },
+      ).setIn(
+        [action.payload.projectKey, 'updatedAt'],
+        action.meta.timestamp,
+      );
+
+    case 'MINIMIZE_COMPONENT':
+      return state.updateIn(
+        [action.payload.projectKey, 'minimizedComponents'],
+        (minimizedComponents) => {
+          return minimizedComponents.add(action.payload.componentName);
+        },
+      ).setIn(
+        [action.payload.projectKey, 'updatedAt'],
+        action.meta.timestamp,
+      );
+
+    case 'MAXIMIZE_COMPONENT':
+      return state.updateIn(
+        [action.payload.projectKey, 'minimizedComponents'],
+        (minimizedComponents) => {
+          return minimizedComponents.delete(action.payload.componentName);
         },
       ).setIn(
         [action.payload.projectKey, 'updatedAt'],

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -25,13 +25,13 @@ const newProject = Immutable.fromJS({
     javascript: '',
   },
   enabledLibraries: new Immutable.Set(),
-  minimizedComponents: new Immutable.Set(),
+  hiddenUIComponents: new Immutable.Set(),
 });
 
 function projectToImmutable(project) {
   return Immutable.fromJS(project).merge({
     enabledLibraries: new Immutable.Set(project.enabledLibraries),
-    minimizedComponents: new Immutable.Set(project.minimizedComponents),
+    hiddenUIComponents: new Immutable.Set(project.hiddenUIComponents),
   });
 }
 
@@ -61,7 +61,7 @@ function importGist(state, projectKey, gistData) {
         join('\n\n'),
       },
       enabledLibraries: popcodeJson.enabledLibraries || [],
-      minimizedComponents: popcodeJson.minimizedComponents || [],
+      hiddenUIComponents: popcodeJson.hiddenUIComponents || [],
     },
   );
 }
@@ -143,9 +143,9 @@ export default function reduceProjects(stateIn, action) {
 
     case 'MINIMIZE_COMPONENT':
       return state.updateIn(
-        [action.payload.projectKey, 'minimizedComponents'],
-        minimizedComponents =>
-          minimizedComponents.add(action.payload.componentName),
+        [action.payload.projectKey, 'hiddenUIComponents'],
+        hiddenUIComponents =>
+          hiddenUIComponents.add(action.payload.componentName),
       ).setIn(
         [action.payload.projectKey, 'updatedAt'],
         action.meta.timestamp,
@@ -153,9 +153,9 @@ export default function reduceProjects(stateIn, action) {
 
     case 'MAXIMIZE_COMPONENT':
       return state.updateIn(
-        [action.payload.projectKey, 'minimizedComponents'],
-        minimizedComponents =>
-          minimizedComponents.delete(action.payload.componentName),
+        [action.payload.projectKey, 'hiddenUIComponents'],
+        hiddenUIComponents =>
+          hiddenUIComponents.delete(action.payload.componentName),
       ).setIn(
         [action.payload.projectKey, 'updatedAt'],
         action.meta.timestamp,

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -4,7 +4,6 @@ import pick from 'lodash/pick';
 const defaultState = new Immutable.Map().
   set('editors', new Immutable.Map({typing: false})).
   set('requestedLine', null).
-  set('minimizedComponents', new Immutable.Set()).
   set('notifications', new Immutable.Set()).
   set(
     'dashboard',
@@ -51,18 +50,6 @@ function ui(stateIn, action) {
 
         return newSubmenu;
       });
-
-    case 'COMPONENT_MINIMIZED':
-      return state.update(
-        'minimizedComponents',
-        components => components.add(action.payload.componentName),
-      );
-
-    case 'COMPONENT_MAXIMIZED':
-      return state.update(
-        'minimizedComponents',
-        components => components.delete(action.payload.componentName),
-      );
 
     case 'USER_REQUESTED_FOCUSED_LINE':
       return state.setIn(

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -49,7 +49,7 @@ export function createGistFromProject(project) {
       language: 'JavaScript',
     };
   }
-  if (project.enabledLibraries.length) {
+  if (project.enabledLibraries.length || project.minimizedComponents.length) {
     files['popcode.json'] = {
       content: createPopcodeJson(project),
       language: 'JSON',
@@ -92,9 +92,13 @@ async function updateGistWithImportUrl(github, gistData) {
 }
 
 function createPopcodeJson(project) {
-  const json = {
-    enabledLibraries: project.enabledLibraries,
-  };
+  const json = {};
+  if (project.enabledLibraries.length) {
+    json.enabledLibraries = project.enabledLibraries;
+  }
+  if (project.minimizedComponents.length) {
+    json.minimizedComponents = project.minimizedComponents;
+  }
   return JSON.stringify(json);
 }
 

--- a/src/services/Gists.js
+++ b/src/services/Gists.js
@@ -49,7 +49,7 @@ export function createGistFromProject(project) {
       language: 'JavaScript',
     };
   }
-  if (project.enabledLibraries.length || project.minimizedComponents.length) {
+  if (project.enabledLibraries.length || project.hiddenUIComponents.length) {
     files['popcode.json'] = {
       content: createPopcodeJson(project),
       language: 'JSON',
@@ -96,8 +96,8 @@ function createPopcodeJson(project) {
   if (project.enabledLibraries.length) {
     json.enabledLibraries = project.enabledLibraries;
   }
-  if (project.minimizedComponents.length) {
-    json.minimizedComponents = project.minimizedComponents;
+  if (project.hiddenUIComponents.length) {
+    json.hiddenUIComponents = project.hiddenUIComponents;
   }
   return JSON.stringify(json);
 }

--- a/test/helpers/factory.js
+++ b/test/helpers/factory.js
@@ -3,7 +3,7 @@ import isNil from 'lodash/isNil';
 import merge from 'lodash/merge';
 
 export function gistData({
-  html, css, javascript, enabledLibraries, minimizedComponents,
+  html, css, javascript, enabledLibraries, hiddenUIComponents,
 } = {}) {
   const files = [];
   if (!isNil(html)) {
@@ -19,11 +19,11 @@ export function gistData({
       content: javascript,
     });
   }
-  if (enabledLibraries || minimizedComponents) {
+  if (enabledLibraries || hiddenUIComponents) {
     files.push({
       language: 'JSON',
       filename: 'popcode.json',
-      content: JSON.stringify({enabledLibraries, minimizedComponents}),
+      content: JSON.stringify({enabledLibraries, hiddenUIComponents}),
     });
   }
   return {files};
@@ -60,7 +60,7 @@ export function project(projectIn) {
       javascript: 'alert("Hi")',
     },
     enabledLibraries: [],
-    minimizedComponents: [],
+    hiddenUIComponents: [],
     updatedAt: Date.now(),
   });
 }

--- a/test/helpers/factory.js
+++ b/test/helpers/factory.js
@@ -1,9 +1,10 @@
 import defaultsDeep from 'lodash/defaultsDeep';
 import isNil from 'lodash/isNil';
-import isEmpty from 'lodash/isEmpty';
 import merge from 'lodash/merge';
 
-export function gistData({html, css, javascript, enabledLibraries = []} = {}) {
+export function gistData({
+  html, css, javascript, enabledLibraries, minimizedComponents,
+} = {}) {
   const files = [];
   if (!isNil(html)) {
     files.push({language: 'HTML', filename: 'index.html', content: html});
@@ -18,11 +19,11 @@ export function gistData({html, css, javascript, enabledLibraries = []} = {}) {
       content: javascript,
     });
   }
-  if (!isEmpty(enabledLibraries)) {
+  if (enabledLibraries || minimizedComponents) {
     files.push({
       language: 'JSON',
       filename: 'popcode.json',
-      content: JSON.stringify({enabledLibraries}),
+      content: JSON.stringify({enabledLibraries, minimizedComponents}),
     });
   }
   return {files};
@@ -59,6 +60,7 @@ export function project(projectIn) {
       javascript: 'alert("Hi")',
     },
     enabledLibraries: [],
+    minimizedComponents: [],
     updatedAt: Date.now(),
   });
 }

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -16,8 +16,8 @@ import {
   projectCreated,
   projectLoaded,
   toggleLibrary,
-  minimizeComponent,
-  maximizeComponent,
+  hideComponent,
+  unhideComponent,
   updateProjectSource,
 } from '../../../src/actions/projects';
 import {userLoggedOut} from '../../../src/actions/user';
@@ -173,10 +173,10 @@ tap(initProjects({1: false}), projects =>
 );
 
 tap(initProjects({1: false}), projects =>
-  test('minimizeComponent', reducerTest(
+  test('hideComponent', reducerTest(
     reducer,
     projects,
-    partial(minimizeComponent, '1', 'output', now),
+    partial(hideComponent, '1', 'output', now),
     projects.update('1', projectIn =>
       projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])).
         set('updatedAt', now),
@@ -185,10 +185,10 @@ tap(initProjects({1: false}), projects =>
 );
 
 tap(initProjects({1: true}), projects =>
-  test('maximizeComponent', reducerTest(
+  test('unhideComponent', reducerTest(
     reducer,
     projects,
-    partial(maximizeComponent, '1', 'output', now),
+    partial(unhideComponent, '1', 'output', now),
     projects.update('1', projectIn =>
       projectIn.set('hiddenUIComponents', new Immutable.Set()).
         set('updatedAt', now),
@@ -201,7 +201,7 @@ function initProjects(map = {}) {
     let projects = reducer(projectsIn, projectCreated(key));
     if (modified) {
       projects = reducer(projects, updateProjectSource(key, 'css', '', now));
-      projects = reducer(projects, minimizeComponent(key, 'output', now));
+      projects = reducer(projects, hideComponent(key, 'output', now));
     }
     return projects;
   }, states.initial);

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -172,14 +172,13 @@ tap(initProjects({1: false}), projects =>
   )),
 );
 
-tap(initProjects({1: false}), projects =>
+tap(initProjects({1: true}), projects =>
   test('hideComponent', reducerTest(
     reducer,
     projects,
     partial(hideComponent, '1', 'output', now),
     projects.update('1', projectIn =>
-      projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])).
-        set('updatedAt', now),
+      projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])),
     ),
   )),
 );
@@ -188,8 +187,7 @@ tap(initProjects({1: true}), projects =>
   test('unhideComponent', reducerTest(
     reducer,
     projects.update('1', projectIn =>
-      projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])).
-        set('updatedAt', now),
+      projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])),
     ),
     partial(unhideComponent, '1', 'output', now),
     projects,

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -47,7 +47,7 @@ test('projectCreated', (t) => {
 
 test('updateProjectSource', reducerTest(
   reducer,
-  initProjects({[projectKey]: true}),
+  initProjects({[projectKey]: false}),
   partial(updateProjectSource, projectKey, 'css', css, now),
   initProjects({[projectKey]: true}).
     update(
@@ -187,21 +187,23 @@ tap(initProjects({1: false}), projects =>
 tap(initProjects({1: true}), projects =>
   test('unhideComponent', reducerTest(
     reducer,
-    projects,
-    partial(unhideComponent, '1', 'output', now),
     projects.update('1', projectIn =>
-      projectIn.set('hiddenUIComponents', new Immutable.Set()).
+      projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])).
         set('updatedAt', now),
     ),
+    partial(unhideComponent, '1', 'output', now),
+    projects,
   )),
 );
 
 function initProjects(map = {}) {
   return reduce(map, (projectsIn, modified, key) => {
-    let projects = reducer(projectsIn, projectCreated(key));
+    const projects = reducer(projectsIn, projectCreated(key));
     if (modified) {
-      projects = reducer(projects, updateProjectSource(key, 'css', '', now));
-      projects = reducer(projects, hideComponent(key, 'output', now));
+      return reducer(
+        projects,
+        updateProjectSource(key, 'css', '', now),
+      );
     }
     return projects;
   }, states.initial);

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -119,7 +119,7 @@ test('gistImported', (t) => {
         html,
         css,
         enabledLibraries: ['jquery'],
-        minimizedComponents: ['output'],
+        hiddenUIComponents: ['output'],
       }),
     ),
     new Immutable.Map({
@@ -178,7 +178,7 @@ tap(initProjects({1: false}), projects =>
     projects,
     partial(minimizeComponent, '1', 'output', now),
     projects.update('1', projectIn =>
-      projectIn.set('minimizedComponents', new Immutable.Set(['output'])).
+      projectIn.set('hiddenUIComponents', new Immutable.Set(['output'])).
         set('updatedAt', now),
     ),
   )),
@@ -190,7 +190,7 @@ tap(initProjects({1: true}), projects =>
     projects,
     partial(maximizeComponent, '1', 'output', now),
     projects.update('1', projectIn =>
-      projectIn.set('minimizedComponents', new Immutable.Set()).
+      projectIn.set('hiddenUIComponents', new Immutable.Set()).
         set('updatedAt', now),
     ),
   )),
@@ -208,7 +208,7 @@ function initProjects(map = {}) {
 }
 
 function buildProject(
-  key, sources, enabledLibraries = [], minimizedComponents = [],
+  key, sources, enabledLibraries = [], hiddenUIComponents = [],
 ) {
   return Immutable.fromJS({
     projectKey: key,
@@ -221,6 +221,6 @@ function buildProject(
       },
     ),
     enabledLibraries: new Immutable.Set(enabledLibraries),
-    minimizedComponents: new Immutable.Set(minimizedComponents),
+    hiddenUIComponents: new Immutable.Set(hiddenUIComponents),
   });
 }

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -14,7 +14,6 @@ import {userLoggedOut} from '../../../src/actions/user';
 const initialState = Immutable.fromJS({
   editors: {typing: false},
   requestedLine: null,
-  minimizedComponents: new Immutable.Set(),
   notifications: new Immutable.Set(),
   dashboard: {
     isOpen: false,


### PR DESCRIPTION
This patch updates Popcode to persist information about which of the editors (incl. "Output") are currently minimized. The information is stored in an array under the key `minimizedComponents` in a project's `popcode.json` file. My implementation moves the `minimizedComponents` state from `ui` to `projects`, since the `popcode.json` file gets *created from* the `project` state. Is that cool? I could modify the implementation so that the `minimizedComponents` state stays under the `ui` subtree, but I think it would require some extra logic during the dehydrate/rehydrate `popcode.json` steps.

Also: on this branch, if you visit Popcode, minimize and maximize an editor, and then close the tab, you get a dialog box warning that you might lose unsaved changes. It's because in `Workspace#_confirmUnload`, `isPristineProject` checks the current project's `updatedAt` time (which is changed when you minimize/maximize an editor. This also happens when you toggle a library, though. Is this behavior desired? And if not, should I address it as part of this PR or should it be separate?

The code for this project is pretty well organized—good job on that! Wasn't too hard for me to jump in and figure out how to implement this feature.

Closes #799 