### PR TITLE
Deprecate mismatched-close-tag into more precise errors

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -102,7 +102,6 @@
       "empty-title-element": "You have an empty <title> tag. A <title> tag should always contain text.",
       "html-in-css-block": "It looks like you typed some HTML code inside a <style> tag. Remember that only CSS code can go inside a <style> tag.",
       "invalid-attribute-name": "{{attribute}} isn’t allowed as an attribute name.",
-      "mismatched-close-tag": "Your <{{open}}> tag needs a closing tag, but instead there’s a </{{close}}> tag where the </{{open}}> tag should be.",
       "self-closing-non-void-element": "{{tag, en-handle-an|capitalize}} <{{tag}}> tag always needs a closing </{{tag}}> tag. Writing <{{tag}}/> is not allowed.",
       "unclosed-tag": "Your <{{tag}}> tag needs to be closed by an </{{tag}}> tag.",
       "unexpected-close-tag": "You have a closing </{{tag}}> tag that doesn’t match any opening <{{tag}}> tag.",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -112,7 +112,8 @@
       "unterminated-comment": "You have a comment that never ends. End the comment with -->",
       "unbound-attribute-value": "The value {{value}} isn’t attached to an attribute. Are you missing an = sign?",
       "invalid-tag-name": "<{{tag}}> isn’t a valid HTML tag. If you want to create a custom tag, make sure the name has a - in it, like <my-tag>",
-      "space-before-tag-name": "You can’t put any space after the < in an HTML tag. Write <{{tag}}> instead of < {{tag}}>."
+      "space-before-tag-name": "You can’t put any space after the < in an HTML tag. Write <{{tag}}> instead of < {{tag}}>.",
+      "misplaced-close-tag": "This closing </{{open}}> tag should go to before the </{{close}}> tag on line {{mismatch}}."
     },
     "css": {
       "missing-opening-curly": "You should have a { at the end of this line.",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "bugsnag-js": "^3.0.1",
     "classnames": "^2.1.5",
     "css": "^2.2.1",
+    "enumify": "^1.0.4",
     "es6-set": "^0.1.4",
     "esprima": "^3.0.0",
     "firebase": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "loop-breaker": "^0.1.0-alpha.7",
     "moment": "^2.14.1",
     "offline-plugin": "^4.8.1",
+    "parse5": "^3.0.2",
     "pify": "^3.0.0",
     "promise-retry": "^1.1.1",
     "prop-types": "^15.5.10",
@@ -140,7 +141,8 @@
     "rxjs": "^5.0.2",
     "slowparse": "^1.1.4",
     "stylelint": "^7.10.1",
-    "text-encoding": "^0.6.0"
+    "text-encoding": "^0.6.0",
+    "void-elements": "^3.1.0"
   },
   "engines": {
     "node": "7.6.0",

--- a/src/validations/html.js
+++ b/src/validations/html.js
@@ -2,10 +2,12 @@ import trim from 'lodash/trim';
 import mergeValidations from './mergeValidations';
 import validateWithHtmlInspector from './html/htmlInspector';
 import validateWithHtmllint from './html/htmllint';
+import validateWithRules from './html/rules';
 import validateWithSlowparse from './html/slowparse';
 
 export default source => mergeValidations([
   validateWithHtmlInspector(source),
   validateWithHtmllint(source),
   validateWithSlowparse(trim(source)),
+  validateWithRules(source),
 ]);

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -64,7 +64,6 @@ const errorMap = {
     return {
       reason: 'unclosed-tag',
       payload: {tag},
-      suppresses: ['mismatched-close-tag'],
     };
   },
 };

--- a/src/validations/html/rules/Code.js
+++ b/src/validations/html/rules/Code.js
@@ -1,0 +1,8 @@
+import {Enum} from 'enumify';
+
+export default class Code extends Enum {}
+Code.initEnum([
+  'MISPLACED_CLOSE_TAG',
+  'UNCLOSED_TAG',
+  'UNOPENED_TAG',
+]);

--- a/src/validations/html/rules/MismatchedTag.js
+++ b/src/validations/html/rules/MismatchedTag.js
@@ -1,0 +1,86 @@
+// If any spare unopened tag exists afterward, diagnose it and only yield
+// MISPLACED_CLOSE_TAG.
+//
+// Otherwise:
+//
+// A mismatched close tag that has been opened means the case
+//
+// <div>
+//   <span>
+// </div>
+//
+// so yield UNCLOSED_TAG.
+//
+// A mismatched close tag that has yet to be opened means the case
+//
+// <div>
+//   </span>
+// </div>
+//
+// so yield UNOPENED_TAG.
+
+import findLastIndex from 'lodash/findLastIndex';
+import Code from '../rules/Code';
+
+export default class {
+  constructor() {
+    this._openTagStack = [];
+    this._mismatchStacksByOpenName = new Map();
+    this._closeTagMisplacements = [];
+    this._unopenedTags = [];
+  }
+
+  openTag(location, {name}) {
+    this._openTagStack.push({location, name});
+  }
+
+  closeTag(location, name) {
+    const openIndex = findLastIndex(
+      this._openTagStack,
+      openTag => openTag.name === name,
+    );
+
+    const isOpened = openIndex >= 0;
+    if (isOpened) {
+      for (let i = openIndex + 1; i < this._openTagStack.length; ++i) {
+        const openTag = this._openTagStack[i];
+        const mismatch = {
+          openTag,
+          closeTag: {location, name},
+        };
+        const mismatches = this._mismatchStacksByOpenName.get(openTag.name);
+        if (mismatches) {
+          mismatches.push(mismatch);
+        } else {
+          this._mismatchStacksByOpenName.set(openTag.name, [mismatch]);
+        }
+      }
+      this._openTagStack.splice(openIndex);
+    } else {
+      const mismatchStack = this._mismatchStacksByOpenName.get(name) || [];
+      const matchingMismatch = mismatchStack.pop();
+      if (matchingMismatch) {
+        const {openTag, closeTag} = matchingMismatch;
+        this._closeTagMisplacements.push({match: location, openTag, closeTag});
+      } else {
+        this._unopenedTags.push({location, name});
+      }
+    }
+  }
+
+  * done() {
+    for (const mismatches of this._mismatchStacksByOpenName.values()) {
+      for (const {openTag, closeTag} of mismatches) {
+        yield {code: Code.UNCLOSED_TAG, openTag, closeTag};
+      }
+    }
+
+    for (const {openTag, closeTag, match} of this._closeTagMisplacements) {
+      yield {code: Code.MISPLACED_CLOSE_TAG, openTag, closeTag, match};
+    }
+
+    for (const closeTag of this._unopenedTags) {
+      yield {code: Code.UNOPENED_TAG, closeTag};
+    }
+  }
+}

--- a/src/validations/html/rules/index.js
+++ b/src/validations/html/rules/index.js
@@ -1,0 +1,51 @@
+import Validator from '../../Validator';
+import runRules from '../runRules';
+import Code from './Code';
+import MismatchedTag from './MismatchedTag';
+
+const errorMap = {
+  [Code.MISPLACED_CLOSE_TAG]: ({openTag, closeTag}) => ({
+    reason: 'misplaced-close-tag',
+    payload: {
+      open: openTag.name,
+      close: closeTag.name,
+      mismatch: closeTag.location.row + 1,
+    },
+  }),
+  [Code.UNCLOSED_TAG]: ({openTag: {name}}) => ({
+    reason: 'unclosed-tag',
+    payload: {tag: name},
+  }),
+  [Code.UNOPENED_TAG]: ({closeTag: {name}}) => ({
+    reason: 'unexpected-close-tag',
+    payload: {tag: name},
+  }),
+};
+
+class RuleValidator extends Validator {
+  constructor(source) {
+    super(source, 'html', errorMap);
+  }
+
+  _keyForError({code}) {
+    return code;
+  }
+
+  async _getRawErrors() {
+    return Array.from(await runRules([new MismatchedTag()], this._source));
+  }
+
+  _locationForError(error) {
+    switch (error.code) {
+      case Code.MISPLACED_CLOSE_TAG:
+        return error.match;
+      case Code.UNOPENED_TAG:
+      case Code.UNCLOSED_TAG:
+        return error.closeTag.location;
+      default:
+        throw new Error(`Unexpected code in ${JSON.stringify(error)}`);
+    }
+  }
+}
+
+export default source => new RuleValidator(source).getAnnotations();

--- a/src/validations/html/runRules.js
+++ b/src/validations/html/runRules.js
@@ -1,0 +1,40 @@
+import {SAXParser} from 'parse5';
+import voidElements from 'void-elements';
+
+// Runs `rules` on `source` and promises an iterable of all errors.
+//
+// `rules` must be an array of objects that satisfy the interface:
+// * done() returns an iterable of errors
+// * optionally,
+//   openTag({row: number, column: number}, {name: string})
+//   to take in open tags that are neither void nor self-closing
+// * optionally,
+//   closeTag({row: number, column: number}, name: string)
+//   to take in close tags
+export default (rules, source) => {
+  const parser = new SAXParser({locationInfo: true});
+  return new Promise((resolve) => {
+    parser.on('startTag', (name, attrs, selfClosing, {line, col}) => {
+      for (const rule of rules) {
+        if (rule.openTag && !selfClosing && !(name in voidElements)) {
+          rule.openTag({row: line - 1, column: col - 1}, {name});
+        }
+      }
+    });
+    parser.on('endTag', (name, {line, col}) => {
+      for (const rule of rules) {
+        if (rule.closeTag) {
+          rule.closeTag({row: line - 1, column: col - 1}, name);
+        }
+      }
+    });
+    parser.write(source);
+    parser.end(() => {
+      resolve(function* () {
+        for (const rule of rules) {
+          yield* rule.done();
+        }
+      }());
+    });
+  });
+};

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -34,6 +34,7 @@ const errorMap = {
         return {
           reason: 'space-before-tag-name',
           payload: {tag: tagMatch[1]},
+          suppresses: ['unexpected-close-tag'],
         };
       }
     }
@@ -55,22 +56,6 @@ const errorMap = {
     payload: {attribute: error.attribute.name.value},
     suppresses: ['lower-case-attribute-name'],
   }),
-
-  MISMATCHED_CLOSE_TAG: (error) => {
-    const openTagName = error.openTag.name;
-    const closeTagName = error.closeTag.name;
-    if (openTagName === '#document-fragment') {
-      return {
-        reason: 'unexpected-close-tag',
-        payload: {tag: closeTagName},
-      };
-    }
-
-    return {
-      reason: 'mismatched-close-tag',
-      payload: {open: openTagName, close: closeTagName},
-    };
-  },
 
   SELF_CLOSING_NON_VOID_ELEMENT: error => ({
     reason: 'self-closing-non-void-element',

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -65,7 +65,6 @@ const errorMap = {
   UNCLOSED_TAG: error => ({
     reason: 'unclosed-tag',
     payload: {tag: error.openTag.name},
-    suppresses: ['mismatched-close-tag'],
   }),
 
   UNEXPECTED_CLOSE_TAG: error => ({

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -59,9 +59,9 @@ test('missing internal closing tag', validationTest(
   htmlWithBody('<div>'),
   html,
   {
-    reason: 'mismatched-close-tag',
+    reason: 'unclosed-tag',
     row: htmlWithBody.offset + 1,
-    payload: {open: 'div', close: 'body'},
+    payload: {tag: 'div'},
   },
 ));
 
@@ -69,9 +69,9 @@ test('missing internal closing tag', validationTest(
   htmlWithBody('<p>'),
   html,
   {
-    reason: 'mismatched-close-tag',
+    reason: 'unclosed-tag',
     row: htmlWithBody.offset + 1,
-    payload: {open: 'p', close: 'body'},
+    payload: {tag: 'p'},
   },
 ));
 
@@ -89,9 +89,25 @@ test('mismatched closing tag', validationTest(
   htmlWithBody('<div></div></span>'),
   html,
   {
-    reason: 'mismatched-close-tag',
+    reason: 'unexpected-close-tag',
     row: htmlWithBody.offset,
-    payload: {open: 'body', close: 'span'},
+    payload: {tag: 'span'},
+  },
+));
+
+test('misplaced closing tag', validationTest(
+  htmlWithBody(`<div><span></div>
+</span>`),
+  html,
+  {
+    reason: 'misplaced-close-tag',
+    row: htmlWithBody.offset + 1,
+    payload: {
+      open: 'span',
+      close: 'div',
+      // Display the mismatch as one-indexed, not zero-indexed.
+      mismatch: htmlWithBody.offset + 1,
+    },
   },
 ));
 

--- a/test/unit/validations/html/rules.js
+++ b/test/unit/validations/html/rules.js
@@ -1,0 +1,79 @@
+import test from 'tape';
+import Code from '../../../../src/validations/html/rules/Code';
+import MismatchedTag
+  from '../../../../src/validations/html/rules/MismatchedTag';
+
+test('misplaced close tag', (t) => {
+  const rule = new MismatchedTag();
+  rule.openTag({row: 0, column: 10}, {name: 'div'});
+  rule.openTag({row: 1, column: 11}, {name: 'p'});
+  rule.closeTag({row: 2, column: 12}, 'div');
+  rule.closeTag({row: 3, column: 13}, 'p');
+  t.deepEqual(
+    Array.from(rule.done()),
+    [
+      {
+        code: Code.MISPLACED_CLOSE_TAG,
+        openTag: {
+          location: {row: 1, column: 11},
+          name: 'p',
+        },
+        closeTag: {
+          location: {row: 2, column: 12},
+          name: 'div',
+        },
+        match: {row: 3, column: 13},
+      },
+    ]);
+  t.end();
+});
+
+test('unclosed tag', (t) => {
+  const rule = new MismatchedTag();
+  rule.openTag({row: 0, column: 10}, {name: 'div'});
+  rule.openTag({row: 1, column: 11}, {name: 'p'});
+  rule.closeTag({row: 2, column: 12}, 'div');
+  t.deepEqual(
+    Array.from(rule.done()),
+    [
+      {
+        code: Code.UNCLOSED_TAG,
+        openTag: {
+          location: {row: 1, column: 11},
+          name: 'p',
+        },
+        closeTag: {
+          location: {row: 2, column: 12},
+          name: 'div',
+        },
+      },
+    ]);
+  t.end();
+});
+
+test('unopened tag', (t) => {
+  const rule = new MismatchedTag();
+  rule.openTag({row: 0, column: 10}, {name: 'div'});
+  rule.closeTag({row: 1, column: 11}, 'div');
+  rule.closeTag({row: 2, column: 12}, 'p');
+  t.deepEqual(
+    Array.from(rule.done()),
+    [
+      {
+        code: Code.UNOPENED_TAG,
+        closeTag: {
+          location: {row: 2, column: 12},
+          name: 'p',
+        },
+      },
+    ]);
+  t.end();
+});
+
+test('mismatched tag okay', (t) => {
+  const rule = new MismatchedTag();
+  rule.openTag({row: 0, column: 10}, {name: 'div'});
+  rule.closeTag({row: 1, column: 11}, 'div');
+  t.deepEqual(Array.from(rule.done()), []);
+  t.end();
+});

--- a/test/unit/validations/html/runRules.js
+++ b/test/unit/validations/html/runRules.js
@@ -1,141 +1,161 @@
 import test from 'tape';
 import runRules from '../../../../src/validations/html/runRules';
 
-test('openTag row', async (t) => {
+test('openTag row', async(t) => {
   t.plan(1);
-  await runRules([{
-    openTag({row}) {
-      t.equal(row, 2);
-    },
+  await runRules([
+    {
+      openTag({row}) {
+        t.equal(row, 2);
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '\n\n<div>');
+  ], '\n\n<div>');
   t.end();
 });
 
-test('openTag column', async (t) => {
+test('openTag column', async(t) => {
   t.plan(1);
-  await runRules([{
-    openTag({column}) {
-      t.equal(column, 1);
-    },
+  await runRules([
+    {
+      openTag({column}) {
+        t.equal(column, 1);
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '\n <div>');
+  ], '\n <div>');
   t.end();
 });
 
-test('openTag name', async (t) => {
+test('openTag name', async(t) => {
   t.plan(1);
-  await runRules([{
-    openTag(_, {name}) {
-      t.equal(name, 'div');
-    },
+  await runRules([
+    {
+      openTag(_, {name}) {
+        t.equal(name, 'div');
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '<div>');
+  ], '<div>');
   t.end();
 });
 
-test('openTag skips void tag', async (t) => {
-  await runRules([{
-    openTag(location, tag) {
-      t.fail(
-        `location: ${JSON.stringify(location)} tag: ${JSON.stringify(tag)}`);
-    },
+test('openTag skips void tag', async(t) => {
+  await runRules([
+    {
+      openTag(location, tag) {
+        t.fail(
+          `location: ${JSON.stringify(location)} tag: ${JSON.stringify(tag)}`);
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '<img>');
+  ], '<img>');
   t.end();
 });
 
-test('openTag skips self-closing non-void tag', async (t) => {
-  await runRules([{
-    openTag(location, tag) {
-      t.fail(
-        `location: ${JSON.stringify(location)} tag: ${JSON.stringify(tag)}`);
-    },
+test('openTag skips self-closing non-void tag', async(t) => {
+  await runRules([
+    {
+      openTag(location, tag) {
+        t.fail(
+          `location: ${JSON.stringify(location)} tag: ${JSON.stringify(tag)}`);
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '<div/>');
+  ], '<div/>');
   t.end();
 });
 
-test('closeTag row', async (t) => {
+test('closeTag row', async(t) => {
   t.plan(1);
-  await runRules([{
-    closeTag({row}) {
-      t.equal(row, 2);
-    },
+  await runRules([
+    {
+      closeTag({row}) {
+        t.equal(row, 2);
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '\n\n</div>');
+  ], '\n\n</div>');
   t.end();
 });
 
-test('closeTag column', async (t) => {
+test('closeTag column', async(t) => {
   t.plan(1);
-  await runRules([{
-    closeTag({column}) {
-      t.equal(column, 1);
-    },
+  await runRules([
+    {
+      closeTag({column}) {
+        t.equal(column, 1);
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '\n </div>');
+  ], '\n </div>');
   t.end();
 });
 
-test('closeTag name', async (t) => {
+test('closeTag name', async(t) => {
   t.plan(1);
-  await runRules([{
-    closeTag(_, name) {
-      t.equal(name, 'div');
-    },
+  await runRules([
+    {
+      closeTag(_, name) {
+        t.equal(name, 'div');
+      },
 
-    * done() {
+      * done() {
+      },
     },
-  }], '</div>');
+  ], '</div>');
   t.end();
 });
 
-test('event sequence', async (t) => {
+test('event sequence', async(t) => {
   const events = [];
   // Use Array.from to consume the errors.
-  Array.from(await runRules([{
-    openTag(_, {name}) {
-      events.push(`<${name}>`);
-    },
+  Array.from(await runRules([
+    {
+      openTag(_, {name}) {
+        events.push(`<${name}>`);
+      },
 
-    closeTag(_, name) {
-      events.push(`</${name}>`);
-    },
+      closeTag(_, name) {
+        events.push(`</${name}>`);
+      },
 
-    done() {
-      events.push(null);
-      return [];
+      done() {
+        events.push(null);
+        return [];
+      },
     },
-  }], ' <div> <p> </p> </div> '));
+  ], ' <div> <p> </p> </div> '));
   t.deepEqual(events, ['<div>', '<p>', '</p>', '</div>', null]);
   t.end();
 });
 
-test('chains errors', async (t) => {
-  const errors = Array.from(await runRules([{
-    * done() {
-      yield 2;
+test('chains errors', async(t) => {
+  const errors = Array.from(await runRules([
+    {
+      * done() {
+        yield 2;
+      },
+    }, {
+      * done() {
+        yield 1;
+      },
     },
-  }, {
-    * done() {
-      yield 1;
-    },
-  }], ''));
+  ], ''));
   // To avoid dependence on iteration order.
   errors.sort();
   t.deepEqual(errors, [1, 2]);

--- a/test/unit/validations/html/runRules.js
+++ b/test/unit/validations/html/runRules.js
@@ -1,0 +1,143 @@
+import test from 'tape';
+import runRules from '../../../../src/validations/html/runRules';
+
+test('openTag row', async (t) => {
+  t.plan(1);
+  await runRules([{
+    openTag({row}) {
+      t.equal(row, 2);
+    },
+
+    * done() {
+    },
+  }], '\n\n<div>');
+  t.end();
+});
+
+test('openTag column', async (t) => {
+  t.plan(1);
+  await runRules([{
+    openTag({column}) {
+      t.equal(column, 1);
+    },
+
+    * done() {
+    },
+  }], '\n <div>');
+  t.end();
+});
+
+test('openTag name', async (t) => {
+  t.plan(1);
+  await runRules([{
+    openTag(_, {name}) {
+      t.equal(name, 'div');
+    },
+
+    * done() {
+    },
+  }], '<div>');
+  t.end();
+});
+
+test('openTag skips void tag', async (t) => {
+  await runRules([{
+    openTag(location, tag) {
+      t.fail(
+        `location: ${JSON.stringify(location)} tag: ${JSON.stringify(tag)}`);
+    },
+
+    * done() {
+    },
+  }], '<img>');
+  t.end();
+});
+
+test('openTag skips self-closing non-void tag', async (t) => {
+  await runRules([{
+    openTag(location, tag) {
+      t.fail(
+        `location: ${JSON.stringify(location)} tag: ${JSON.stringify(tag)}`);
+    },
+
+    * done() {
+    },
+  }], '<div/>');
+  t.end();
+});
+
+test('closeTag row', async (t) => {
+  t.plan(1);
+  await runRules([{
+    closeTag({row}) {
+      t.equal(row, 2);
+    },
+
+    * done() {
+    },
+  }], '\n\n</div>');
+  t.end();
+});
+
+test('closeTag column', async (t) => {
+  t.plan(1);
+  await runRules([{
+    closeTag({column}) {
+      t.equal(column, 1);
+    },
+
+    * done() {
+    },
+  }], '\n </div>');
+  t.end();
+});
+
+test('closeTag name', async (t) => {
+  t.plan(1);
+  await runRules([{
+    closeTag(_, name) {
+      t.equal(name, 'div');
+    },
+
+    * done() {
+    },
+  }], '</div>');
+  t.end();
+});
+
+test('event sequence', async (t) => {
+  const events = [];
+  // Use Array.from to consume the errors.
+  Array.from(await runRules([{
+    openTag(_, {name}) {
+      events.push(`<${name}>`);
+    },
+
+    closeTag(_, name) {
+      events.push(`</${name}>`);
+    },
+
+    done() {
+      events.push(null);
+      return [];
+    },
+  }], ' <div> <p> </p> </div> '));
+  t.deepEqual(events, ['<div>', '<p>', '</p>', '</div>', null]);
+  t.end();
+});
+
+test('chains errors', async (t) => {
+  const errors = Array.from(await runRules([{
+    * done() {
+      yield 2;
+    },
+  }, {
+    * done() {
+      yield 1;
+    },
+  }], ''));
+  // To avoid dependence on iteration order.
+  errors.sort();
+  t.deepEqual(errors, [1, 2]);
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,6 +2676,10 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+enumify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/enumify/-/enumify-1.0.4.tgz#2bb6263071dd4551e54c55755707fad24a40cd7e"
+
 err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@types/node@^6.0.46":
+  version "6.0.78"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.78.tgz#5d4a3f579c1524e01ee21bf474e6fba09198f470"
+
 JSONStream@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
@@ -5891,6 +5895,12 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
+parse5@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+  dependencies:
+    "@types/node" "^6.0.46"
+
 parsejson@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.3.tgz#ab7e3759f209ece99437973f7d0f1f64ae0e64ab"
@@ -8539,6 +8549,10 @@ vm-browserify@0.0.4:
 void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+
+void-elements@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
 
 w3c-blob@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
An attempt to fix #562, although goes a bit farther by deprecating `mismatched-close-tag` in favor of three distinct errors:

- `misplaced-close-tag`: **(new)** suggests moving a spare unopened close tag
- `unclosed-tag-by-mismatched-close-tag`: **(new)** suggests adding a close tag right before the mismatched close tag
- `unexpected-close-tag`: preexisting

This pull request introduces a new HTML `Validator` that performs its own lexical analysis using the [SAX](https://en.wikipedia.org/wiki/Simple_API_for_XML) parser from [`parse5`](https://github.com/inikulin/parse5) to parse HTML tokens.

The code is a bit complex, so feel free to offer readability suggestions. Thanks!