### PR TITLE
Clean up webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.14.0",
-    "babel-loader": "^6.2.4",
+    "babel-loader": "^7.1.1",
     "babel-polyfill": "^6.6.1",
     "babel-preset-env": "^1.5.1",
     "babel-preset-es2015": "^6.24.1",
@@ -206,7 +206,7 @@
     "string-replace-loader": "^1.0.5",
     "stylelint-selector-bem-pattern": "^1.0.0",
     "substitute-loader": "^1.0.0",
-    "svg-react-loader": "^0.4.0-beta.2",
+    "svg-react-loader": "^0.4.4",
     "svgo": "^0.7.2",
     "svgo-loader": "^1.1.2",
     "tape": "^4.6.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,9 @@ let targets;
 if (process.env.DEBUG === 'true') {
   targets = {browsers: 'last 1 Chrome version'};
 } else {
-  targets = JSON.parse(fs.readFileSync('./config/browsers.json'));
+  targets = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, 'config/browsers.json'))
+  );
 }
 const babelrc = {
   presets: [
@@ -69,7 +71,7 @@ module.exports = {
     sourceMapFilename: 'application.js.map',
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.jsx?$/,
         include: [
@@ -78,124 +80,27 @@ module.exports = {
         ],
         use: [
           {loader: 'babel-loader', options: babelrc},
-          {loader: 'eslint-loader'},
+          'eslint-loader'
         ],
-      },
-      {
-        test: /\.js$/,
-        include: [
-          path.resolve(__dirname, 'node_modules/htmllint'),
-        ],
-        loader: 'transform-loader/cacheable?bulkify',
-      },
-      {
-        test: /\.js$/,
-        include: [
-          path.resolve(__dirname, 'node_modules/PrettyCSS'),
-          path.resolve(__dirname, 'node_modules/css'),
-        ],
-        loader: 'transform-loader/cacheable?brfs',
-      },
-      {
-        test: /\.js$/,
-        include: [
-          path.resolve(__dirname, 'node_modules/postcss/lib/previous-map'),
-          path.resolve(
-            __dirname,
-            'node_modules/stylelint/lib/getPostcssResult'
-          ),
-          matchModule('postcss/lib/previous-map'),
-        ],
-        loader: 'string-replace-loader',
-        query: {
-          search: /require\(['"]fs['"]\)/,
-          replace: '{}',
-        },
-      },
-      {
-        test: /\.js$/,
-        include: [
-          matchModule('htmllint'),
-        ],
-        loader: 'string-replace-loader',
-        query: {
-          search: 'require(plugin)',
-          replace: 'undefined',
-        },
-      },
-      {
-        test: /\.js$/,
-        include: [
-          path.resolve(
-            __dirname,
-            'node_modules/stylelint/lib/utils/isAutoprefixable'
-          ),
-        ],
-        loader: 'substitute-loader',
-        query: {content: '() => false'},
-      },
-      {
-        test: /\.js$/,
-        include: [
-          matchModule('redux'),
-          matchModule('lodash-es'),
-          matchModule('stylelint'),
-          matchModule('redux-saga-debounce-effect'),
-        ],
-        use: {loader: 'babel-loader', options: babelrc},
-      },
-      {
-        include: [
-          path.resolve(
-            __dirname,
-            'node_modules/html-inspector/html-inspector.js'
-          ),
-        ],
-        loader:
-          'imports-loader?window=>{}!exports-loader?window.HTMLInspector',
-      },
-      {
-        test: /\.js$/,
-        include: [
-          path.resolve(__dirname, 'node_modules/brace/worker'),
-          matchModule('autoprefixer'),
-          matchModule('postcss-scss'),
-          matchModule('postcss-less'),
-          matchModule('sugarss'),
-          matchModule('stylelint/lib/dynamicRequire'),
-          matchModule('css/lib/stringify/source-map-support'),
-        ],
-        loader: 'null-loader',
-      },
-      {
-        test: /\.js$/,
-        include: directoryContentsExcept(
-          'node_modules/stylelint/lib/rules',
-          [
-            'index.js',
-            'declaration-block-trailing-semicolon/index.js',
-          ]
-        ),
-        loader: 'null-loader',
       },
       {
         test: /\.json$/,
-        loader: 'json-loader',
+        use: ['json-loader'],
       },
       {
         include: [
           path.resolve(__dirname, 'bower_components'),
           path.resolve(__dirname, 'templates'),
         ],
-        use: {loader: 'raw-loader'},
+        use: ['raw-loader'],
       },
       {
         test: /\.svg$/,
-        loader: [
+        use: [
           'svg-react-loader',
           {
             loader: 'svgo-loader',
-            query: {
+            options: {
               plugins: [
                 {
                   removeXMLNS: true,
@@ -213,11 +118,93 @@ module.exports = {
       },
       {
         include: path.resolve(__dirname, 'locales'),
-        loader: 'i18next-resource-store-loader',
-        query: 'include=\\.json$',
+        use: [{
+          loader: 'i18next-resource-store-loader',
+          options: 'include=\\.json$',
+        }],
       },
+      {
+        include: matchModule('htmllint'),
+        enforce: 'post',
+        use: ['transform-loader/cacheable?bulkify'],
+      },
+      {
+        include: [matchModule('PrettyCSS'), matchModule('css')],
+        use: ['transform-loader/cacheable?brfs'],
+      },
+      {
+        test: /\.js$/,
+        include: [
+          matchModule('htmllint'),
+        ],
+        use: [{
+          loader: 'string-replace-loader',
+          options: {
+            search: 'require(plugin)',
+            replace: 'undefined',
+          },
+        }],
+      },
+      {
+        test: /\.js$/,
+        include: [
+          path.resolve(
+            __dirname,
+            'node_modules/stylelint/lib/utils/isAutoprefixable'
+          ),
+        ],
+        use: [{
+          loader: 'substitute-loader',
+          options: {content: '() => false'},
+        }],
+      },
+      {
+        test: /\.js$/,
+        include: [
+          matchModule('redux'),
+          matchModule('lodash-es'),
+          matchModule('stylelint'),
+          matchModule('redux-saga-debounce-effect'),
+        ],
+        use: {loader: 'babel-loader', options: babelrc},
+      },
+      {
+        include: matchModule('html-inspector'),
+        use: [
+          {loader: 'imports-loader', options: 'window=>{}'},
+          {
+            loader: 'exports-loader',
+            options: {'window.HTMLInspector': true},
+          },
+        ],
+      },
+      {
+        test: /\.js$/,
+        include: [
+          path.resolve(__dirname, 'node_modules/brace/worker'),
+          matchModule('autoprefixer'),
+          matchModule('postcss-scss'),
+          matchModule('postcss-less'),
+          matchModule('sugarss'),
+          matchModule('stylelint/lib/dynamicRequire'),
+          matchModule('css/lib/stringify/source-map-support'),
+        ],
+        use: ['null-loader'],
+      },
+      {
+        test: /\.js$/,
+        include: directoryContentsExcept(
+          'node_modules/stylelint/lib/rules',
+          [
+            'index.js',
+            'declaration-block-trailing-semicolon/index.js',
+          ]
+        ),
+        use: ['null-loader'],
+      }
     ],
   },
+
   plugins: [
     new webpack.EnvironmentPlugin({
       FIREBASE_APP: 'popcode-development',
@@ -229,6 +216,11 @@ module.exports = {
       GOOGLE_ANALYTICS_TRACKING_ID: 'UA-90316486-2'
     }),
   ],
+
+  node: {
+    fs: 'empty',
+  },
+
   resolve: {
     alias: {
       'github-api$': 'github-api/dist/components/GitHub.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,14 +506,13 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-loader@^6.2.4:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.4.1.tgz#0b34112d5b0748a8dcdbf51acf6f9bd42d50b8ca"
+babel-loader@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.1.tgz#b87134c8b12e3e4c2a94e0546085bc680a2b8488"
   dependencies:
-    find-cache-dir "^0.1.1"
-    loader-utils "^0.2.16"
+    find-cache-dir "^1.0.0"
+    loader-utils "^1.0.2"
     mkdirp "^0.5.1"
-    object-assign "^4.0.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -3160,6 +3159,14 @@ find-cache-dir@^0.1.1:
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
 
+find-cache-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^2.0.0"
+
 find-index@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
@@ -3175,7 +3182,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -4719,7 +4726,7 @@ loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.0.3, loader-utils@^1.1.0:
+loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.0.3, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -5860,6 +5867,12 @@ pkg-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
   dependencies:
     find-up "^1.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  dependencies:
+    find-up "^2.1.0"
 
 pkg-up@^1.0.0:
   version "1.0.0"
@@ -7709,11 +7722,12 @@ supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-svg-react-loader@^0.4.0-beta.2:
-  version "0.4.0-beta.2"
-  resolved "https://registry.yarnpkg.com/svg-react-loader/-/svg-react-loader-0.4.0-beta.2.tgz#3dc8702aff538703712862be47eb2bc6d01ccf72"
+svg-react-loader@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/svg-react-loader/-/svg-react-loader-0.4.4.tgz#ea3b2ebc8ff8eaafd7cca5b86750f90a2faac4fd"
   dependencies:
     css "2.2.1"
+    loader-utils "1.1.0"
     ramda "0.21.0"
     rx "4.1.0"
     traverse "0.6.6"


### PR DESCRIPTION
* Use currently preferred configuration format—`module.rules` instead of `module.loaders`, `use` instead of `loader`, etc.
* Put general loader configurations first, then module-specific workarounds
* Use `node: {fs: 'empty'}` to stub out `fs` rather than doing it with a substitute loader

This is extracted from an attempt to port our build tooling to Blendid, which I have since decided not to do.

Upgrade `babel-loader` and `svg-react-loader` to avoid warnings.