### PR TITLE
Move text size toggle to the top bar

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -3,9 +3,6 @@
     "type": "component",
     "template": "import React from 'react';\nimport PropTypes from 'prop-types';\n\nexport default function {}() {open}\n{close}\n\n{}.propTypes = {open}\n{close};"
   },
-  "src/components/*/index.jsx": {
-    "type": "component",
-  },
   "src/containers/*.js": {
     "type": "container",
     "template": "import {open}connect{close} from 'react-redux';\nimport {open}{}{close} from '../components';\nimport {open}{close} from '../actions';\n\nfunction mapStateToProps(state) {open}\n  return {open}\n  {close};\n{close}\n\nfunction mapDispatchToProps(dispatch) {open}\n  return {open}\n  {close};\n{close}\n\nexport default connect(\n  mapStateToProps,\n  mapDispatchToProps,\n)({});\n"

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -144,19 +144,19 @@ class Dashboard extends React.Component {
     return (
       <div className="dashboard__links">
         <a
-          className="dashboard__link u__fontawesome"
+          className="dashboard__link u__icon"
           href="https://github.com/popcodeorg/popcode"
           rel="noopener noreferrer"
           target="_blank"
         >&#xf09b;</a>
         <a
-          className="dashboard__link u__fontawesome"
+          className="dashboard__link u__icon"
           href="https://twitter.com/popcodeorg"
           rel="noopener noreferrer"
           target="_blank"
         >&#xf099;</a>
         <a
-          className="dashboard__link u__fontawesome"
+          className="dashboard__link u__icon"
           href="https://slack.popcode.org/"
           rel="noopener noreferrer"
           target="_blank"

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -46,16 +46,6 @@ class Sidebar extends React.Component {
           )}
           onClick={this.props.onToggleDashboard}
         />
-        <div
-          className="sidebar__plusMinus"
-          onClick={this.props.onToggleEditorTextSize}
-        >
-          {
-            this.props.textSizeIsLarge ?
-              <span className="u__icon">&#xf010;</span> :
-              <span className="u__icon">&#xf00e;</span>
-          }
-        </div>
         {this._renderHiddenComponents()}
       </div>
     );
@@ -65,11 +55,9 @@ class Sidebar extends React.Component {
 Sidebar.propTypes = {
   dashboardIsOpen: PropTypes.bool.isRequired,
   hiddenComponents: PropTypes.array.isRequired,
-  textSizeIsLarge: PropTypes.bool.isRequired,
   validationState: PropTypes.string.isRequired,
   onComponentUnhide: PropTypes.func.isRequired,
   onToggleDashboard: PropTypes.func.isRequired,
-  onToggleEditorTextSize: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/src/components/TopBar/CurrentUser.jsx
+++ b/src/components/TopBar/CurrentUser.jsx
@@ -28,7 +28,7 @@ export default function CurrentUser({
           src={user.avatarUrl}
         />
         <span className="top-bar__username">{name}</span>
-        <span className="top-bar__drop-down-button u__fontawesome">
+        <span className="top-bar__drop-down-button u__icon">
           &#xf0d7;
         </span>
         <CurrentUserMenu isOpen={isOpen} onLogOut={onLogOut} />

--- a/src/components/TopBar/TextSize.jsx
+++ b/src/components/TopBar/TextSize.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function TextSize({isLarge, onToggle}) {
+  return (
+    <div
+      className="top-bar__menu-button top-bar__text-size"
+      onClick={onToggle}
+    >
+      {
+        isLarge ?
+          <span className="u__icon">&#xf010;</span> :
+          <span className="u__icon">&#xf00e;</span>
+      }
+    </div>
+  );
+}
+
+TextSize.propTypes = {
+  isLarge: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+};

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -37,7 +37,7 @@ export default function TopBar({
       <div
         className={classnames(
           'top-bar__hamburger',
-          'u__fontawesome',
+          'u__icon',
           {'top-bar__hamburger_active': isHamburgerMenuActive},
         )}
         onClick={onClickHamburgerMenu}

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -5,6 +5,7 @@ import partial from 'lodash/partial';
 import Wordmark from '../../static/images/wordmark.svg';
 import Pop from '../Pop';
 import CurrentUser from './CurrentUser';
+import TextSize from './TextSize';
 
 function uiVariants({validationState, isUserTyping}) {
   if (validationState === 'passed') {
@@ -24,11 +25,13 @@ export default function TopBar({
   isHamburgerMenuActive,
   isUserTyping,
   openMenu,
+  isTextSizeLarge,
   validationState,
   onClickHamburgerMenu,
   onClickMenu,
   onLogOut,
   onStartLogIn,
+  onToggleTextSize,
 }) {
   const {popVariant, modifier} = uiVariants({validationState, isUserTyping});
 
@@ -51,6 +54,7 @@ export default function TopBar({
         <Wordmark />
       </div>
       <div className="top-bar__spacer" />
+      <TextSize isLarge={isTextSizeLarge} onToggle={onToggleTextSize} />
       <CurrentUser
         isOpen={openMenu === 'currentUser'}
         user={currentUser}
@@ -65,6 +69,7 @@ export default function TopBar({
 TopBar.propTypes = {
   currentUser: PropTypes.object.isRequired,
   isHamburgerMenuActive: PropTypes.bool.isRequired,
+  isTextSizeLarge: PropTypes.bool.isRequired,
   isUserTyping: PropTypes.bool.isRequired,
   openMenu: PropTypes.string,
   validationState: PropTypes.string.isRequired,
@@ -72,6 +77,7 @@ TopBar.propTypes = {
   onClickMenu: PropTypes.func.isRequired,
   onLogOut: PropTypes.func.isRequired,
   onStartLogIn: PropTypes.func.isRequired,
+  onToggleTextSize: PropTypes.func.isRequired,
 };
 
 TopBar.defaultProps = {

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -31,7 +31,6 @@ import {
   startDragColumnDivider,
   stopDragColumnDivider,
   applicationLoaded,
-  toggleEditorTextSize,
 
 } from '../actions';
 
@@ -77,7 +76,6 @@ class Workspace extends React.Component {
       '_handleRequestedLineFocused',
       '_storeDividerRef',
       '_storeColumnRef',
-      '_handleEditorTextSizeToggled',
     );
     this.columnRefs = [null, null];
   }
@@ -215,10 +213,6 @@ class Workspace extends React.Component {
     this.props.dispatch(editorFocusedRequestedLine());
   }
 
-  _handleEditorTextSizeToggled() {
-    this.props.dispatch(toggleEditorTextSize());
-  }
-
   _renderSidebar() {
     let hiddenComponents = [];
     if (!isNull(this.props.currentProject)) {
@@ -229,11 +223,9 @@ class Workspace extends React.Component {
         <Sidebar
           dashboardIsOpen={this.props.ui.dashboard.isOpen}
           hiddenComponents={hiddenComponents}
-          textSizeIsLarge={this.props.ui.editors.textSizeIsLarge}
           validationState={this._getOverallValidationState()}
           onComponentUnhide={this._handleComponentUnhide}
           onToggleDashboard={this._handleToggleDashboard}
-          onToggleEditorTextSize={this._handleEditorTextSizeToggled}
         />
       </div>
     );

--- a/src/components/notifications/SnapshotNotification.jsx
+++ b/src/components/notifications/SnapshotNotification.jsx
@@ -17,7 +17,7 @@ export default function SnapshotNotification({
   if (isCopied) {
     checkmark = [
       ' ',
-      <span className="u__fontawesome" key="icon">&#xf058;</span>,
+      <span className="u__icon" key="icon">&#xf058;</span>,
     ];
   }
 

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -8,12 +8,14 @@ import {
   getCurrentValidationState,
   getOpenTopBarMenu,
   isDashboardOpen,
+  isTextSizeLarge,
   isUserTyping,
 } from '../selectors';
 import {
   toggleTopBarMenu,
   notificationTriggered,
   toggleDashboard,
+  toggleEditorTextSize,
 } from '../actions';
 import {
   signIn,
@@ -24,6 +26,7 @@ function mapStateToProps(state) {
   return {
     currentUser: getCurrentUser(state),
     isHamburgerMenuActive: isDashboardOpen(state),
+    isTextSizeLarge: isTextSizeLarge(state),
     isUserTyping: isUserTyping(state),
     openMenu: getOpenTopBarMenu(state),
     validationState: getCurrentValidationState(state),
@@ -71,6 +74,10 @@ function mapDispatchToProps(dispatch) {
             break;
         }
       });
+    },
+
+    onToggleTextSize() {
+      dispatch(toggleEditorTextSize());
     },
   };
 }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -740,8 +740,5 @@ body {
   font-family: 'FontAwesome';
   cursor: pointer;
   user-select: none;
-}
-
-.u__fontawesome {
-  font-family: 'FontAwesome';
+  font-weight: normal;
 }

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -15,6 +15,7 @@ import isDashboardOpen from './isDashboardOpen';
 import isExperimental from './isExperimental';
 import isGistExportInProgress from './isGistExportInProgress';
 import isSnapshotInProgress from './isSnapshotInProgress';
+import isTextSizeLarge from './isTextSizeLarge';
 import isUserTyping from './isUserTyping';
 
 export {
@@ -34,5 +35,6 @@ export {
   isExperimental,
   isGistExportInProgress,
   isSnapshotInProgress,
+  isTextSizeLarge,
   isUserTyping,
 };

--- a/src/selectors/isTextSizeLarge.js
+++ b/src/selectors/isTextSizeLarge.js
@@ -1,0 +1,3 @@
+export default function(state) {
+  return state.getIn(['ui', 'editors', 'textSizeIsLarge']);
+}


### PR DESCRIPTION
Next step in the move everything to the top bar project—moves the text size toggle.

![localhost-3001- laptop with hidpi screen 4](https://user-images.githubusercontent.com/14214/29241259-0e856b54-7f44-11e7-99ed-493270b522ea.png)

Also consolidates the `u__fontawesome` element into the better `u__icon`, and removes a pesky projection.

Another step in #779 