### PR TITLE
Upgrade i18next to 8.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "github-api": "^3.0.0",
     "html-inspector": "^0.8.2",
     "htmllint": "^0.5.0",
-    "i18next": "^7.0.0",
+    "i18next": "^8.4.3",
     "immutable": "^3.7.5",
     "js-cookie": "^2.1.3",
     "jshint": "^2.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,9 +4000,9 @@ i18next-resource-store-loader@^0.1.1:
     loader-utils "^0.2.11"
     lodash "^4.6.1"
 
-i18next@^7.0.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-7.2.3.tgz#a6c220ac1c8240ff1078aa9bc997fd449e052dc7"
+i18next@^8.4.3:
+  version "8.4.3"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-8.4.3.tgz#36b6ff516c4f992010eedcce24a36c4609e8c7dc"
 
 iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"


### PR DESCRIPTION
[Only change in the major upgrade](https://github.com/i18next/i18next/blob/master/CHANGELOG.md#800) doesn’t affect us.