### PR TITLE
Add stylelint enforcement of BEM pattern

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,6 @@
 {
+  "plugins": ["stylelint-selector-bem-pattern"],
+
   "rules": {
     "at-rule-empty-line-before": ["always", {
       "except": [
@@ -124,6 +126,12 @@
     "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never",
-    "value-list-max-empty-lines": 0
+    "value-list-max-empty-lines": 0,
+
+    "plugin/selector-bem-pattern": {
+      "preset": "bem",
+      "utilitySelectors": "u",
+      "ignoreSelectors": "\\b(svg|path)\\b"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -116,12 +116,12 @@
     "redux-saga-debounce-effect": "https://github.com/madewithlove/redux-saga-debounce-effect.git#v0.2.2",
     "rxjs": "^5.0.2",
     "slowparse": "^1.1.4",
-    "stylelint": "^7.5.0",
+    "stylelint": "^7.10.1",
     "text-encoding": "^0.6.0"
   },
   "engines": {
     "node": "7.6.0",
-    "yarn": "0.20.3"
+    "yarn": "0.24.6"
   },
   "scripts": {
     "postinstall": "bower install",
@@ -185,6 +185,7 @@
     "redux-saga-test-plan": "^3.0.2",
     "sinon": "^2.3.1",
     "string-replace-loader": "^1.0.5",
+    "stylelint-selector-bem-pattern": "^1.0.0",
     "substitute-loader": "^1.0.0",
     "svg-react-loader": "^0.4.0-beta.2",
     "svgo": "^0.7.2",

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -174,19 +174,19 @@ class Dashboard extends React.Component {
     return (
       <div className="dashboard__links">
         <a
-          className="dashboard__link fontawesome"
+          className="dashboard__link u__fontawesome"
           href="https://github.com/popcodeorg/popcode"
           rel="noopener noreferrer"
           target="_blank"
         >&#xf09b;</a>
         <a
-          className="dashboard__link fontawesome"
+          className="dashboard__link u__fontawesome"
           href="https://twitter.com/popcodeorg"
           rel="noopener noreferrer"
           target="_blank"
         >&#xf099;</a>
         <a
-          className="dashboard__link fontawesome"
+          className="dashboard__link u__fontawesome"
           href="https://slack.popcode.org/"
           rel="noopener noreferrer"
           target="_blank"

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -71,6 +71,8 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+/** @define layout */
+
 .layout {
   display: flex;
   height: 100vh;
@@ -82,6 +84,17 @@ body {
   border-right: 1px solid var(--color-gray);
   display: flex;
 }
+
+.layout__main {
+  flex: 1 1 100%;
+  position: relative;
+}
+
+.layout__dashboard {
+  flex: 1 0 20%;
+}
+
+/** @define sidebar */
 
 .sidebar {
   background-color: var(--color-green);
@@ -180,6 +193,8 @@ body {
   transform: rotate(-45deg);
   transform-origin: right 50%;
 }
+
+/** @define dashboard */
 
 .dashboard {
   background-color: var(--color-green);
@@ -332,9 +347,7 @@ body {
   font-size: 1.5rem;
 }
 
-.fontawesome {
-  font-family: 'FontAwesome';
-}
+/** @define project-preview */
 
 .project-preview__timestamp {
   text-align: right;
@@ -343,10 +356,7 @@ body {
   font-weight: normal;
 }
 
-.layout__main {
-  flex: 1 1 100%;
-  position: relative;
-}
+/** @define workspace */
 
 .workspace {
   display: flex;
@@ -354,9 +364,7 @@ body {
   height: 100%;
 }
 
-.layout__dashboard {
-  flex: 1 0 20%;
-}
+/** @define environment */
 
 .environment {
   box-sizing: border-box;
@@ -387,6 +395,8 @@ body {
   right: 1em;
   z-index: 1;
 }
+
+/** @define editors */
 
 .editors {
   display: flex;
@@ -429,6 +439,8 @@ body {
   pointer-events: none;
 }
 
+/** @define label */
+
 .label {
   background-color: black;
   border-radius: 4px;
@@ -443,6 +455,8 @@ body {
 .label:hover {
   opacity: 0.5;
 }
+
+/** @define output */
 
 .output {
   display: flex;
@@ -467,6 +481,8 @@ body {
   background: white url(../images/large-spinner.gif) no-repeat center center;
   opacity: 0.2;
 }
+
+/** @define preview */
 
 .preview {
   position: relative;
@@ -494,6 +510,8 @@ body {
 .preview__pop-out-button:hover {
   opacity: 0.5;
 }
+
+/** @define error-list */
 
 .error-list {
   position: relative;
@@ -525,12 +543,15 @@ body {
   overflow-wrap: break-word;
 }
 
+/** @define notification-list */
+
 .notification-list__notification {
   text-align: center;
   margin-bottom: 0.2rem;
   padding: 0.2rem 0;
 }
 
+/* postcss-bem-linter: ignore */
 .notification-list__notification a {
   color: inherit;
   text-align: center;
@@ -554,15 +575,20 @@ body {
   cursor: pointer;
 }
 
+/** @define unsupported-browser */
+
 .unsupported-browser {
   font-size: 1.5rem;
   margin-top: 5rem;
   text-align: center;
 
+  /* postcss-bem-linter: ignore */
   & a {
     color: inherit;
   }
 }
+
+/** @define pop-throbber */
 
 .pop-throbber {
   position: absolute;
@@ -593,6 +619,8 @@ body {
   fill: var(--color-gray) !important;
 }
 
+/** @define utilities */
+
 .u__flex-container {
   display: flex;
 }
@@ -615,4 +643,8 @@ body {
 
 .u__hidden {
   display: none;
+}
+
+.u__fontawesome {
+  font-family: 'FontAwesome';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,7 +1485,7 @@ camelcase@^1.0.2, camelcase@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^2.0.0, camelcase@^2.0.1:
+camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
@@ -4846,7 +4846,7 @@ lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
-"lodash@4.6.1 || ^4.16.1", lodash@^4, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.5.1, lodash@^4.6.1, lodash@^4.7.0:
+"lodash@4.6.1 || ^4.16.1", lodash@>=3.10.0, lodash@^4, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.5.1, lodash@^4.6.1, lodash@^4.7.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5774,6 +5774,14 @@ postcss-attribute-case-insensitive@^1.0.1:
   dependencies:
     postcss "^5.1.1"
     postcss-selector-parser "^2.2.0"
+
+postcss-bem-linter@^2.1.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/postcss-bem-linter/-/postcss-bem-linter-2.7.0.tgz#475e36b079009c8fc05a2cd3e1969bd6a9e2c5e9"
+  dependencies:
+    minimatch "^3.0.3"
+    postcss "^5.0.0"
+    postcss-resolve-nested-selector "^0.1.1"
 
 postcss-calc@^5.0.0, postcss-calc@^5.2.0:
   version "5.3.1"
@@ -7485,7 +7493,16 @@ stylehacks@^2.3.2:
     text-table "^0.2.0"
     write-file-stdout "0.0.2"
 
-stylelint@^7.5.0:
+stylelint-selector-bem-pattern@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-selector-bem-pattern/-/stylelint-selector-bem-pattern-1.0.0.tgz#9420e1bb8fe5e014547f91aedb635ab5df86b070"
+  dependencies:
+    lodash ">=3.10.0"
+    postcss "^5.0.19"
+    postcss-bem-linter "^2.1.0"
+    stylelint ">=3.0.2"
+
+stylelint@>=3.0.2, stylelint@^7.10.1:
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.10.1.tgz#209a7ce5e781fc2a62489fbb31ec0201ec675db2"
   dependencies:
@@ -8296,7 +8313,7 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-window-size@^0.1.2, window-size@^0.1.4:
+window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
@@ -8412,7 +8429,7 @@ yargs-parser@^4.1.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@3.29.0:
+yargs@3.29.0, yargs@^3.5.4:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.29.0.tgz#1aab9660eae79d8b8f675bcaeeab6ee34c2cf69c"
   dependencies:
@@ -8445,18 +8462,6 @@ yargs@6.4.0, yargs@^6.0.0:
 yargs@^1.2.6:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
-
-yargs@^3.5.4:
-  version "3.32.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
-  dependencies:
-    camelcase "^2.0.1"
-    cliui "^3.0.3"
-    decamelize "^1.1.1"
-    os-locale "^1.4.0"
-    string-width "^1.0.1"
-    window-size "^0.1.4"
-    y18n "^3.2.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Adds the `stylelint-selector-bem-pattern` linter and configures it. Uses the BEM preset with global exceptions for selecting `<svg>` and `<path>` elements since we can’t give them class names.

Use the `@define` comment method to mark off components within the single big stylesheet. I think it‘s about time to break each component into its own file, but getting the postcss `@import` of it all to work properly seems non-trivial, so I figured this would be a good first step.

Also:

* Move all the `layout` component selectors into one place
* Make `fontawesome` a utility element rather than its own component