### PR TITLE
Use TextEncoder polyfill in a place where we were missing it

### DIFF
--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 import uniq from 'lodash/uniq';
 import base64 from 'base64-js';
+import {TextEncoder} from 'text-encoding';
 import loopBreaker from 'loop-breaker';
 import libraries from '../config/libraries';
 import previewFrameLibraries from '../config/previewFrameLibraries';


### PR DESCRIPTION
We were missing the TextEncoder polyfill in the `generatePreview` module; this is fine on modern browsers but breaks on older supported versions of Chrome and Safari (it also breaks IE and Edge early enough that the unsupported browser message doesn’t show up).

Fixes #964
Fixes #960
Fixes #953
Fixes #947
Fixes #940
Fixes #912
Fixes #908
Fixes #906
Fixes #888
Fixes #872
Fixes #865