### PR TITLE
Automatically load jQuery when Bootstrap is loaded

### DIFF
--- a/src/config/libraries.js
+++ b/src/config/libraries.js
@@ -28,6 +28,7 @@ const libraries = {
     name: 'Bootstrap',
     css: BOOTSTRAP_CSS,
     javascript: BOOTSTRAP_JS,
+    dependsOn: ['jquery'],
   },
 };
 


### PR DESCRIPTION
Bootstrap’s JavaScript depends on jQuery. Currently it’s actually impossible to get Boostrap’s JS to work because the `generatePreview` code adds scripts in the reverse order of their specification in the configuration (this is an unintentional/emergent effect of the way the code is written).

We fix by doing two things:

* Add a `dependsOn` mechanism for libraries. When the `previewGenerator` decides which libraries to put on the page, it looks at the `dependsOn` and, if present, recurses through the dependencies. Note that there is no guard against circular dependencies, but since a circular dependency scenario could only be caused by a misconfiguration in our code, I’m not too worried about it.
* Modify the logic for where library scripts are put on the page.  Specifically, we identify the first `<script>` element in the DOM that was written into the HTML (we look before we start messing with the HTML ourselves). If such a `<script>` tag is present, we add library scripts just before it. If it’s not, we add library scripts to the end of the `<head>` tag.

Note that the dependency resolution is done *at the page generation level*—this does not mean that enabling Bootstrap will automatically enable jQuery at the project level (jQuery will not automatically be selected in the UI; the linter will still prevent coders from accessing `$`). If the coder manually enables jQuery, of course, the two play nicely together.

I think there might be an argument for making the dependency relationship more explicit, but I also think there’s an argument for keeping it totally implicit, and at the very least I think this is a Pareto improvement over the current situation / worth releasing as-is while we ponder the UX of a more explicit approach.