### PR TITLE
Use username as display name if there is no display name

### DIFF
--- a/config/firebase-auth.json
+++ b/config/firebase-auth.json
@@ -17,6 +17,12 @@
         ".read": "$user_id === auth.uid",
         ".write": "$user_id === auth.uid"
       }
+    },
+    "providerInfo": {
+      "$user_id": {
+        ".read": "$user_id === auth.uid",
+        ".write": "$user_id === auth.uid"
+      }
     }
   }
 }

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -8,14 +8,17 @@ function user(stateIn, action) {
 
   switch (action.type) {
     case 'USER_AUTHENTICATED': {
-      const {user: userData, credential} = action.payload;
+      const {user: userData, credential, additionalUserInfo} = action.payload;
 
       const profileData = get(userData, ['providerData', 0], userData);
 
       return state.merge({
         authenticated: true,
         id: userData.uid,
-        displayName: profileData.displayName,
+        displayName: profileData.displayName || get(
+          additionalUserInfo,
+          'username',
+        ),
         avatarUrl: profileData.photoURL,
         accessTokens: new Immutable.Map().set(
           credential.providerId,

--- a/test/helpers/factory.js
+++ b/test/helpers/factory.js
@@ -29,15 +29,20 @@ export function gistData({
   return {files};
 }
 
-export function userCredential({user: userIn, credential: credentialIn} = {}) {
+export function userCredential({
+  user: userIn,
+  credential: credentialIn,
+  additionalUserInfo: additionalUserInfoIn,
+} = {}) {
   return {
     user: user(userIn),
     credential: credential(credentialIn),
+    additionalUserInfo: additionalUserInfo(additionalUserInfoIn),
   };
 }
 
 export function user(userIn) {
-  return merge({
+  return defaultsDeep({}, userIn, {
     displayName: null,
     photoURL: null,
     providerData: [
@@ -50,7 +55,7 @@ export function user(userIn) {
       },
     ],
     uid: 'abc123',
-  }, userIn);
+  });
 }
 
 export function project(projectIn) {
@@ -72,4 +77,12 @@ export function credential(credentialIn) {
     accessToken: '0123456789abcdef',
     providerId: 'github.com',
   }, credentialIn);
+}
+
+export function additionalUserInfo(additionalUserInfoIn) {
+  return defaultsDeep({}, additionalUserInfoIn, {
+    profile: {},
+    providerId: 'github.com',
+    username: 'popcoder',
+  });
 }

--- a/test/unit/reducers/user.js
+++ b/test/unit/reducers/user.js
@@ -19,12 +19,24 @@ const loggedInState = Immutable.fromJS({
   },
 });
 
-test('userAuthenticated', reducerTest(
-  reducer,
-  states.initial,
-  partial(userAuthenticated, userCredentialIn),
-  loggedInState,
-));
+test('userAuthenticated', (t) => {
+  t.test('with displayName', reducerTest(
+    reducer,
+    states.initial,
+    partial(userAuthenticated, userCredentialIn),
+    loggedInState,
+  ));
+
+  t.test('with no displayName', reducerTest(
+    reducer,
+    states.initial,
+    partial(
+      userAuthenticated,
+      userCredential({user: {providerData: [{displayName: null}]}}),
+    ),
+    loggedInState.set('displayName', 'popcoder'),
+  ));
+});
 
 test('userLoggedOut', reducerTest(
   reducer,


### PR DESCRIPTION
If the user has not added a real name to their GitHub profile, we now fall back to using their GitHub username.

![localhost-3001- laptop with hidpi screen 3](https://user-images.githubusercontent.com/14214/29236205-6de77bec-7ed5-11e7-8bb4-f37d1721dac0.png)

The Firebase `UserCredential` object can optionally contain an `additionalUserInfo` key that contains the raw profile data from the provider. This is useful e.g. in the case of GitHub (the only case!) for retrieving the user’s username (which, frustratingly, is not available via the normalized Firebase user profile).

However, when re-authenticating (e.g. loading Popcode while already logged in), that data is not made available to the auth event handler, and as far as I can tell there is no way to ask for it. So, whenever the user logs in explicitly, we grab the `additionalUserInfo` and store it in the Firebase database; then we retrieve it on re-authentication and add it to the synthetic `UserCredential` object that is exposed to reauthentication listeners. This is exactly the same thing we do for the `credential` part of the `UserCredential` already.

With the `additionalUserInfo` object thus ensured available, we can pull the username from it if need be.

Fixes #969 