### PR TITLE
Reducer unhides relevant editor when line focused

### DIFF
--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -7,7 +7,7 @@ import createApplicationStore from '../../../src/createApplicationStore';
 
 import {
   editorFocusedRequestedLine,
-  userRequestedFocusedLine,
+  focusLine,
   notificationTriggered,
   userDismissedNotification,
 } from '../../../src/actions';
@@ -27,9 +27,9 @@ describe('interfaceStateActions', () => {
     clock.restore();
   });
 
-  describe('userRequestedFocusedLine', () => {
+  describe('focusLine', () => {
     beforeEach(
-      () => store.dispatch(userRequestedFocusedLine('javascript', 4, 2)),
+      () => store.dispatch(focusLine('javascript', 4, 2)),
     );
 
     it('sets requestedFocusedLine to given value', () => {
@@ -44,7 +44,7 @@ describe('interfaceStateActions', () => {
 
   describe('editorFocusedRequestedLine', () => {
     beforeEach(() => {
-      store.dispatch(userRequestedFocusedLine('javascript', 4, 2));
+      store.dispatch(focusLine('javascript', 4, 2));
       store.dispatch(editorFocusedRequestedLine());
     });
 

--- a/spec/examples/actions/ui.spec.js
+++ b/spec/examples/actions/ui.spec.js
@@ -6,8 +6,6 @@ import {assert} from 'chai';
 import createApplicationStore from '../../../src/createApplicationStore';
 
 import {
-  editorFocusedRequestedLine,
-  focusLine,
   notificationTriggered,
   userDismissedNotification,
 } from '../../../src/actions';
@@ -25,34 +23,6 @@ describe('interfaceStateActions', () => {
   afterEach(() => {
     clock.tick(timeInterval);
     clock.restore();
-  });
-
-  describe('focusLine', () => {
-    beforeEach(
-      () => store.dispatch(focusLine('javascript', 4, 2)),
-    );
-
-    it('sets requestedFocusedLine to given value', () => {
-      assert.deepEqual(
-        store.getState().getIn(
-          ['ui', 'editors', 'requestedFocusedLine'],
-        ).toJS(),
-        {language: 'javascript', line: 4, column: 2},
-      );
-    });
-  });
-
-  describe('editorFocusedRequestedLine', () => {
-    beforeEach(() => {
-      store.dispatch(focusLine('javascript', 4, 2));
-      store.dispatch(editorFocusedRequestedLine());
-    });
-
-    it('sets requestedFocusedLine to null', () => {
-      assert.isNull(
-        store.getState().getIn(['ui', 'editors', 'requestedFocusedLine']),
-      );
-    });
   });
 
   describe('notificationTriggered', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -16,7 +16,7 @@ import {
 } from './projects';
 
 import {
-  userRequestedFocusedLine,
+  focusLine,
   editorFocusedRequestedLine,
   editorsUpdateVerticalFlex,
   notificationTriggered,
@@ -62,7 +62,7 @@ export {
   unhideComponent,
   toggleDashboard,
   toggleDashboardSubmenu,
-  userRequestedFocusedLine,
+  focusLine,
   editorFocusedRequestedLine,
   editorsUpdateVerticalFlex,
   notificationTriggered,

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -5,6 +5,7 @@ export const userDoneTyping = createAction('USER_DONE_TYPING');
 export const userRequestedFocusedLine = createAction(
   'USER_REQUESTED_FOCUSED_LINE',
   (language, line, column) => ({language, line, column}),
+  (_language, _line, _column, timestamp = Date.now()) => ({timestamp}),
 );
 
 export const editorFocusedRequestedLine = createAction(

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -2,8 +2,8 @@ import {createAction} from 'redux-actions';
 
 export const userDoneTyping = createAction('USER_DONE_TYPING');
 
-export const userRequestedFocusedLine = createAction(
-  'USER_REQUESTED_FOCUSED_LINE',
+export const focusLine = createAction(
+  'FOCUS_LINE',
   (language, line, column) => ({language, line, column}),
   (_language, _line, _column, timestamp = Date.now()) => ({timestamp}),
 );

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -35,7 +35,7 @@ import {
   unhideComponent,
   toggleDashboard,
   toggleDashboardSubmenu,
-  userRequestedFocusedLine,
+  focusLine,
   editorFocusedRequestedLine,
   editorsUpdateVerticalFlex,
   notificationTriggered,
@@ -146,7 +146,7 @@ class Workspace extends React.Component {
   }
 
   _handleErrorClick(language, line, column) {
-    this.props.dispatch(userRequestedFocusedLine(language, line, column));
+    this.props.dispatch(focusLine(language, line, column));
   }
 
   _handleEditorInput(language, source) {

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -146,7 +146,6 @@ class Workspace extends React.Component {
   }
 
   _handleErrorClick(language, line, column) {
-    this.props.dispatch(unhideComponent(`editor.${language}`));
     this.props.dispatch(userRequestedFocusedLine(language, line, column));
   }
 

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -45,6 +45,13 @@ function removePristineExcept(state, keepProjectKey) {
   ));
 }
 
+function unhideComponent(state, projectKey, component, timestamp) {
+  return state.updateIn(
+    [projectKey, 'hiddenUIComponents'],
+    hiddenUIComponents => hiddenUIComponents.delete(component),
+  ).setIn([projectKey, 'updatedAt'], timestamp);
+}
+
 function importGist(state, projectKey, gistData) {
   const files = values(gistData.files);
   const popcodeJsonFile = find(files, {filename: 'popcode.json'});
@@ -83,6 +90,13 @@ export function reduceRoot(stateIn, action) {
             projects.get(currentProjectKey),
           );
         }
+      case 'USER_REQUESTED_FOCUSED_LINE':
+        return unhideComponent(
+          projects,
+          stateIn.getIn(['currentProject', 'projectKey']),
+          `editor.${action.payload.language}`,
+          action.meta.timestamp,
+        );
     }
     return projects;
   });
@@ -152,12 +166,10 @@ export default function reduceProjects(stateIn, action) {
       );
 
     case 'UNHIDE_COMPONENT':
-      return state.updateIn(
-        [action.payload.projectKey, 'hiddenUIComponents'],
-        hiddenUIComponents =>
-          hiddenUIComponents.delete(action.payload.componentName),
-      ).setIn(
-        [action.payload.projectKey, 'updatedAt'],
+      return unhideComponent(
+        state,
+        action.payload.projectKey,
+        action.payload.componentName,
         action.meta.timestamp,
       );
 

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -90,7 +90,7 @@ export function reduceRoot(stateIn, action) {
             projects.get(currentProjectKey),
           );
         }
-      case 'USER_REQUESTED_FOCUSED_LINE':
+      case 'FOCUS_LINE':
         return unhideComponent(
           projects,
           stateIn.getIn(['currentProject', 'projectKey']),

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -65,7 +65,7 @@ export default function ui(stateIn, action) {
         return newSubmenu;
       });
 
-    case 'USER_REQUESTED_FOCUSED_LINE':
+    case 'FOCUS_LINE':
       return state.setIn(
         ['editors', 'requestedFocusedLine'],
         new Immutable.Map().

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -8,8 +8,8 @@ const defaultState = new Immutable.Map().
   set('editors', new Immutable.Map({
     typing: false,
     verticalFlex: DEFAULT_VERTICAL_FLEX,
+    requestedFocusedLine: null,
   })).
-  set('requestedLine', null).
   set('notifications', new Immutable.Set()).
   set(
     'dashboard',

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -20,6 +20,9 @@ import {
   unhideComponent,
   updateProjectSource,
 } from '../../../src/actions/projects';
+import {
+  userRequestedFocusedLine,
+} from '../../../src/actions/ui';
 import {userLoggedOut} from '../../../src/actions/user';
 
 const now = Date.now();
@@ -193,6 +196,25 @@ tap(initProjects({1: true}), projects =>
     projects,
   )),
 );
+
+tap(initProjects({1: true}), (projects) => {
+  const timestamp = Date.now();
+  test('userRequestedFocusedLine', reducerTest(
+    rootReducer,
+    Immutable.fromJS({
+      projects: projects.setIn(
+        ['1', 'hiddenUIComponents'],
+        new Immutable.Set(['editor.javascript']),
+      ),
+      currentProject: {projectKey: '1'},
+    }),
+    partial(userRequestedFocusedLine, 'javascript', 1, 1, timestamp),
+    Immutable.fromJS({
+      projects: projects.setIn(['1', 'updatedAt'], timestamp),
+      currentProject: {projectKey: '1'},
+    }),
+  ));
+});
 
 function initProjects(map = {}) {
   return reduce(map, (projectsIn, modified, key) => {

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -21,7 +21,7 @@ import {
   updateProjectSource,
 } from '../../../src/actions/projects';
 import {
-  userRequestedFocusedLine,
+  focusLine,
 } from '../../../src/actions/ui';
 import {userLoggedOut} from '../../../src/actions/user';
 
@@ -199,7 +199,7 @@ tap(initProjects({1: true}), projects =>
 
 tap(initProjects({1: true}), (projects) => {
   const timestamp = Date.now();
-  test('userRequestedFocusedLine', reducerTest(
+  test('focusLine', reducerTest(
     rootReducer,
     Immutable.fromJS({
       projects: projects.setIn(
@@ -208,7 +208,7 @@ tap(initProjects({1: true}), (projects) => {
       ),
       currentProject: {projectKey: '1'},
     }),
-    partial(userRequestedFocusedLine, 'javascript', 1, 1, timestamp),
+    partial(focusLine, 'javascript', 1, 1, timestamp),
     Immutable.fromJS({
       projects: projects.setIn(['1', 'updatedAt'], timestamp),
       currentProject: {projectKey: '1'},

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -12,6 +12,8 @@ import {
 import {
   editorsUpdateVerticalFlex,
   userDoneTyping,
+  focusLine,
+  editorFocusedRequestedLine,
 } from '../../../src/actions/ui';
 import {
   gistExportNotDisplayed,
@@ -21,8 +23,11 @@ import {EmptyGistError} from '../../../src/clients/gists';
 import {userLoggedOut} from '../../../src/actions/user';
 
 const initialState = Immutable.fromJS({
-  editors: {typing: false, verticalFlex: DEFAULT_VERTICAL_FLEX},
-  requestedLine: null,
+  editors: {
+    typing: false,
+    requestedFocusedLine: null,
+    verticalFlex: DEFAULT_VERTICAL_FLEX,
+  },
   notifications: new Immutable.Set(),
   dashboard: {
     isOpen: false,
@@ -167,3 +172,23 @@ test('gistExportError', (t) => {
     withNotification('empty-gist', 'error'),
   ));
 });
+
+test('focusLine', reducerTest(
+  reducer,
+  initialState,
+  partial(focusLine, 'javascript', 4, 2),
+  initialState.setIn(
+    ['editors', 'requestedFocusedLine'],
+    new Immutable.Map({language: 'javascript', line: 4, column: 2}),
+  ),
+));
+
+test('editorFocusedRequestedLine', reducerTest(
+  reducer,
+  initialState.setIn(
+    ['editors', 'requestedFocusedLine'],
+    new Immutable.Map({language: 'javascript', line: 4, column: 2}),
+  ),
+  editorFocusedRequestedLine,
+  initialState,
+));


### PR DESCRIPTION
Previously the Workspace component’s handler for line focus would dispatch an `unhideComponent` action from the handler for a focused line request.  This had trivially buggy behavior in that it omitted the required first argument to `unhideComponent`, which should have been the current project ID.

However, it also doesn’t follow the recently adopted pattern of reducers knowing what to do in response to actions, rather than procedural code dispatching multiple actions to deal with different aspects of responding to a particular user action or external event.

So, remove the call to `unhideComponent` and instead have the `ui` reducer handle the focus line action.

Also while we’re in there, rename the rather awkward `userRequestedFocusedLine` to `focusLine`, following the convention of using the active voice for user-initiated actions.

Fixes #812 
Fixes #827 
Fixes #829 