### PR TITLE
Move current user unit to the top bar

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -3,6 +3,9 @@
     "type": "component",
     "template": "import React from 'react';\nimport PropTypes from 'prop-types';\n\nexport default function {}() {open}\n{close}\n\n{}.propTypes = {open}\n{close};"
   },
+  "src/components/*/index.jsx": {
+    "type": "component",
+  },
   "src/containers/*.js": {
     "type": "container",
     "template": "import {open}connect{close} from 'react-redux';\nimport {open}{}{close} from '../components';\nimport {open}{close} from '../actions';\n\nfunction mapStateToProps(state) {open}\n  return {open}\n  {close};\n{close}\n\nfunction mapDispatchToProps(dispatch) {open}\n  return {open}\n  {close};\n{close}\n\nexport default connect(\n  mapStateToProps,\n  mapDispatchToProps,\n)({});\n"

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,10 +1,11 @@
 {
-  "dashboard": {
+  "top-bar": {
     "session": {
-      "not-logged-in": "Not logged in",
-      "log-in-prompt": "Sign in",
-      "log-out-prompt": "Sign out"
-    },
+      "log-in-prompt": "Log in to save",
+      "log-out-prompt": "Log out"
+    }
+  },
+  "dashboard": {
     "menu": {
       "new-project": "New Project",
       "load-project": "Load Project",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -32,6 +32,7 @@ import {
   refreshPreview,
   popOutProject,
   toggleEditorTextSize,
+  toggleTopBarMenu,
 } from './ui';
 
 import {
@@ -83,4 +84,5 @@ export {
   repoExportDisplayed,
   repoExportNotDisplayed,
   toggleEditorTextSize,
+  toggleTopBarMenu,
 };

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -55,3 +55,7 @@ export const refreshPreview = createAction(
 export const toggleEditorTextSize = createAction(
   'TOGGLE_EDITOR_TEXT_SIZE',
 );
+
+export const toggleTopBarMenu = createAction(
+  'TOGGLE_TOP_BAR_MENU',
+);

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -9,43 +9,6 @@ import ProjectList from './ProjectList';
 import LibraryPicker from './LibraryPicker';
 
 class Dashboard extends React.Component {
-  _renderLoginState() {
-    const {currentUser} = this.props;
-
-    if (currentUser.authenticated) {
-      const name = currentUser.displayName;
-
-      return (
-        <div className="dashboard__session">
-          <img
-            className="dashboard__avatar"
-            src={currentUser.avatarUrl}
-          />
-          <span className="dashboard__username">{name}</span>
-          <span
-            className="dashboard__log-in-out"
-            onClick={this.props.onLogOut}
-          >
-            {t('dashboard.session.log-out-prompt')}
-          </span>
-        </div>
-      );
-    }
-    return (
-      <div className="dashboard__session">
-        <span className="dashboard__username">
-          {t('dashboard.session.not-logged-in')}
-        </span>
-        <span
-          className="dashboard__log-in-out"
-          onClick={this.props.onStartLogIn}
-        >
-          {t('dashboard.session.log-in-prompt')}
-        </span>
-      </div>
-    );
-  }
-
   _renderSubmenuToggleButton(submenu, label) {
     return (
       <div
@@ -216,7 +179,6 @@ class Dashboard extends React.Component {
 
     return (
       <div className={sidebarClassnames}>
-        {this._renderLoginState()}
         {this._renderMenu()}
         {this._renderSubmenu()}
         <div className="dashboard__spacer" />
@@ -239,10 +201,8 @@ Dashboard.propTypes = {
   onExportGist: PropTypes.func.isRequired,
   onExportRepo: PropTypes.func.isRequired,
   onLibraryToggled: PropTypes.func.isRequired,
-  onLogOut: PropTypes.func.isRequired,
   onNewProject: PropTypes.func.isRequired,
   onProjectSelected: PropTypes.func.isRequired,
-  onStartLogIn: PropTypes.func.isRequired,
   onSubmenuToggled: PropTypes.func.isRequired,
 };
 

--- a/src/components/TopBar/CurrentUser.jsx
+++ b/src/components/TopBar/CurrentUser.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {t} from 'i18next';
+
+export default function CurrentUser({user, onLogOut, onStartLogIn}) {
+  if (user.authenticated) {
+    const name = user.displayName;
+
+    return (
+      <div className="top-bar__current-user">
+        <img
+          className="top-bar__avatar"
+          src={user.avatarUrl}
+        />
+        <span className="top-bar__username">{name}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="top-bar__current-user">
+      <span
+        className="top-bar__log-in-prompt"
+        onClick={onStartLogIn}
+      >
+        {t('top-bar.session.log-in-prompt')}
+      </span>
+    </div>
+  );
+}
+
+CurrentUser.propTypes = {
+  user: PropTypes.shape({
+    authenticated: PropTypes.boolean,
+  }).isRequired,
+  onLogOut: PropTypes.func.isRequired,
+  onStartLogIn: PropTypes.func.isRequired,
+};

--- a/src/components/TopBar/CurrentUser.jsx
+++ b/src/components/TopBar/CurrentUser.jsx
@@ -1,18 +1,37 @@
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
+import CurrentUserMenu from './CurrentUserMenu';
 
-export default function CurrentUser({user, onLogOut, onStartLogIn}) {
+export default function CurrentUser({
+  isOpen,
+  user,
+  onClick,
+  onLogOut,
+  onStartLogIn,
+}) {
   if (user.authenticated) {
     const name = user.displayName;
 
     return (
-      <div className="top-bar__current-user">
+      <div
+        className={classnames(
+          'top-bar__menu-button',
+          'top-bar__current-user',
+          {'top-bar__menu-button_active': isOpen},
+        )}
+        onClick={onClick}
+      >
         <img
           className="top-bar__avatar"
           src={user.avatarUrl}
         />
         <span className="top-bar__username">{name}</span>
+        <span className="top-bar__drop-down-button u__fontawesome">
+          &#xf0d7;
+        </span>
+        <CurrentUserMenu isOpen={isOpen} onLogOut={onLogOut} />
       </div>
     );
   }
@@ -29,9 +48,11 @@ export default function CurrentUser({user, onLogOut, onStartLogIn}) {
 }
 
 CurrentUser.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
   user: PropTypes.shape({
     authenticated: PropTypes.boolean,
   }).isRequired,
+  onClick: PropTypes.func.isRequired,
   onLogOut: PropTypes.func.isRequired,
   onStartLogIn: PropTypes.func.isRequired,
 };

--- a/src/components/TopBar/CurrentUserMenu.jsx
+++ b/src/components/TopBar/CurrentUserMenu.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {t} from 'i18next';
+
+export default function CurrentUserMenu({isOpen, onLogOut}) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="top-bar__menu">
+      <div className="top-bar__menu-item" onClick={onLogOut}>
+        {t('top-bar.session.log-out-prompt')}
+      </div>
+    </div>
+  );
+}
+
+CurrentUserMenu.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onLogOut: PropTypes.func.isRequired,
+};

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import partial from 'lodash/partial';
 import Wordmark from '../../static/images/wordmark.svg';
 import Pop from '../Pop';
 import CurrentUser from './CurrentUser';
@@ -22,8 +23,10 @@ export default function TopBar({
   currentUser,
   isHamburgerMenuActive,
   isUserTyping,
+  openMenu,
   validationState,
   onClickHamburgerMenu,
+  onClickMenu,
   onLogOut,
   onStartLogIn,
 }) {
@@ -49,7 +52,9 @@ export default function TopBar({
       </div>
       <div className="top-bar__spacer" />
       <CurrentUser
+        isOpen={openMenu === 'currentUser'}
         user={currentUser}
+        onClick={partial(onClickMenu, 'currentUser')}
         onLogOut={onLogOut}
         onStartLogIn={onStartLogIn}
       />
@@ -61,8 +66,14 @@ TopBar.propTypes = {
   currentUser: PropTypes.object.isRequired,
   isHamburgerMenuActive: PropTypes.bool.isRequired,
   isUserTyping: PropTypes.bool.isRequired,
+  openMenu: PropTypes.string,
   validationState: PropTypes.string.isRequired,
   onClickHamburgerMenu: PropTypes.func.isRequired,
+  onClickMenu: PropTypes.func.isRequired,
   onLogOut: PropTypes.func.isRequired,
   onStartLogIn: PropTypes.func.isRequired,
+};
+
+TopBar.defaultProps = {
+  openMenu: null,
 };

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Wordmark from '../static/images/wordmark.svg';
-import Pop from './Pop';
+import Wordmark from '../../static/images/wordmark.svg';
+import Pop from '../Pop';
+import CurrentUser from './CurrentUser';
 
 function uiVariants({validationState, isUserTyping}) {
   if (validationState === 'passed') {
@@ -18,10 +19,13 @@ function uiVariants({validationState, isUserTyping}) {
 }
 
 export default function TopBar({
+  currentUser,
   isHamburgerMenuActive,
   isUserTyping,
   validationState,
   onClickHamburgerMenu,
+  onLogOut,
+  onStartLogIn,
 }) {
   const {popVariant, modifier} = uiVariants({validationState, isUserTyping});
 
@@ -43,13 +47,22 @@ export default function TopBar({
       <div className="top-bar__wordmark-container">
         <Wordmark />
       </div>
+      <div className="top-bar__spacer" />
+      <CurrentUser
+        user={currentUser}
+        onLogOut={onLogOut}
+        onStartLogIn={onStartLogIn}
+      />
     </div>
   );
 }
 
 TopBar.propTypes = {
+  currentUser: PropTypes.object.isRequired,
   isHamburgerMenuActive: PropTypes.bool.isRequired,
   isUserTyping: PropTypes.bool.isRequired,
   validationState: PropTypes.string.isRequired,
   onClickHamburgerMenu: PropTypes.func.isRequired,
+  onLogOut: PropTypes.func.isRequired,
+  onStartLogIn: PropTypes.func.isRequired,
 };

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -1,7 +1,4 @@
 import {connect} from 'react-redux';
-import isError from 'lodash/isError';
-import isString from 'lodash/isString';
-import Bugsnag from '../util/Bugsnag';
 import {Dashboard} from '../components';
 import {
   changeCurrentProject,
@@ -9,7 +6,6 @@ import {
   createSnapshot,
   exportGist,
   exportRepo,
-  notificationTriggered,
   toggleDashboardSubmenu,
   toggleLibrary,
 } from '../actions';
@@ -23,10 +19,6 @@ import {
   isGistExportInProgress,
   isSnapshotInProgress,
 } from '../selectors';
-import {
-  signIn,
-  signOut,
-} from '../clients/firebase';
 
 function mapStateToProps(state) {
   return {
@@ -59,45 +51,12 @@ function mapDispatchToProps(dispatch) {
       dispatch(toggleLibrary(projectKey, libraryKey));
     },
 
-    onLogOut() {
-      signOut();
-    },
-
     onNewProject() {
       dispatch(createProject());
     },
 
     onProjectSelected(project) {
       dispatch(changeCurrentProject(project.projectKey));
-    },
-
-    onStartLogIn() {
-      signIn().catch((e) => {
-        switch (e.code) {
-          case 'auth/popup-closed-by-user':
-            dispatch(notificationTriggered('user-cancelled-auth'));
-            break;
-          case 'auth/network-request-failed':
-            dispatch(notificationTriggered('auth-network-error'));
-            break;
-          case 'auth/cancelled-popup-request':
-            break;
-          case 'auth/web-storage-unsupported':
-          case 'auth/operation-not-supported-in-this-environment':
-            dispatch(
-              notificationTriggered('auth-third-party-cookies-disabled'),
-            );
-            break;
-          default:
-            dispatch(notificationTriggered('auth-error'));
-            if (isError(e)) {
-              Bugsnag.notifyException(e, e.code);
-            } else if (isString(e)) {
-              Bugsnag.notifyException(new Error(e));
-            }
-            break;
-        }
-      });
     },
 
     onSubmenuToggled(submenu) {

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -1,17 +1,26 @@
-import {bindActionCreators} from 'redux';
+import isError from 'lodash/isError';
+import isString from 'lodash/isString';
 import {connect} from 'react-redux';
+import Bugsnag from '../util/Bugsnag';
 import {TopBar} from '../components';
 import {
+  getCurrentUser,
   getCurrentValidationState,
   isDashboardOpen,
   isUserTyping,
 } from '../selectors';
 import {
+  notificationTriggered,
   toggleDashboard,
 } from '../actions';
+import {
+  signIn,
+  signOut,
+} from '../clients/firebase';
 
 function mapStateToProps(state) {
   return {
+    currentUser: getCurrentUser(state),
     isHamburgerMenuActive: isDashboardOpen(state),
     isUserTyping: isUserTyping(state),
     validationState: getCurrentValidationState(state),
@@ -19,9 +28,44 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    onClickHamburgerMenu: toggleDashboard,
-  }, dispatch);
+  return {
+    onClickHamburgerMenu() {
+      dispatch(toggleDashboard);
+    },
+
+    onLogOut() {
+      signOut();
+    },
+
+    onStartLogIn() {
+      signIn().catch((e) => {
+        switch (e.code) {
+          case 'auth/popup-closed-by-user':
+            dispatch(notificationTriggered('user-cancelled-auth'));
+            break;
+          case 'auth/network-request-failed':
+            dispatch(notificationTriggered('auth-network-error'));
+            break;
+          case 'auth/cancelled-popup-request':
+            break;
+          case 'auth/web-storage-unsupported':
+          case 'auth/operation-not-supported-in-this-environment':
+            dispatch(
+              notificationTriggered('auth-third-party-cookies-disabled'),
+            );
+            break;
+          default:
+            dispatch(notificationTriggered('auth-error'));
+            if (isError(e)) {
+              Bugsnag.notifyException(e, e.code);
+            } else if (isString(e)) {
+              Bugsnag.notifyException(new Error(e));
+            }
+            break;
+        }
+      });
+    },
+  };
 }
 
 export default connect(

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -6,10 +6,12 @@ import {TopBar} from '../components';
 import {
   getCurrentUser,
   getCurrentValidationState,
+  getOpenTopBarMenu,
   isDashboardOpen,
   isUserTyping,
 } from '../selectors';
 import {
+  toggleTopBarMenu,
   notificationTriggered,
   toggleDashboard,
 } from '../actions';
@@ -23,6 +25,7 @@ function mapStateToProps(state) {
     currentUser: getCurrentUser(state),
     isHamburgerMenuActive: isDashboardOpen(state),
     isUserTyping: isUserTyping(state),
+    openMenu: getOpenTopBarMenu(state),
     validationState: getCurrentValidationState(state),
   };
 }
@@ -31,6 +34,10 @@ function mapDispatchToProps(dispatch) {
   return {
     onClickHamburgerMenu() {
       dispatch(toggleDashboard);
+    },
+
+    onClickMenu(menuKey) {
+      dispatch(toggleTopBarMenu(menuKey));
     },
 
     onLogOut() {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -107,11 +107,11 @@ body {
 .top-bar {
   background-color: var(--color-green);
   display: flex;
-  padding-left: 1em;
   font-size: 18px;
   font-weight: bold;
   align-items: center;
   padding: 0 1em;
+  z-index: 2;
 }
 
 .top-bar_yellow {
@@ -158,6 +158,52 @@ body {
 
 .top-bar__username {
   margin-left: 0.5em;
+}
+
+.top-bar__menu-button {
+  align-self: stretch;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 0 1px;
+  box-sizing: border-box;
+  cursor: pointer;
+  line-height: 3em;
+  padding: 0 0.5em;
+  position: relative;
+  user-select: none;
+  vertical-align: middle;
+}
+
+.top-bar__menu-button_active {
+  background-color: white;
+  border-color: var(--color-gray);
+}
+
+.top-bar__menu {
+  border: 1px solid var(--color-gray);
+  box-shadow: 2px 2px 2px var(--color-gray);
+  left: -1px;
+  position: absolute;
+  top: 100%;
+  width: 100%;
+}
+
+.top-bar__menu-item {
+  background-color: white;
+  box-sizing: border-box;
+  color: var(--color-very-dark-gray);
+  font-weight: normal;
+  padding: 0 0.5em;
+  width: 100%;
+}
+
+.top-bar__menu-item:hover {
+  background-color: var(--color-gray);
+  color: black;
+}
+
+.top-bar__drop-down-button {
+  padding: 0 0.5em;
 }
 
 .top-bar__spacer {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -108,7 +108,10 @@ body {
   background-color: var(--color-green);
   display: flex;
   padding-left: 1em;
-  font-size: 16px;
+  font-size: 18px;
+  font-weight: bold;
+  align-items: center;
+  padding: 0 1em;
 }
 
 .top-bar_yellow {
@@ -121,7 +124,7 @@ body {
 
 .top-bar__hamburger {
   font-size: 2em;
-  padding: 0.25em 0.5em 0.25em 0;
+  padding-right: 0.5em;
   user-select: none;
   cursor: pointer;
 }
@@ -130,7 +133,7 @@ body {
   color: var(--color-dark-gray);
 }
 
-.top-bar__logo-container svg {
+.top-bar__logo-container > svg {
   height: 3em;
 }
 
@@ -139,11 +142,31 @@ body {
   margin-left: -0.25em;
 }
 
-.top-bar__wordmark-container svg {
-  padding: 1em;
+.top-bar__wordmark-container > svg {
+  padding: 0 1em;
   max-height: 1em;
   max-width: 100%;
   width: auto;
+}
+
+.top-bar__avatar {
+  height: 2em;
+  border-radius: 50%;
+  vertical-align: middle;
+  line-height: 1em;
+}
+
+.top-bar__username {
+  margin-left: 0.5em;
+}
+
+.top-bar__spacer {
+  flex: 1 0 0;
+}
+
+.top-bar__log-in-prompt {
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 /** @define sidebar */
@@ -240,33 +263,6 @@ body {
   background-color: var(--color-gray);
   color: black;
   padding: 0 1rem;
-}
-
-.dashboard__session {
-  flex: 0 0 auto;
-  font-size: 0.8rem;
-  white-space: nowrap;
-  padding: 1em;
-  margin: 0 auto;
-  overflow: hidden;
-}
-
-.dashboard__avatar {
-  max-width: 32px;
-  max-height: 32px;
-  border-radius: 50%;
-  vertical-align: middle;
-}
-
-.dashboard__username {
-  font-weight: bold;
-  padding-left: 0.5rem;
-}
-
-.dashboard__log-in-out {
-  padding-left: 1rem;
-  text-decoration: underline;
-  cursor: pointer;
 }
 
 .dashboard__menu {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -27,6 +27,7 @@ const defaultState = new Immutable.Map().
       set('isOpen', false).
       set('activeSubmenu', null),
   ).
+  set('topBar', new Immutable.Map({openMenu: null})).
   set('lastRefreshTimestamp', null);
 
 function addNotification(state, type, severity, payload = {}) {
@@ -142,13 +143,13 @@ export default function ui(stateIn, action) {
       );
 
     case 'USER_LOGGED_OUT':
-      if (state.getIn(['dashboard', 'activeSubmenu']) === 'projectList') {
-        return state.setIn(
-          ['dashboard', 'activeSubmenu'],
-          null,
-        );
-      }
-      return state;
+      return state.updateIn(
+        ['topBar', 'openMenu'],
+        menu => menu === 'currentUser' ? null : menu,
+      ).updateIn(
+        ['dashboard', 'activeSubmenu'],
+        submenu => submenu === 'projectList' ? null : submenu,
+      );
 
     case 'SNAPSHOT_CREATED':
       return addNotification(
@@ -204,6 +205,12 @@ export default function ui(stateIn, action) {
     case 'TOGGLE_EDITOR_TEXT_SIZE':
       return state.updateIn(['editors', 'textSizeIsLarge'],
         textSizeIsLarge => !textSizeIsLarge,
+      );
+
+    case 'TOGGLE_TOP_BAR_MENU':
+      return state.updateIn(
+        ['topBar', 'openMenu'],
+        menu => menu === action.payload ? null : action.payload,
       );
 
     default:

--- a/src/selectors/getOpenTopBarMenu.js
+++ b/src/selectors/getOpenTopBarMenu.js
@@ -1,0 +1,3 @@
+export default function getOpenTopBarMenu(state) {
+  return state.getIn(['ui', 'topBar', 'openMenu']);
+}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -7,6 +7,7 @@ import getCurrentValidationState from './getCurrentValidationState';
 import getErrors from './getErrors';
 import getLastRefreshTimestamp from './getLastRefreshTimestamp';
 import getNotifications from './getNotifications';
+import getOpenTopBarMenu from './getOpenTopBarMenu';
 import isCurrentlyValidating from './isCurrentlyValidating';
 import isCurrentProjectSyntacticallyValid
   from './isCurrentProjectSyntacticallyValid';
@@ -26,6 +27,7 @@ export {
   getErrors,
   getLastRefreshTimestamp,
   getNotifications,
+  getOpenTopBarMenu,
   isCurrentlyValidating,
   isCurrentProjectSyntacticallyValid,
   isDashboardOpen,

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -18,6 +18,7 @@ import {
   notificationTriggered,
   userDismissedNotification,
   refreshPreview,
+  toggleTopBarMenu,
 } from '../../../src/actions/ui';
 import {
   snapshotCreated,
@@ -30,7 +31,9 @@ import {
   repoExportError,
 } from '../../../src/actions/clients';
 import {EmptyGistError} from '../../../src/clients/github';
-import {userLoggedOut} from '../../../src/actions/user';
+import {
+  userLoggedOut,
+} from '../../../src/actions/user';
 import {applicationLoaded} from '../../../src/actions/';
 
 const initialState = Immutable.fromJS({
@@ -45,6 +48,7 @@ const initialState = Immutable.fromJS({
     activeSubmenu: null,
   },
   lastRefreshTimestamp: null,
+  topBar: {openMenu: null},
 });
 
 function withNotification(type, severity, payload = {}) {
@@ -172,6 +176,27 @@ test('userLoggedOut', (t) => {
     ),
     userLoggedOut,
     initialState,
+  ));
+
+  t.test('with no top bar menu open', reducerTest(
+    reducer,
+    initialState,
+    userLoggedOut,
+    initialState,
+  ));
+
+  t.test('with currentUser menu open', reducerTest(
+    reducer,
+    initialState.setIn(['topBar', 'openMenu'], 'currentUser'),
+    userLoggedOut,
+    initialState,
+  ));
+
+  t.test('with different menu open', reducerTest(
+    reducer,
+    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    userLoggedOut,
+    initialState.setIn(['topBar', 'openMenu'], 'silly'),
   ));
 });
 
@@ -313,3 +338,26 @@ tap('123-456', snapshotKey =>
     withNotification('snapshot-created', 'notice', {snapshotKey}),
   )),
 );
+
+test('toggleTopBarMenu', (t) => {
+  t.test('with no menu open', reducerTest(
+    reducer,
+    initialState,
+    partial(toggleTopBarMenu, 'silly'),
+    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+  ));
+
+  t.test('with specified menu open', reducerTest(
+    reducer,
+    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    partial(toggleTopBarMenu, 'silly'),
+    initialState,
+  ));
+
+  t.test('with different menu open', reducerTest(
+    reducer,
+    initialState.setIn(['topBar', 'openMenu'], 'goofy'),
+    partial(toggleTopBarMenu, 'silly'),
+    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+  ));
+});


### PR DESCRIPTION
If coder is not logged in, display a prompt “Log in to save”

![localhost-3001- laptop with hidpi screen](https://user-images.githubusercontent.com/14214/29101978-e7968a4a-7c83-11e7-86f6-acdfc2ab903d.png)

If coder is logged in, display avatar and display name, along with a down arrow indicating the user badge is clickable.

![localhost-3001- laptop with hidpi screen 1](https://user-images.githubusercontent.com/14214/29101984-f2fdb5fc-7c83-11e7-96c7-2e7b0f9c483d.png)

When the user badge is clicked, expose a “Log Out” prompt

![localhost-3001- laptop with hidpi screen 2](https://user-images.githubusercontent.com/14214/29101991-fe2ac5fa-7c83-11e7-9042-9e4d8ac71902.png)

Another step toward #779 