### PR TITLE
Just turn off complexity rule for ui reducer until further notice

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,8 +53,7 @@
             {"before": false, "after": true}
         ],
         "complexity": [
-          2,
-          {"max": 36}
+          2
         ],
         "computed-property-spacing": [
             2,

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -35,6 +35,7 @@ function addNotification(state, type, severity, payload = {}) {
   );
 }
 
+/* eslint-disable complexity */
 export default function ui(stateIn, action) {
   let state = stateIn;
   if (state === undefined) {


### PR DESCRIPTION
Eventually I will get around to refactoring the reducers to not use enormous case statements, but for now, bumping the complexity all the time is not a good use of anyone’s time or code review.