### PR TITLE
Pass correct arguments to addRuntimeError action creator

### DIFF
--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -25,8 +25,8 @@ function mapDispatchToProps(dispatch) {
       dispatch(popOutProject(project));
     },
 
-    onRuntimeError(language, error) {
-      dispatch(addRuntimeError(language, error));
+    onRuntimeError(error) {
+      dispatch(addRuntimeError('javascript', error));
     },
 
     onRefreshClick() {


### PR DESCRIPTION
Expects `language` and `error`, but the `Preview` prop `onRuntimeError` was only being passed the error itself. Reasonable, since runtime errors in fact only happen with JavaScript. So, the container fills in the language.

Fixes #910
Fixes #934