### PR TITLE
Make editor windows vertically resizable

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "qs": "^6.1.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
+    "react-draggable": "^2.2.6",
     "react-ga": "^2.1.2",
     "react-redux": "^5.0.3",
     "reduce-reducers": "^0.1.2",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -25,6 +25,7 @@ import {
 import {
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
+  editorsUpdateVerticalFlex,
   notificationTriggered,
   userDismissedNotification,
 } from './ui';
@@ -140,6 +141,7 @@ export {
   toggleDashboardSubmenu,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
+  editorsUpdateVerticalFlex,
   notificationTriggered,
   userDismissedNotification,
   exportingGist,

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -11,6 +11,10 @@ export const editorFocusedRequestedLine = createAction(
   'EDITOR_FOCUSED_REQUESTED_LINE',
 );
 
+export const editorsUpdateVerticalFlex = createAction(
+  'EDITORS_UPDATE_VERTICAL_FLEX',
+);
+
 export const notificationTriggered = createAction(
   'NOTIFICATION_TRIGGERED',
   (type, severity = 'error', payload = {}) => ({type, severity, payload}),

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -16,7 +16,11 @@ function EditorContainer(props) {
   }
 
   return (
-    <div className="editors__editor-container">
+    <div
+      className="editors__editor-container"
+      ref={props.onRef}
+      style={props.style}
+    >
       <div
         className="environment__label label"
         onClick={props.onHide}
@@ -33,7 +37,9 @@ EditorContainer.propTypes = {
   children: React.PropTypes.node.isRequired,
   language: React.PropTypes.string.isRequired,
   source: React.PropTypes.string.isRequired,
+  style: React.PropTypes.object.isRequired,
   onHide: React.PropTypes.func.isRequired,
+  onRef: React.PropTypes.func.isRequired,
 };
 
 export default EditorContainer;

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import {DraggableCore} from 'react-draggable';
+import bindAll from 'lodash/bindAll';
 import isEmpty from 'lodash/isEmpty';
 import includes from 'lodash/includes';
 import partial from 'lodash/partial';
@@ -13,58 +15,116 @@ function allErrorsFor(language, errors, runtimeErrors) {
   return errors[language].items;
 }
 
-export default function EditorsColumn({
-  currentProject,
-  errors,
-  onComponentHide,
-  onEditorInput,
-  onRequestedLineFocused,
-  runtimeErrors,
-  ui,
-}) {
-  const editors = [];
-  ['html', 'css', 'javascript'].forEach((language) => {
-    if (includes(currentProject.hiddenUIComponents, `editor.${language}`)) {
-      return;
+function getNodeHeights(refs) {
+  return Array.from(refs).sort().map(([, node]) => {
+    if (node) {
+      const minHeight = window.getComputedStyle(node).minHeight;
+      return {
+        height: node.offsetHeight,
+        minHeight: parseInt(minHeight.replace('px', ''), 10),
+      };
     }
-
-    editors.push(
-      <EditorContainer
-        key={language}
-        language={language}
-        source={currentProject.sources[language]}
-        onHide={
-          partial(onComponentHide, `editor.${language}`)
-        }
-      >
-        <Editor
-          errors={allErrorsFor(language, errors, runtimeErrors)}
-          key={language}
-          language={language}
-          percentageOfHeight={1 / editors.length}
-          projectKey={currentProject.projectKey}
-          requestedFocusedLine={ui.editors.requestedFocusedLine}
-          source={currentProject.sources[language]}
-          onInput={partial(onEditorInput, language)}
-          onRequestedLineFocused={onRequestedLineFocused}
-        />
-      </EditorContainer>,
-    );
+    return {};
   });
+}
 
-  if (isEmpty(editors)) {
-    return null;
+export default class EditorsColumn extends React.Component {
+  constructor(props) {
+    super(props);
+    this.dividerRefs = new Map([[1, null], [2, null], [3, null]]);
+    this.editorRefs = new Map([[1, null], [2, null], [3, null]]);
+    bindAll(
+      this,
+      '_storeDividerRef',
+      '_storeEditorRef',
+      '_handleEditorDividerDrag',
+    );
   }
 
-  return (
-    <div className="environment__column">
-      <div className="environment__columnContents editors">{editors}</div>
-    </div>
-  );
+  _storeEditorRef(index, editor) {
+    this.editorRefs.set(index, editor);
+  }
+
+  _storeDividerRef(index, divider) {
+    this.dividerRefs.set(index, divider);
+  }
+
+  _handleEditorDividerDrag(index, _, {deltaY, lastY, y}) {
+    const {onUpdateFlex} = this.props;
+    const editorHeights = getNodeHeights(this.editorRefs);
+    const dividerHeights = getNodeHeights(this.dividerRefs);
+    onUpdateFlex({deltaY, dividerHeights, editorHeights, index, lastY, y});
+  }
+
+  render() {
+    const {
+      currentProject,
+      editorsFlex,
+      errors,
+      onComponentHide,
+      onEditorInput,
+      onRequestedLineFocused,
+      runtimeErrors,
+      ui,
+    } = this.props;
+
+    const children = [];
+    const languages = ['html', 'css', 'javascript'].filter(language =>
+      !includes(currentProject.hiddenUIComponents, `editor.${language}`),
+    );
+    languages.forEach((language, index) => {
+      children.push(
+        <EditorContainer
+          key={language}
+          language={language}
+          source={currentProject.sources[language]}
+          style={{flex: editorsFlex[index]}}
+          onHide={partial(onComponentHide, `editor.${language}`)}
+          onRef={partial(this._storeEditorRef, index)}
+        >
+          <Editor
+            errors={allErrorsFor(language, errors, runtimeErrors)}
+            key={language}
+            language={language}
+            percentageOfHeight={1 / languages.length}
+            projectKey={currentProject.projectKey}
+            requestedFocusedLine={ui.editors.requestedFocusedLine}
+            source={currentProject.sources[language]}
+            onInput={partial(onEditorInput, language)}
+            onRequestedLineFocused={onRequestedLineFocused}
+          />
+        </EditorContainer>,
+      );
+      if (index < languages.length - 1) {
+        children.push(
+          <DraggableCore
+            key={`divider:${language}`}
+            onDrag={partial(this._handleEditorDividerDrag, index)}
+          >
+            <div
+              className="editors__divider"
+              ref={partial(this._storeDividerRef, index)}
+            />
+          </DraggableCore>,
+        );
+      }
+    });
+
+    if (isEmpty(children)) {
+      return null;
+    }
+
+    return (
+      <div className="environment__column">
+        <div className="environment__columnContents editors">{children}</div>
+      </div>
+    );
+  }
 }
 
 EditorsColumn.propTypes = {
   currentProject: React.PropTypes.object.isRequired,
+  editorsFlex: React.PropTypes.array.isRequired,
   errors: React.PropTypes.object.isRequired,
   runtimeErrors: React.PropTypes.array.isRequired,
   ui: React.PropTypes.shape({
@@ -73,4 +133,5 @@ EditorsColumn.propTypes = {
   onComponentHide: React.PropTypes.func.isRequired,
   onEditorInput: React.PropTypes.func.isRequired,
   onRequestedLineFocused: React.PropTypes.func.isRequired,
+  onUpdateFlex: React.PropTypes.func.isRequired,
 };

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -41,6 +41,7 @@ import {
   toggleDashboardSubmenu,
   userRequestedFocusedLine,
   editorFocusedRequestedLine,
+  editorsUpdateVerticalFlex,
   notificationTriggered,
   userDismissedNotification,
   exportingGist,
@@ -79,6 +80,7 @@ function mapStateToProps(state) {
     errors: state.get('errors').toJS(),
     runtimeErrors: state.get('runtimeErrors').toJS(),
     isUserTyping: state.getIn(['ui', 'editors', 'typing']),
+    editorsFlex: state.getIn(['ui', 'editors', 'verticalFlex']).toJS(),
     currentUser: state.get('user').toJS(),
     ui: state.get('ui').toJS(),
     clients: state.get('clients').toJS(),
@@ -96,6 +98,7 @@ class Workspace extends React.Component {
       '_handleComponentHide',
       '_handleDashboardSubmenuToggled',
       '_handleEditorInput',
+      '_handleEditorsUpdateVerticalFlex',
       '_handleErrorClick',
       '_handleLibraryToggled',
       '_handleLogOut',
@@ -240,6 +243,10 @@ class Workspace extends React.Component {
 
   _handleToggleDashboard() {
     this.props.dispatch(toggleDashboard());
+  }
+
+  _handleEditorsUpdateVerticalFlex(data) {
+    this.props.dispatch(editorsUpdateVerticalFlex(data));
   }
 
   _listenForAuthChange() {
@@ -394,12 +401,14 @@ class Workspace extends React.Component {
       <div className="environment">
         <EditorsColumn
           currentProject={currentProject}
+          editorsFlex={this.props.editorsFlex}
           errors={this.props.errors}
           runtimeErrors={this.props.runtimeErrors}
           ui={this.props.ui}
           onComponentHide={this._handleComponentHide}
           onEditorInput={this._handleEditorInput}
           onRequestedLineFocused={this._handleRequestedLineFocused}
+          onUpdateFlex={this._handleEditorsUpdateVerticalFlex}
         />
         {this._renderOutput()}
       </div>
@@ -431,6 +440,7 @@ Workspace.propTypes = {
   currentProject: React.PropTypes.object,
   currentUser: React.PropTypes.object.isRequired,
   dispatch: React.PropTypes.func.isRequired,
+  editorsFlex: React.PropTypes.array.isRequired,
   errors: React.PropTypes.object.isRequired,
   isUserTyping: React.PropTypes.bool,
   runtimeErrors: React.PropTypes.array.isRequired,

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -396,21 +396,23 @@ body {
 
 .editors__editor-container {
   box-sizing: border-box;
-  flex: 0 1 100vh;
   border-right: 4px solid var(--color-dark-gray);
-  border-bottom: 4px solid var(--color-dark-gray);
   position: relative;
   z-index: 0;
   display: flex;
-}
-
-.editors__editor-container:last-child {
-  border-bottom: 0;
+  flex-direction: column;
+  min-height: 85px;
 }
 
 .editors__editor {
   z-index: 0;
-  flex: 1 0 100%;
+  flex: 1;
+}
+
+.editors__divider {
+  background-color: var(--color-dark-gray);
+  cursor: ns-resize;
+  min-height: 4px;
 }
 
 .editors__help-text {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -1,8 +1,14 @@
 import Immutable from 'immutable';
 import pick from 'lodash/pick';
+import {updateVerticalFlex} from '../util/resize';
+
+export const DEFAULT_VERTICAL_FLEX = new Immutable.List(['1', '1', '1']);
 
 const defaultState = new Immutable.Map().
-  set('editors', new Immutable.Map({typing: false})).
+  set('editors', new Immutable.Map({
+    typing: false,
+    verticalFlex: DEFAULT_VERTICAL_FLEX,
+  })).
   set('requestedLine', null).
   set('notifications', new Immutable.Set()).
   set(
@@ -23,7 +29,6 @@ function addNotification(state, type, severity, payload = {}) {
   );
 }
 
-
 function ui(stateIn, action) {
   let state = stateIn;
   if (state === undefined) {
@@ -31,6 +36,15 @@ function ui(stateIn, action) {
   }
 
   switch (action.type) {
+    case 'CHANGE_CURRENT_PROJECT':
+    case 'HIDE_COMPONENT':
+    case 'PROJECT_CREATED':
+    case 'UNHIDE_COMPONENT':
+      return state.setIn(
+        ['editors', 'verticalFlex'],
+        DEFAULT_VERTICAL_FLEX,
+      );
+
     case 'UPDATE_PROJECT_SOURCE':
       return state.setIn(['editors', 'typing'], true);
 
@@ -62,6 +76,12 @@ function ui(stateIn, action) {
 
     case 'EDITOR_FOCUSED_REQUESTED_LINE':
       return state.setIn(['editors', 'requestedFocusedLine'], null);
+
+    case 'EDITORS_UPDATE_VERTICAL_FLEX':
+      return state.updateIn(['editors', 'verticalFlex'], (prevFlex) => {
+        const newFlex = updateVerticalFlex(action.payload);
+        return newFlex ? Immutable.fromJS(newFlex) : prevFlex;
+      });
 
     case 'GIST_NOT_FOUND':
       return addNotification(

--- a/src/util/resize.js
+++ b/src/util/resize.js
@@ -1,0 +1,64 @@
+function isSecondDividerPushingUpFirstDivider(
+  [
+    {height: height0, minHeight: editorMinHeight0},
+    {height: height1, minHeight: editorMinHeight1},
+  ],
+  deltaY,
+) {
+  return height0 > editorMinHeight0 &&
+    height1 === editorMinHeight1 &&
+    deltaY < 0;
+}
+
+function constrainY([,, {height, minHeight}], lastY, deltaY, offset) {
+  const maxDeltaY = height - minHeight;
+  return lastY + Math.min(deltaY, maxDeltaY) - offset;
+}
+
+export function updateVerticalFlex({
+  deltaY,
+  dividerHeights: [{minHeight: dividerMinHeight0}],
+  editorHeights,
+  index,
+  lastY,
+  y,
+}) {
+  const [
+    {height: editorHeight0},
+    {height: editorHeight1},
+    {height: editorHeight2, minHeight: editorMinHeight2},
+  ] = editorHeights;
+  if (index === 0) {
+    return [
+      `0 1 ${y}px`,
+      '1',
+      editorHeight2 ? `0 1 ${editorHeight2}px` : '1',
+    ];
+  }
+  const distanceToTopOfEditor1 = dividerMinHeight0 + editorHeight0;
+  const projectedHeightOfEditor1 = y - distanceToTopOfEditor1;
+  if (
+    isSecondDividerPushingUpFirstDivider(editorHeights, deltaY)
+  ) {
+    return [
+      `0 1 ${editorHeight0 + deltaY}px`,
+      `0 1 ${projectedHeightOfEditor1}px`,
+      '1',
+    ];
+  } else if (editorHeight2 > editorMinHeight2) {
+    const constrainedHeightOfEditor1 =
+      constrainY(editorHeights, lastY, deltaY, distanceToTopOfEditor1);
+    return [
+      `0 1 ${editorHeight0}px`,
+      `0 1 ${constrainedHeightOfEditor1}px`,
+      '1',
+    ];
+  } else if (deltaY < 0 && projectedHeightOfEditor1 <= editorHeight1) {
+    return [
+      `0 1 ${editorHeight0}px`,
+      `0 1 ${projectedHeightOfEditor1}px`,
+      '1',
+    ];
+  }
+  return null;
+}

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -2,17 +2,20 @@ import test from 'tape';
 import Immutable from 'immutable';
 import partial from 'lodash/partial';
 import reducerTest from '../../helpers/reducerTest';
-import reducer from '../../../src/reducers/ui';
+import reducer, {DEFAULT_VERTICAL_FLEX} from '../../../src/reducers/ui';
 import {
   gistNotFound,
   gistImportError,
   updateProjectSource,
 } from '../../../src/actions/projects';
-import {userDoneTyping} from '../../../src/actions/ui';
+import {
+  editorsUpdateVerticalFlex,
+  userDoneTyping,
+} from '../../../src/actions/ui';
 import {userLoggedOut} from '../../../src/actions/user';
 
 const initialState = Immutable.fromJS({
-  editors: {typing: false},
+  editors: {typing: false, verticalFlex: DEFAULT_VERTICAL_FLEX},
   requestedLine: null,
   notifications: new Immutable.Set(),
   dashboard: {
@@ -22,6 +25,55 @@ const initialState = Immutable.fromJS({
 });
 
 const gistId = '12345';
+
+test('editorsUpdateVerticalFlex', (t) => {
+  t.test('dragging first divider down', reducerTest(
+    reducer,
+    initialState,
+    partial(editorsUpdateVerticalFlex, {
+      deltaY: 5,
+      dividerHeights: [
+        {minHeight: 4},
+        {minHeight: 4},
+      ],
+      editorHeights: [
+        {height: 100, minHeight: 85},
+        {height: 100, minHeight: 85},
+        {height: 100, minHeight: 85},
+      ],
+      index: 0,
+      lastY: 100,
+      y: 105,
+    }),
+    initialState.setIn(
+      ['editors', 'verticalFlex'],
+      new Immutable.List(['0 1 105px', '1', '0 1 100px']),
+    ),
+  ));
+  t.test('dragging second divider down', reducerTest(
+    reducer,
+    initialState,
+    partial(editorsUpdateVerticalFlex, {
+      deltaY: 5,
+      dividerHeights: [
+        {minHeight: 4},
+        {minHeight: 4},
+      ],
+      editorHeights: [
+        {height: 100, minHeight: 85},
+        {height: 100, minHeight: 85},
+        {height: 100, minHeight: 85},
+      ],
+      index: 1,
+      lastY: 204,
+      y: 209,
+    }),
+    initialState.setIn(
+      ['editors', 'verticalFlex'],
+      new Immutable.List(['0 1 100px', '0 1 105px', '1']),
+    ),
+  ));
+});
 
 test('gistNotFound', reducerTest(
   reducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,7 +1631,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.1.5:
+classnames@^2.1.5, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -6507,6 +6507,12 @@ react-dom@^15.4.1:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+react-draggable@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-2.2.6.tgz#3a806e10f2da6babfea4136be6510e89b0d76901"
+  dependencies:
+    classnames "^2.2.5"
 
 react-ga@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Addresses part of https://github.com/popcodeorg/popcode/issues/302 (horizontal resizing should be comparatively easy to add later)

@outoftime I feel a bit silly turning `EditorsColumn` back into a stateful component here, but I believe it's necessary as long as the implementation relies on refs. Speaking of refs, I looked up a few declarative-style solutions for managing element height, and didn't find anything that solid (nothing with >100 stars && actively maintained). Still, the ref management here is the part I'm least satisfied with. Please let me know if you have any better ideas/libraries for this!

OTOH moving from `state` to `redux` went smoothly and the dragging might feel just a little jittery but I don't think it's too bad.

This also happens to fix https://github.com/popcodeorg/popcode/issues/782.

[Demo!](http://recordit.co/iCnHgBmmOe)