### PR TITLE
Flex column at top level of layout

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -236,6 +236,7 @@ class Dashboard extends React.Component {
     }
 
     const sidebarClassnames = classnames(
+      'layout__dashboard',
       'dashboard',
       'u__flex-container',
       'u__flex-container_column',

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -299,9 +299,9 @@ class Workspace extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className="layout">
         <NotificationList />
-        <div className="layout">
+        <div className="layout__columns">
           <Dashboard />
           {this._renderSidebar()}
           <div className="workspace layout__main">

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -74,24 +74,31 @@ body {
 /** @define layout */
 
 .layout {
-  display: flex;
   height: 100vh;
   position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout__columns {
+  position: relative;
+  display: flex;
+  flex: 0 1 100vh;
 }
 
 .layout__sidebar {
-  flex: 0 0 auto;
+  flex: none;
   border-right: 1px solid var(--color-gray);
   display: flex;
 }
 
 .layout__main {
-  flex: 1 1 100%;
+  flex: 1 1 100vw;
   position: relative;
 }
 
 .layout__dashboard {
-  flex: 1 0 20%;
+  flex: 0 0 20%;
 }
 
 /** @define sidebar */
@@ -199,7 +206,6 @@ body {
 .dashboard {
   background-color: var(--color-green);
   color: black;
-  height: 100vh;
 }
 
 .dashboard_yellow {
@@ -361,7 +367,6 @@ body {
 .workspace {
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 /** @define environment */
@@ -371,7 +376,6 @@ body {
   flex: 1 1 auto;
   display: flex;
   flex-direction: row;
-  height: 100vh;
 }
 
 .environment__column {


### PR DESCRIPTION
Previously the top-level layout was based on a flex row, containing the dashboard, sidebar, and main editing environment. This worked pretty well because usually we didn’t have anything else that needed horizontal space. The exception was notifications, which ended up just pushing the rest of the environment down a bit, such that the bottom was outside the viewport—definitely a bug, but not the end of the world.

This fixes that bug by creating a top-level column flex and then within it a row flex. The column flex currently just contains any notifications followed by the main user interface. However, the real motivation for this is to allow us to add an always-on  top bar for the layout overhaul, which will follow in a subsequent PR.