### PR TITLE
Put static/compiled back in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+static/compiled
 node_modules
 npm-debug.log
 bower_components


### PR DESCRIPTION
Even though it’s no longer used, anyone with an existing development environment will have stuff in there that git will consider untracked files. Keep things simple and just retain it in .gitignore.