### PR TITLE
Dashboard container

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -140,7 +140,10 @@ class Dashboard extends React.Component {
     return (
       <LibraryPicker
         enabledLibraries={this.props.currentProject.enabledLibraries}
-        onLibraryToggled={this.props.onLibraryToggled}
+        onLibraryToggled={partial(
+          this.props.onLibraryToggled,
+          this.props.currentProject.projectKey,
+        )}
       />
     );
   }
@@ -197,6 +200,10 @@ class Dashboard extends React.Component {
   }
 
   render() {
+    if (!this.props.isOpen) {
+      return null;
+    }
+
     const sidebarClassnames = classnames(
       'dashboard',
       'u__flex-container',
@@ -227,6 +234,7 @@ Dashboard.propTypes = {
   currentProject: PropTypes.object,
   currentUser: PropTypes.object.isRequired,
   gistExportInProgress: PropTypes.bool.isRequired,
+  isOpen: PropTypes.bool.isRequired,
   validationState: PropTypes.string.isRequired,
   onExportGist: PropTypes.func.isRequired,
   onLibraryToggled: PropTypes.func.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -2,69 +2,50 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {DraggableCore} from 'react-draggable';
 import {connect} from 'react-redux';
-import get from 'lodash/get';
 import values from 'lodash/values';
 import bindAll from 'lodash/bindAll';
 import includes from 'lodash/includes';
 import isNull from 'lodash/isNull';
 import partial from 'lodash/partial';
-import sortBy from 'lodash/sortBy';
 import map from 'lodash/map';
-import isError from 'lodash/isError';
-import isString from 'lodash/isString';
 import {t} from 'i18next';
 import qs from 'qs';
 import {getNodeWidth, getNodeWidths} from '../util/resize';
-import Bugsnag from '../util/Bugsnag';
 import {
   onSignedIn,
   onSignedOut,
-  signIn,
-  signOut,
   startSessionHeartbeat,
 } from '../clients/firebaseAuth';
 
 import {
-  changeCurrentProject,
-  createProject,
   updateProjectSource,
   userAuthenticated,
   userLoggedOut,
-  toggleLibrary,
   hideComponent,
   unhideComponent,
   toggleDashboard,
-  toggleDashboardSubmenu,
   focusLine,
   editorFocusedRequestedLine,
   dragRowDivider,
   dragColumnDivider,
   startDragColumnDivider,
   stopDragColumnDivider,
-  notificationTriggered,
   userDismissedNotification,
-  exportGist,
   applicationLoaded,
 } from '../actions';
 
 import {isPristineProject} from '../util/projectUtils';
 import {getCurrentProject} from '../selectors';
 
+import {Dashboard} from '../containers';
 import EditorsColumn from './EditorsColumn';
 import Output from './Output';
 import Sidebar from './Sidebar';
-import Dashboard from './Dashboard';
 import NotificationList from './NotificationList';
 import PopThrobber from './PopThrobber';
 
 function mapStateToProps(state) {
-  const projects = sortBy(
-    values(state.get('projects').toJS()),
-    project => -project.updatedAt,
-  );
-
   return {
-    allProjects: projects,
     currentProject: getCurrentProject(state),
     errors: state.get('errors').toJS(),
     isDraggingColumnDivider: state.getIn(
@@ -75,7 +56,6 @@ function mapStateToProps(state) {
     rowsFlex: state.getIn(['ui', 'workspace', 'rowFlex']).toJS(),
     currentUser: state.get('user').toJS(),
     ui: state.get('ui').toJS(),
-    clients: state.get('clients').toJS(),
   };
 }
 
@@ -87,22 +67,15 @@ class Workspace extends React.Component {
       '_confirmUnload',
       '_handleComponentUnhide',
       '_handleComponentHide',
-      '_handleDashboardSubmenuToggled',
       '_handleDividerDrag',
       '_handleDividerStart',
       '_handleDividerStop',
       '_handleEditorInput',
       '_handleEditorsDividerDrag',
       '_handleErrorClick',
-      '_handleLibraryToggled',
-      '_handleLogOut',
-      '_handleNewProject',
-      '_handleProjectSelected',
-      '_handleStartLogIn',
       '_handleToggleDashboard',
       '_handleRequestedLineFocused',
       '_handleNotificationDismissed',
-      '_handleExportGist',
       '_storeDividerRef',
       '_storeColumnRef',
     );
@@ -174,27 +147,6 @@ class Workspace extends React.Component {
     );
   }
 
-  _handleLibraryToggled(libraryKey) {
-    this.props.dispatch(
-      toggleLibrary(
-        this.props.currentProject.projectKey,
-        libraryKey,
-      ),
-    );
-  }
-
-  _handleNewProject() {
-    this.props.dispatch(createProject());
-  }
-
-  _handleProjectSelected(project) {
-    this.props.dispatch(changeCurrentProject(project.projectKey));
-  }
-
-  _handleDashboardSubmenuToggled(submenu) {
-    this.props.dispatch(toggleDashboardSubmenu(submenu));
-  }
-
   _getOverallValidationState() {
     const errorStates = map(values(this.props.errors), 'state');
 
@@ -251,84 +203,12 @@ class Workspace extends React.Component {
     onSignedOut(() => this.props.dispatch(userLoggedOut()));
   }
 
-  _handleStartLogIn() {
-    signIn().catch((e) => {
-      switch (e.code) {
-        case 'auth/popup-closed-by-user':
-          this.props.dispatch(notificationTriggered('user-cancelled-auth'));
-          break;
-        case 'auth/network-request-failed':
-          this.props.dispatch(notificationTriggered('auth-network-error'));
-          break;
-        case 'auth/cancelled-popup-request':
-          break;
-        case 'auth/web-storage-unsupported':
-          this.props.dispatch(
-            notificationTriggered('auth-third-party-cookies-disabled'),
-          );
-          break;
-        default:
-          this.props.dispatch(notificationTriggered('auth-error'));
-          if (isError(e)) {
-            Bugsnag.notifyException(e, e.code);
-          } else if (isString(e)) {
-            Bugsnag.notifyException(new Error(e));
-          }
-          break;
-      }
-    });
-  }
-
   _handleNotificationDismissed(error) {
     this.props.dispatch(userDismissedNotification(error.type));
   }
 
-  _handleLogOut() {
-    signOut();
-  }
-
   _handleRequestedLineFocused() {
     this.props.dispatch(editorFocusedRequestedLine());
-  }
-
-  _handleExportGist() {
-    this.props.dispatch(exportGist());
-  }
-
-  _renderDashboard() {
-    const {
-      allProjects,
-      clients,
-      currentProject,
-      currentUser,
-      ui,
-    } = this.props;
-
-    if (!ui.dashboard.isOpen) {
-      return null;
-    }
-
-    return (
-      <div className="layout__dashboard">
-        <Dashboard
-          activeSubmenu={ui.dashboard.activeSubmenu}
-          allProjects={allProjects}
-          currentProject={currentProject}
-          currentUser={currentUser}
-          gistExportInProgress={
-            get(clients, 'gists.lastExport.status') === 'waiting'
-          }
-          validationState={this._getOverallValidationState()}
-          onExportGist={this._handleExportGist}
-          onLibraryToggled={this._handleLibraryToggled}
-          onLogOut={this._handleLogOut}
-          onNewProject={this._handleNewProject}
-          onProjectSelected={this._handleProjectSelected}
-          onStartLogIn={this._handleStartLogIn}
-          onSubmenuToggled={this._handleDashboardSubmenuToggled}
-        />
-      </div>
-    );
   }
 
   _renderSidebar() {
@@ -424,7 +304,7 @@ class Workspace extends React.Component {
           onErrorDismissed={this._handleNotificationDismissed}
         />
         <div className="layout">
-          {this._renderDashboard()}
+          <Dashboard />
           {this._renderSidebar()}
           <div className="workspace layout__main">
             {this._renderEnvironment()}
@@ -436,8 +316,6 @@ class Workspace extends React.Component {
 }
 
 Workspace.propTypes = {
-  allProjects: PropTypes.array.isRequired,
-  clients: PropTypes.object.isRequired,
   currentProject: PropTypes.object,
   currentUser: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,9 @@
+import Dashboard from './Dashboard';
 import ErrorReport from './ErrorReport';
 import Preview from './Preview';
 
 export {
+  Dashboard,
   ErrorReport,
   Preview,
 };

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -1,0 +1,108 @@
+import {connect} from 'react-redux';
+import isError from 'lodash/isError';
+import isString from 'lodash/isString';
+import Bugsnag from '../util/Bugsnag';
+import {Dashboard} from '../components';
+import {
+  changeCurrentProject,
+  createProject,
+  exportGist,
+  notificationTriggered,
+  toggleDashboardSubmenu,
+  toggleLibrary,
+} from '../actions';
+import {
+  getActiveSubmenu,
+  getAllProjects,
+  getCurrentProject,
+  getCurrentUser,
+  getCurrentValidationState,
+  isDashboardOpen,
+  isGistExportInProgress,
+  isUserTyping,
+} from '../selectors';
+import {
+  signIn,
+  signOut,
+} from '../clients/firebaseAuth';
+
+function getValidationStateForDashboard(state) {
+  const validationState = getCurrentValidationState(state);
+  if (validationState === 'validation-error' && isUserTyping(state)) {
+    return 'validating';
+  }
+  return validationState;
+}
+
+function mapStateToProps(state) {
+  return {
+    activeSubmenu: getActiveSubmenu(state),
+    allProjects: getAllProjects(state),
+    currentProject: getCurrentProject(state),
+    currentUser: getCurrentUser(state),
+    gistExportInProgress: isGistExportInProgress(state),
+    isOpen: isDashboardOpen(state),
+    validationState: getValidationStateForDashboard(state),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onExportGist() {
+      dispatch(exportGist());
+    },
+
+    onLibraryToggled(projectKey, libraryKey) {
+      dispatch(toggleLibrary(projectKey, libraryKey));
+    },
+
+    onLogOut() {
+      signOut();
+    },
+
+    onNewProject() {
+      dispatch(createProject());
+    },
+
+    onProjectSelected(project) {
+      dispatch(changeCurrentProject(project.projectKey));
+    },
+
+    onStartLogIn() {
+      signIn().catch((e) => {
+        switch (e.code) {
+          case 'auth/popup-closed-by-user':
+            dispatch(notificationTriggered('user-cancelled-auth'));
+            break;
+          case 'auth/network-request-failed':
+            dispatch(notificationTriggered('auth-network-error'));
+            break;
+          case 'auth/cancelled-popup-request':
+            break;
+          case 'auth/web-storage-unsupported':
+            dispatch(
+              notificationTriggered('auth-third-party-cookies-disabled'),
+            );
+            break;
+          default:
+            dispatch(notificationTriggered('auth-error'));
+            if (isError(e)) {
+              Bugsnag.notifyException(e, e.code);
+            } else if (isString(e)) {
+              Bugsnag.notifyException(new Error(e));
+            }
+            break;
+        }
+      });
+    },
+
+    onSubmenuToggled(submenu) {
+      dispatch(toggleDashboardSubmenu(submenu));
+    },
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Dashboard);

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -1,7 +1,9 @@
-import Preview from './Preview';
+import Dashboard from './Dashboard';
 import ErrorReport from './ErrorReport';
+import Preview from './Preview';
 
 export {
+  Dashboard,
   ErrorReport,
   Preview,
 };

--- a/src/selectors/getActiveSubmenu.js
+++ b/src/selectors/getActiveSubmenu.js
@@ -1,0 +1,3 @@
+export default function getActiveSubmenu(state) {
+  return state.getIn(['ui', 'dashboard', 'activeSubmenu']);
+}

--- a/src/selectors/getAllProjects.js
+++ b/src/selectors/getAllProjects.js
@@ -1,0 +1,11 @@
+import {createSelector} from 'reselect';
+import sortBy from 'lodash/sortBy';
+import values from 'lodash/values';
+
+export default createSelector(
+  state => state.get('projects'),
+  projects => sortBy(
+    values(projects.toJS()),
+    project => -project.updatedAt,
+  ),
+);

--- a/src/selectors/getCurrentUser.js
+++ b/src/selectors/getCurrentUser.js
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  state => state.get('user'),
+  user => user.toJS(),
+);

--- a/src/selectors/getCurrentValidationState.js
+++ b/src/selectors/getCurrentValidationState.js
@@ -1,0 +1,23 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  state => state.get('errors'),
+  (errors) => {
+    const errorStates =
+      errors.map(errorList => errorList.get('state'));
+
+    if (errorStates.includes('validation-error')) {
+      return 'validation-error';
+    }
+
+    if (errorStates.includes('validating')) {
+      return 'validating';
+    }
+
+    if (errorStates.includes('runtime-error')) {
+      return 'runtime-error';
+    }
+
+    return 'passed';
+  },
+);

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,16 +1,28 @@
+import getActiveSubmenu from './getActiveSubmenu';
+import getAllProjects from './getAllProjects';
 import getCurrentProject from './getCurrentProject';
+import getCurrentUser from './getCurrentUser';
+import getCurrentValidationState from './getCurrentValidationState';
 import getErrors from './getErrors';
 import getLastRefreshTimestamp from './getLastRefreshTimestamp';
 import isCurrentlyValidating from './isCurrentlyValidating';
 import isCurrentProjectSyntacticallyValid
   from './isCurrentProjectSyntacticallyValid';
+import isDashboardOpen from './isDashboardOpen';
+import isGistExportInProgress from './isGistExportInProgress';
 import isUserTyping from './isUserTyping';
 
 export {
+  getActiveSubmenu,
+  getAllProjects,
   getCurrentProject,
+  getCurrentUser,
+  getCurrentValidationState,
   getErrors,
   getLastRefreshTimestamp,
   isCurrentlyValidating,
   isCurrentProjectSyntacticallyValid,
+  isDashboardOpen,
+  isGistExportInProgress,
   isUserTyping,
 };

--- a/src/selectors/isCurrentlyValidating.js
+++ b/src/selectors/isCurrentlyValidating.js
@@ -2,5 +2,5 @@ import {createSelector} from 'reselect';
 
 export default createSelector(
   state => state.get('errors'),
-  errors => errors.find(error => error.get('state') === 'validating'),
+  errors => Boolean(errors.find(error => error.get('state') === 'validating')),
 );

--- a/src/selectors/isDashboardOpen.js
+++ b/src/selectors/isDashboardOpen.js
@@ -1,0 +1,3 @@
+export default function isDashboardOpen(state) {
+  return state.getIn(['ui', 'dashboard', 'isOpen']);
+}

--- a/src/selectors/isGistExportInProgress.js
+++ b/src/selectors/isGistExportInProgress.js
@@ -1,0 +1,5 @@
+export default function isGistExportInProgress(state) {
+  return state.getIn(
+    ['clients', 'gists', 'lastExport', 'status'],
+  ) === 'waiting';
+}


### PR DESCRIPTION
Adds a `Dashboard` container, which connects the Redux store to the `<Dashboard>` component. Mostly neutral with respect to the props `<Dashboard>` takes; the only exception is the `onLibraryToggled` callback, which is now passed the `projectKey` explicitly by `<Dashboard>` because `mapDispatchToProps` doesn’t have access to `state`.