### PR TITLE
Don’t render project list if the current project hasn’t resolved yet

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -123,6 +123,10 @@ class Dashboard extends React.Component {
   }
 
   _renderProjects() {
+    if (isNull(this.props.currentProject)) {
+      return null;
+    }
+
     return (
       <ProjectList
         currentProject={this.props.currentProject}


### PR DESCRIPTION
During bootstrap, the `currentProject` may not yet be loaded. However, the `<ProjectList>` component requires `currentProject` to be set. So, don’t render the `<ProjectList>` if we don’t yet have a `currentProject`.

Fixes #920
Fixes #909
Fixes #843
Fixes #798
Fixes #758