### PR TITLE
Catch operation-not-supported-in-this-environment

### DIFF
--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -80,6 +80,7 @@ function mapDispatchToProps(dispatch) {
           case 'auth/cancelled-popup-request':
             break;
           case 'auth/web-storage-unsupported':
+          case 'auth/operation-not-supported-in-this-environment':
             dispatch(
               notificationTriggered('auth-third-party-cookies-disabled'),
             );


### PR DESCRIPTION
Another Firebase login error, seems to happen in similar situations to `web-storage-unsupported` so we just use the same error.

Fixes #796
Fixes #818
Fixes #933