### PR TITLE
Remove redux-thunk and dead code in actions/index

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "redux-logger": "^2.5.0",
     "redux-saga": "^0.15.3",
     "redux-saga-debounce-effect": "https://github.com/madewithlove/redux-saga-debounce-effect.git#v0.2.2",
-    "redux-thunk": "^2.1.0",
     "rxjs": "^5.0.2",
     "slowparse": "^1.1.4",
     "stylelint": "^7.5.0",

--- a/src/createApplicationStore.js
+++ b/src/createApplicationStore.js
@@ -1,5 +1,4 @@
 import Immutable from 'immutable';
-import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
 import {createStore, applyMiddleware} from 'redux';
 import createSagaMiddleware from 'redux-saga';
@@ -18,9 +17,6 @@ if (config.logReduxActions()) {
 const sagaMiddleware = createSagaMiddleware();
 createStoreWithMiddleware =
   applyMiddleware(sagaMiddleware)(createStoreWithMiddleware);
-
-createStoreWithMiddleware =
-  applyMiddleware(thunkMiddleware)(createStoreWithMiddleware);
 
 function createApplicationStore() {
   const store = createStoreWithMiddleware(reducers, new Immutable.Map());

--- a/yarn.lock
+++ b/yarn.lock
@@ -6734,10 +6734,6 @@ redux-saga@^0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.15.3.tgz#be2b86b4ad46bf0d84fcfcb0ca96cfc33db91acb"
 
-redux-thunk@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
-
 redux@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"


### PR DESCRIPTION
We no longer have any thunk actions that are used in live code paths.  Remove a few vestigial ones that had stuck around, and most of the other meaningful code in `actions/index`. The end goal is for `actions/index` to only re-export functions from modules within `actions`, and at this point we’re very close to that goal (just need to move a handful of trivial actions into child modules, and write tests for them).

Also removes `redux-thunk` from dependencies.