### PR TITLE
Add reselect and use it to extract data from store in containers

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -7,6 +7,10 @@
     "type": "container",
     "template": "import {open}connect{close} from 'react-redux';\nimport {open}{}{close} from '../components';\nimport {open}{close} from '../actions';\n\nfunction mapStateToProps(state) {open}\n  return {open}\n  {close};\n{close}\n\nfunction mapDispatchToProps(dispatch) {open}\n  return {open}\n  {close};\n{close}\n\nexport default connect(\n  mapStateToProps,\n  mapDispatchToProps,\n)({});\n"
   },
+  "src/selectors/*.js": {
+    "type": "selector",
+    "template": "import {open}createSelector{close} from 'reselect';\n\nexport default createSelector(\n  [],\n  () => {open}\n  {close},\n);"
+  },
   "src/store.js": {
     "type": "store"
   },

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "redux-logger": "^2.5.0",
     "redux-saga": "^0.15.3",
     "redux-saga-debounce-effect": "https://github.com/madewithlove/redux-saga-debounce-effect.git#v0.2.2",
+    "reselect": "^3.0.1",
     "rxjs": "^5.0.2",
     "slowparse": "^1.1.4",
     "stylelint": "^7.10.1",

--- a/src/analyzers/index.js
+++ b/src/analyzers/index.js
@@ -9,7 +9,7 @@ class Analyzer {
 
   get doc() {
     if (isUndefined(this._doc)) {
-      const htmlString = this._project.getIn(['sources', 'html']);
+      const htmlString = this._project.sources.html;
       this._doc = domParser.parseFromString(htmlString, 'text/html');
     }
     return this._doc;
@@ -20,7 +20,7 @@ class Analyzer {
   }
 
   get enabledLibraries() {
-    return this._project.get('enabledLibraries').toJS();
+    return this._project.enabledLibraries;
   }
 }
 

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -47,7 +47,8 @@ import {
   applicationLoaded,
 } from '../actions';
 
-import {getCurrentProject, isPristineProject} from '../util/projectUtils';
+import {isPristineProject} from '../util/projectUtils';
+import {getCurrentProject} from '../selectors';
 
 import EditorsColumn from './EditorsColumn';
 import Output from './Output';

--- a/src/containers/ErrorReport.js
+++ b/src/containers/ErrorReport.js
@@ -1,18 +1,18 @@
 import {connect} from 'react-redux';
 import {ErrorReport} from '../components';
 import {focusLine} from '../actions';
-import {getErrors} from '../selectors';
+import {
+  getErrors,
+  isCurrentlyValidating,
+  isCurrentProjectSyntacticallyValid,
+  isUserTyping,
+} from '../selectors';
 
 function mapStateToProps(state) {
   return {
     errors: getErrors(state),
-    isValidating: Boolean(
-      state.getIn(['ui', 'editors', 'typing']) &&
-      state.get('errors').find(
-        error => error.get('state') === 'validation-error',
-      ) ||
-      state.get('errors').find(error => error.get('state') === 'validating'),
-    ),
+    isValidating: isCurrentlyValidating(state) ||
+      (isUserTyping(state) && !isCurrentProjectSyntacticallyValid(state)),
   };
 }
 

--- a/src/containers/ErrorReport.js
+++ b/src/containers/ErrorReport.js
@@ -1,10 +1,11 @@
 import {connect} from 'react-redux';
 import {ErrorReport} from '../components';
 import {focusLine} from '../actions';
+import {getErrors} from '../selectors';
 
 function mapStateToProps(state) {
   return {
-    errors: state.get('errors').toJS(),
+    errors: getErrors(state),
     isValidating: Boolean(
       state.getIn(['ui', 'editors', 'typing']) &&
       state.get('errors').find(

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -5,7 +5,7 @@ import {
   popOutProject,
   refreshPreview,
 } from '../actions';
-import {getCurrentProject} from '../util/projectUtils';
+import {getCurrentProject} from '../selectors';
 
 const syntacticallyValidStates = new Set(['passed', 'runtime-error']);
 

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -5,16 +5,16 @@ import {
   popOutProject,
   refreshPreview,
 } from '../actions';
-import {getCurrentProject} from '../selectors';
-
-const syntacticallyValidStates = new Set(['passed', 'runtime-error']);
+import {
+  getCurrentProject,
+  getLastRefreshTimestamp,
+  isCurrentProjectSyntacticallyValid,
+} from '../selectors';
 
 function mapStateToProps(state) {
   return {
-    isSyntacticallyValid: !state.get('errors').find(
-      error => !syntacticallyValidStates.has(error.get('state')),
-    ),
-    lastRefreshTimestamp: state.getIn(['ui', 'lastRefreshTimestamp']),
+    isSyntacticallyValid: isCurrentProjectSyntacticallyValid(state),
+    lastRefreshTimestamp: getLastRefreshTimestamp(state),
     project: getCurrentProject(state),
   };
 }

--- a/src/sagas/clients.js
+++ b/src/sagas/clients.js
@@ -1,7 +1,7 @@
 import {call, put, select, takeEvery} from 'redux-saga/effects';
 import {createFromProject} from '../clients/gists';
 import {gistExported, gistExportError} from '../actions/clients';
-import {getCurrentProject} from '../util/projectUtils';
+import {getCurrentProject} from '../selectors';
 
 export function* exportGist() {
   const state = yield select();

--- a/src/sagas/errors.js
+++ b/src/sagas/errors.js
@@ -8,15 +8,9 @@ import {
   takeEvery,
 } from 'redux-saga/effects';
 import Analyzer from '../analyzers';
+import {getCurrentProject} from '../selectors';
 import validations from '../validations';
 import {validatedSource} from '../actions/errors';
-
-function getCurrentProject(state) {
-  return state.getIn([
-    'projects',
-    state.getIn(['currentProject', 'projectKey']),
-  ]);
-}
 
 export function* toggleLibrary(tasks) {
   yield call(validateCurrentProject, tasks);
@@ -37,7 +31,8 @@ export function* validateCurrentProject(tasks) {
   const currentProject = getCurrentProject(state);
   const analyzer = new Analyzer(currentProject);
 
-  for (const [language, source] of currentProject.get('sources')) {
+  for (const language of Reflect.ownKeys(currentProject.sources)) {
+    const source = currentProject.sources[language];
     yield fork(
       validateSource,
       tasks,

--- a/src/selectors/getCurrentProject.js
+++ b/src/selectors/getCurrentProject.js
@@ -1,0 +1,19 @@
+import {createSelector} from 'reselect';
+
+function getCurrentProjectKey(state) {
+  return state.getIn(['currentProject', 'projectKey']);
+}
+
+function getProjects(state) {
+  return state.get('projects');
+}
+
+export default createSelector(
+  [getCurrentProjectKey, getProjects],
+  (projectKey, projects) => {
+    if (projectKey) {
+      return projects.get(projectKey).toJS();
+    }
+    return null;
+  },
+);

--- a/src/selectors/getErrors.js
+++ b/src/selectors/getErrors.js
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  state => state.get('errors'),
+  errors => errors.toJS(),
+);

--- a/src/selectors/getLastRefreshTimestamp.js
+++ b/src/selectors/getLastRefreshTimestamp.js
@@ -1,0 +1,3 @@
+export default function getLastRefreshTimestamp(state) {
+  return state.getIn(['ui', 'lastRefreshTimestamp']);
+}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,0 +1,3 @@
+import getCurrentProject from './getCurrentProject';
+
+export {getCurrentProject};

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,10 +1,12 @@
 import getCurrentProject from './getCurrentProject';
+import getErrors from './getErrors';
 import getLastRefreshTimestamp from './getLastRefreshTimestamp';
 import isCurrentProjectSyntacticallyValid
   from './isCurrentProjectSyntacticallyValid';
 
 export {
   getCurrentProject,
+  getErrors,
   getLastRefreshTimestamp,
   isCurrentProjectSyntacticallyValid,
 };

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,12 +1,16 @@
 import getCurrentProject from './getCurrentProject';
 import getErrors from './getErrors';
 import getLastRefreshTimestamp from './getLastRefreshTimestamp';
+import isCurrentlyValidating from './isCurrentlyValidating';
 import isCurrentProjectSyntacticallyValid
   from './isCurrentProjectSyntacticallyValid';
+import isUserTyping from './isUserTyping';
 
 export {
   getCurrentProject,
   getErrors,
   getLastRefreshTimestamp,
+  isCurrentlyValidating,
   isCurrentProjectSyntacticallyValid,
+  isUserTyping,
 };

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,3 +1,10 @@
 import getCurrentProject from './getCurrentProject';
+import getLastRefreshTimestamp from './getLastRefreshTimestamp';
+import isCurrentProjectSyntacticallyValid
+  from './isCurrentProjectSyntacticallyValid';
 
-export {getCurrentProject};
+export {
+  getCurrentProject,
+  getLastRefreshTimestamp,
+  isCurrentProjectSyntacticallyValid,
+};

--- a/src/selectors/isCurrentProjectSyntacticallyValid.js
+++ b/src/selectors/isCurrentProjectSyntacticallyValid.js
@@ -1,0 +1,10 @@
+import {createSelector} from 'reselect';
+
+const syntacticallyValidStates = new Set(['passed', 'runtime-error']);
+
+export default createSelector(
+  state => state.get('errors'),
+  errors => !errors.find(
+    error => !syntacticallyValidStates.has(error.get('state')),
+  ),
+);

--- a/src/selectors/isCurrentlyValidating.js
+++ b/src/selectors/isCurrentlyValidating.js
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  state => state.get('errors'),
+  errors => errors.find(error => error.get('state') === 'validating'),
+);

--- a/src/selectors/isUserTyping.js
+++ b/src/selectors/isUserTyping.js
@@ -1,0 +1,3 @@
+export default function isUserTyping(state) {
+  return state.getIn(['ui', 'editors', 'typing']);
+}

--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -2,7 +2,7 @@ import 'bugsnag-js';
 import isError from 'lodash/isError';
 import isString from 'lodash/isString';
 import config from '../config';
-import {getCurrentProject} from './projectUtils';
+import {getCurrentProject} from '../selectors';
 
 const Bugsnag = window.Bugsnag.noConflict();
 Bugsnag.apiKey = config.bugsnagApiKey;

--- a/src/util/projectUtils.js
+++ b/src/util/projectUtils.js
@@ -1,16 +1,9 @@
 import {Map} from 'immutable';
 import FirebasePersistor from '../persistors/FirebasePersistor';
+import {getCurrentProject} from '../selectors';
 
 export function getProjectKeys(state) {
   return Array.from(state.get('projects').keys());
-}
-
-export function getCurrentProject(state) {
-  const projectKey = state.getIn(['currentProject', 'projectKey']);
-  if (projectKey) {
-    return state.getIn(['projects', projectKey]).toJS();
-  }
-  return null;
 }
 
 export function isPristineProject(project) {

--- a/test/helpers/Scenario.js
+++ b/test/helpers/Scenario.js
@@ -29,7 +29,7 @@ export default class Scenario {
   }
 
   get analyzer() {
-    return new Analyzer(this.project);
+    return new Analyzer(this.project.toJS());
   }
 
   _reduce(action) {

--- a/test/unit/Analyzer.js
+++ b/test/unit/Analyzer.js
@@ -1,18 +1,18 @@
 import test from 'tape';
 import Analyzer from '../../src/analyzers';
-import buildImmutableProject from '../helpers/buildImmutableProject';
+import {project as buildProject} from '../helpers/factory';
 
 test('no script tag', (assert) => {
   const html = '<h1>Some harmless html</h1>';
-  const currentProject = buildImmutableProject({html});
+  const currentProject = buildProject({sources: {html}});
   const analyzer = new Analyzer(currentProject);
   assert.notOk(analyzer.containsExternalScript);
   assert.end();
 });
 
 test('<script> tag', (assert) => {
-  const currentProject = buildImmutableProject({
-    html: '<script src="https://script.com/script.js">',
+  const currentProject = buildProject({
+    sources: {html: '<script src="https://script.com/script.js">'},
   });
   const analyzer = new Analyzer(currentProject);
   assert.ok(analyzer.containsExternalScript);
@@ -20,7 +20,10 @@ test('<script> tag', (assert) => {
 });
 
 test('libraries', (assert) => {
-  const currentProject = buildImmutableProject({html: ''}, ['jquery']);
+  const currentProject = buildProject({
+    sources: {html: ''},
+    enabledLibraries: ['jquery'],
+  });
   const analyzer = new Analyzer(currentProject);
   assert.deepEqual(analyzer.enabledLibraries, ['jquery']);
   assert.end();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6999,6 +6999,10 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"


### PR DESCRIPTION
Adds the `reselect` library, which enables the creation of memoized selectors. The job of selector is to derive information from the state tree in a form that’s useful to the UI.

A few motivations here:

* `reselect` selectors are memoized, meaning expensive calculations can be done once and retained until the inputs change. This is good for runtime efficiency.
* Selector memoization also means that we can get all the benefits of `Immutable` outside the Redux store without having to actually pass around `Immutable` objects. In particular, as long as `toJS()` calls are happening inside a selector, we have a guarantee of object-level equality of the selectors’ output as long as the data hasn’t changed.
* Finally, selectors give us a first-class place to put code that derives useful information out of the Redux store, replacing the ad-hoc system we use now (e.g. `projectUtils` etc.)