### PR TITLE
Revert "Upgrade babel-loader"

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.14.0",
-    "babel-loader": "^7.0.0",
+    "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.6.1",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,13 +510,14 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-loader@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.0.0.tgz#2e43a66bee1fff4470533d0402c8a4532fafbaf7"
+babel-loader@^6.2.4:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.4.1.tgz#0b34112d5b0748a8dcdbf51acf6f9bd42d50b8ca"
   dependencies:
     find-cache-dir "^0.1.1"
-    loader-utils "^1.0.2"
+    loader-utils "^0.2.16"
     mkdirp "^0.5.1"
+    object-assign "^4.0.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -5062,11 +5063,7 @@ lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
-lru-cache@2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
-
-lru-cache@2.2.x:
+lru-cache@2, lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 


### PR DESCRIPTION
This reverts commit 3f36633e0e2c57c42f75a2715b495119458162de.

Causes a build error that I somehow didn’t catch before.

Fixes #822