### PR TITLE
Horizontally resizeable workspace columns

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,7 +50,7 @@
         ],
         "complexity": [
           2,
-          {"max": 22}
+          {"max": 26}
         ],
         "computed-property-spacing": [
             2,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -18,7 +18,10 @@ import {
 import {
   focusLine,
   editorFocusedRequestedLine,
-  editorsUpdateVerticalFlex,
+  dragRowDivider,
+  dragColumnDivider,
+  startDragColumnDivider,
+  stopDragColumnDivider,
   notificationTriggered,
   userDismissedNotification,
 } from './ui';
@@ -64,7 +67,10 @@ export {
   toggleDashboardSubmenu,
   focusLine,
   editorFocusedRequestedLine,
-  editorsUpdateVerticalFlex,
+  dragRowDivider,
+  dragColumnDivider,
+  startDragColumnDivider,
+  stopDragColumnDivider,
   notificationTriggered,
   userDismissedNotification,
   exportGist,

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -12,8 +12,20 @@ export const editorFocusedRequestedLine = createAction(
   'EDITOR_FOCUSED_REQUESTED_LINE',
 );
 
-export const editorsUpdateVerticalFlex = createAction(
-  'EDITORS_UPDATE_VERTICAL_FLEX',
+export const dragRowDivider = createAction(
+  'DRAG_ROW_DIVIDER',
+);
+
+export const dragColumnDivider = createAction(
+  'DRAG_COLUMN_DIVIDER',
+);
+
+export const startDragColumnDivider = createAction(
+  'START_DRAG_COLUMN_DIVIDER',
+);
+
+export const stopDragColumnDivider = createAction(
+  'STOP_DRAG_COLUMN_DIVIDER',
 );
 
 export const notificationTriggered = createAction(

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -61,17 +61,28 @@ class Output extends React.Component {
   }
 
   render() {
+    const {
+      isDraggingColumnDivider,
+      isHidden,
+      style,
+      onHide,
+      onRef,
+    } = this.props;
     return (
       <div
         className={classnames(
           'environment__column',
-          {u__hidden: this.props.isHidden},
+          {u__hidden: isHidden},
         )}
+        ref={onRef}
+        style={Object.assign({}, style, {
+          pointerEvents: isDraggingColumnDivider ? 'none' : 'all',
+        })}
       >
         <div className="environment__columnContents output">
           <div
             className="environment__label label"
-            onClick={this.props.onHide}
+            onClick={onHide}
           >
             {t('workspace.components.output')}
           </div>
@@ -86,13 +97,16 @@ class Output extends React.Component {
 
 Output.propTypes = {
   errors: PropTypes.object.isRequired,
+  isDraggingColumnDivider: PropTypes.bool.isRequired,
   isHidden: PropTypes.bool.isRequired,
   project: PropTypes.object,
   runtimeErrors: PropTypes.array.isRequired,
+  style: PropTypes.object.isRequired,
   validationState: PropTypes.string.isRequired,
   onClearRuntimeErrors: PropTypes.func.isRequired,
   onErrorClick: PropTypes.func.isRequired,
   onHide: PropTypes.func.isRequired,
+  onRef: PropTypes.func.isRequired,
   onRuntimeError: PropTypes.func.isRequired,
 };
 

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -377,6 +377,7 @@ body {
 .environment__column {
   flex: 1 0 0;
   position: relative;
+  min-width: 300px;
 }
 
 .environment__columnContents {
@@ -406,7 +407,6 @@ body {
 
 .editors__editor-container {
   box-sizing: border-box;
-  border-right: 4px solid var(--color-dark-gray);
   position: relative;
   z-index: 0;
   display: flex;
@@ -419,7 +419,13 @@ body {
   flex: 1;
 }
 
-.editors__divider {
+.editors__column-divider {
+  background-color: var(--color-dark-gray);
+  cursor: ew-resize;
+  min-width: 4px;
+}
+
+.editors__row-divider {
   background-color: var(--color-dark-gray);
   cursor: ns-resize;
   min-height: 4px;

--- a/src/util/resize.js
+++ b/src/util/resize.js
@@ -1,62 +1,141 @@
-function isSecondDividerPushingUpFirstDivider(
+export function getNodeWidth(node) {
+  const minWidth = window.getComputedStyle(node).minWidth;
+  return {
+    width: node.offsetWidth,
+    minWidth: parseInt(minWidth.replace('px', ''), 10),
+  };
+}
+
+export function getNodeWidths(refs) {
+  return refs.map(node => node ? getNodeWidth(node) : null);
+}
+
+export function getNodeHeights(refs) {
+  return refs.map((node) => {
+    if (node) {
+      const minHeight = window.getComputedStyle(node).minHeight;
+      return {
+        height: node.offsetHeight,
+        minHeight: parseInt(minHeight.replace('px', ''), 10),
+      };
+    }
+    return null;
+  });
+}
+
+function isSecondDividerPushingFirstDivider(
   [
-    {height: height0, minHeight: editorMinHeight0},
-    {height: height1, minHeight: editorMinHeight1},
+    {size: size0, minSize: contentMinSize0},
+    {size: size1, minSize: contentMinSize1},
   ],
-  deltaY,
+  deltaPosition,
 ) {
-  return height0 > editorMinHeight0 &&
-    height1 === editorMinHeight1 &&
-    deltaY < 0;
+  return size0 > contentMinSize0 &&
+    size1 === contentMinSize1 &&
+    deltaPosition < 0;
 }
 
-function constrainY([,, {height, minHeight}], lastY, deltaY, offset) {
-  const maxDeltaY = height - minHeight;
-  return lastY + Math.min(deltaY, maxDeltaY) - offset;
+function constrainPosition(
+  [,, {size, minSize}],
+  lastPosition,
+  deltaPosition,
+  offset,
+) {
+  const maxDeltaY = size - minSize;
+  return lastPosition + Math.min(deltaPosition, maxDeltaY) - offset;
 }
 
-export function updateVerticalFlex({
-  deltaY,
-  dividerHeights: [{minHeight: dividerMinHeight0}],
-  editorHeights,
+function columnToContent(column) {
+  return column ? {size: column.width, minSize: column.minWidth} : null;
+}
+
+function editorToContent(editor) {
+  return editor ? {size: editor.height, minSize: editor.minHeight} : null;
+}
+
+export function updateEditorColumnFlex({
   index,
+  dividerHeights,
+  editorHeights,
+  deltaY,
   lastY,
   y,
 }) {
+  return updateFlex({
+    index,
+    contentSizes: editorHeights.map(editorToContent),
+    dividerSizes: dividerHeights.map(editorToContent),
+    deltaPosition: deltaY,
+    lastPosition: lastY,
+    position: y,
+  });
+}
+
+export function updateWorkspaceRowFlex({
+  columnWidths,
+  dividerWidth,
+  deltaX,
+  lastX,
+  x,
+}) {
+  return updateFlex({
+    index: 0,
+    contentSizes: columnWidths.map(columnToContent),
+    dividerSizes: [columnToContent(dividerWidth)],
+    deltaPosition: deltaX,
+    lastPosition: lastX,
+    position: x,
+  });
+}
+
+function updateFlex({
+  deltaPosition,
+  dividerSizes: [{minSize: dividerMinSize0}],
+  contentSizes,
+  index,
+  lastPosition,
+  position,
+}) {
   const [
-    {height: editorHeight0},
-    {height: editorHeight1},
-    {height: editorHeight2, minHeight: editorMinHeight2},
-  ] = editorHeights;
+    {size: contentSize0},
+    {size: contentSize1},
+  ] = contentSizes;
+  const contentSize2 = contentSizes[2] ? contentSizes[2].size : 0;
+
   if (index === 0) {
     return [
-      `0 1 ${y}px`,
+      `0 1 ${position}px`,
       '1',
-      editorHeight2 ? `0 1 ${editorHeight2}px` : '1',
+      contentSize2 ? `0 1 ${contentSize2}px` : '1',
     ];
   }
-  const distanceToTopOfEditor1 = dividerMinHeight0 + editorHeight0;
-  const projectedHeightOfEditor1 = y - distanceToTopOfEditor1;
+  const distanceToTopOfContent1 = dividerMinSize0 + contentSize0;
+  const projectedSizeOfContent1 = position - distanceToTopOfContent1;
+  const contentMinSize2 = contentSizes[2].minSize;
   if (
-    isSecondDividerPushingUpFirstDivider(editorHeights, deltaY)
+    isSecondDividerPushingFirstDivider(contentSizes, deltaPosition)
   ) {
     return [
-      `0 1 ${editorHeight0 + deltaY}px`,
-      `0 1 ${projectedHeightOfEditor1}px`,
+      `0 1 ${contentSize0 + deltaPosition}px`,
+      `0 1 ${projectedSizeOfContent1}px`,
       '1',
     ];
-  } else if (editorHeight2 > editorMinHeight2) {
-    const constrainedHeightOfEditor1 =
-      constrainY(editorHeights, lastY, deltaY, distanceToTopOfEditor1);
+  } else if (contentSize2 > contentMinSize2) {
+    const constrainedSizeOfContent1 = constrainPosition(
+      contentSizes,
+      lastPosition,
+      deltaPosition,
+      distanceToTopOfContent1,
+    );
     return [
-      `0 1 ${editorHeight0}px`,
-      `0 1 ${constrainedHeightOfEditor1}px`,
+      `0 1 ${contentSize0}px`,
+      `0 1 ${constrainedSizeOfContent1}px`,
       '1',
     ];
-  } else if (deltaY < 0 && projectedHeightOfEditor1 <= editorHeight1) {
+  } else if (deltaPosition < 0 && projectedSizeOfContent1 <= contentSize1) {
     return [
-      `0 1 ${editorHeight0}px`,
-      `0 1 ${projectedHeightOfEditor1}px`,
+      `0 1 ${contentSize0}px`,
+      `0 1 ${projectedSizeOfContent1}px`,
       '1',
     ];
   }

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -3,14 +3,15 @@ import Immutable from 'immutable';
 import tap from 'lodash/tap';
 import partial from 'lodash/partial';
 import reducerTest from '../../helpers/reducerTest';
-import reducer, {DEFAULT_VERTICAL_FLEX} from '../../../src/reducers/ui';
+import reducer, {DEFAULT_WORKSPACE} from '../../../src/reducers/ui';
 import {
   gistNotFound,
   gistImportError,
   updateProjectSource,
 } from '../../../src/actions/projects';
 import {
-  editorsUpdateVerticalFlex,
+  dragColumnDivider,
+  dragRowDivider,
   userDoneTyping,
   focusLine,
   editorFocusedRequestedLine,
@@ -28,8 +29,8 @@ const initialState = Immutable.fromJS({
   editors: {
     typing: false,
     requestedFocusedLine: null,
-    verticalFlex: DEFAULT_VERTICAL_FLEX,
   },
+  workspace: DEFAULT_WORKSPACE,
   notifications: new Immutable.Set(),
   dashboard: {
     isOpen: false,
@@ -50,12 +51,31 @@ function withNotification(type, severity, payload = {}) {
 
 const gistId = '12345';
 
-test('editorsUpdateVerticalFlex', (t) => {
+test('dragColumnDivider', reducerTest(
+  reducer,
+  initialState,
+  partial(dragColumnDivider, {
+    dividerWidth: {minWidth: 4},
+    columnWidths: [
+      {width: 400, minWidth: 300},
+      {width: 400, minWidth: 300},
+    ],
+    deltaX: 5,
+    lastX: 400,
+    x: 405,
+  }),
+  initialState.setIn(
+    ['workspace', 'rowFlex'],
+    new Immutable.List(['0 1 405px', '1', '1']),
+  ),
+));
+
+test('dragRowDivider', (t) => {
   t.test('dragging first divider down', reducerTest(
     reducer,
     initialState,
-    partial(editorsUpdateVerticalFlex, {
-      deltaY: 5,
+    partial(dragRowDivider, {
+      index: 0,
       dividerHeights: [
         {minHeight: 4},
         {minHeight: 4},
@@ -65,20 +85,20 @@ test('editorsUpdateVerticalFlex', (t) => {
         {height: 100, minHeight: 85},
         {height: 100, minHeight: 85},
       ],
-      index: 0,
+      deltaY: 5,
       lastY: 100,
       y: 105,
     }),
     initialState.setIn(
-      ['editors', 'verticalFlex'],
+      ['workspace', 'columnFlex'],
       new Immutable.List(['0 1 105px', '1', '0 1 100px']),
     ),
   ));
   t.test('dragging second divider down', reducerTest(
     reducer,
     initialState,
-    partial(editorsUpdateVerticalFlex, {
-      deltaY: 5,
+    partial(dragRowDivider, {
+      index: 1,
       dividerHeights: [
         {minHeight: 4},
         {minHeight: 4},
@@ -88,12 +108,12 @@ test('editorsUpdateVerticalFlex', (t) => {
         {height: 100, minHeight: 85},
         {height: 100, minHeight: 85},
       ],
-      index: 1,
+      deltaY: 5,
       lastY: 204,
       y: 209,
     }),
     initialState.setIn(
-      ['editors', 'verticalFlex'],
+      ['workspace', 'columnFlex'],
       new Immutable.List(['0 1 100px', '0 1 105px', '1']),
     ),
   ));


### PR DESCRIPTION
The second half of https://github.com/popcodeorg/popcode/issues/302!
All of the changes in `resize.js` are one-to-one vocabulary changes:
- `height` -> `size`
- `y` -> `position`
- `editors.verticalFlex` -> `workspace.columnFlex`

I also modified the editor hide/unhide behavior to allow for e.g. horizontal resize proportions to remain constant when an editor component is hidden.

The only complication is in capturing the movement event when the mouse moves over the preview iframe. The most graceful hacky solution I could come up with was enabling same-origin rights in the iframe and manually dispatching a rough clone of the internally captured event, with adjustments for the iframe's position.

If same-origin is a deal breaker I can restructure in terms of `postMessage`.

Recording of resizing, also showing off component hide/unhide behavior: http://recordit.co/IzcC8B7VYk