### PR TITLE
Explicitly install the right version of yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
+  - export PATH="$HOME/.yarn/bin:$PATH"
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Travis has a really old version of `yarn`, which is, I’m guessing, why `yarn check` is failing on CI but not locally. So, add explicit configuration for Travis to install the same version of `yarn` that is in `package.json` etc.