### PR TITLE
Move snapshot button to top bar

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -64,21 +64,6 @@ class Dashboard extends React.Component {
               'dashboard__menu-item_grid',
               {
                 'dashboard__menu-item_spinner':
-                  this.props.snapshotInProgress,
-              },
-            )
-          }
-          onClick={this.props.onCreateSnapshot}
-        >
-          {t('dashboard.menu.create-snapshot')}
-        </div>
-        <div
-          className={
-            classnames(
-              'dashboard__menu-item',
-              'dashboard__menu-item_grid',
-              {
-                'dashboard__menu-item_spinner':
                   this.props.gistExportInProgress,
               },
             )
@@ -196,8 +181,6 @@ Dashboard.propTypes = {
   gistExportInProgress: PropTypes.bool.isRequired,
   isExperimental: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  snapshotInProgress: PropTypes.bool.isRequired,
-  onCreateSnapshot: PropTypes.func.isRequired,
   onExportGist: PropTypes.func.isRequired,
   onExportRepo: PropTypes.func.isRequired,
   onLibraryToggled: PropTypes.func.isRequired,

--- a/src/components/TopBar/SnapshotButton.jsx
+++ b/src/components/TopBar/SnapshotButton.jsx
@@ -1,0 +1,23 @@
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function SnapshotButton({isInProgress, onClick}) {
+  return (
+    <div
+      className={classnames(
+        'top-bar__menu-button',
+        'top-bar__snapshot',
+        {'top-bar__snapshot_in-progress': isInProgress},
+      )}
+      onClick={onClick}
+    >
+      Snapshot
+    </div>
+  );
+}
+
+SnapshotButton.propTypes = {
+  isInProgress: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -5,6 +5,7 @@ import partial from 'lodash/partial';
 import Wordmark from '../../static/images/wordmark.svg';
 import Pop from '../Pop';
 import CurrentUser from './CurrentUser';
+import SnapshotButton from './SnapshotButton';
 import TextSize from './TextSize';
 
 function uiVariants({validationState, isUserTyping}) {
@@ -24,11 +25,13 @@ export default function TopBar({
   currentUser,
   isHamburgerMenuActive,
   isUserTyping,
-  openMenu,
+  isSnapshotInProgress,
   isTextSizeLarge,
+  openMenu,
   validationState,
   onClickHamburgerMenu,
   onClickMenu,
+  onCreateSnapshot,
   onLogOut,
   onStartLogIn,
   onToggleTextSize,
@@ -54,6 +57,10 @@ export default function TopBar({
         <Wordmark />
       </div>
       <div className="top-bar__spacer" />
+      <SnapshotButton
+        isInProgress={isSnapshotInProgress}
+        onClick={onCreateSnapshot}
+      />
       <TextSize isLarge={isTextSizeLarge} onToggle={onToggleTextSize} />
       <CurrentUser
         isOpen={openMenu === 'currentUser'}
@@ -69,12 +76,14 @@ export default function TopBar({
 TopBar.propTypes = {
   currentUser: PropTypes.object.isRequired,
   isHamburgerMenuActive: PropTypes.bool.isRequired,
+  isSnapshotInProgress: PropTypes.bool.isRequired,
   isTextSizeLarge: PropTypes.bool.isRequired,
   isUserTyping: PropTypes.bool.isRequired,
   openMenu: PropTypes.string,
   validationState: PropTypes.string.isRequired,
   onClickHamburgerMenu: PropTypes.func.isRequired,
   onClickMenu: PropTypes.func.isRequired,
+  onCreateSnapshot: PropTypes.func.isRequired,
   onLogOut: PropTypes.func.isRequired,
   onStartLogIn: PropTypes.func.isRequired,
   onToggleTextSize: PropTypes.func.isRequired,

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -3,7 +3,6 @@ import {Dashboard} from '../components';
 import {
   changeCurrentProject,
   createProject,
-  createSnapshot,
   exportGist,
   exportRepo,
   toggleDashboardSubmenu,
@@ -17,7 +16,6 @@ import {
   isDashboardOpen,
   isExperimental,
   isGistExportInProgress,
-  isSnapshotInProgress,
 } from '../selectors';
 
 function mapStateToProps(state) {
@@ -29,16 +27,11 @@ function mapStateToProps(state) {
     gistExportInProgress: isGistExportInProgress(state),
     isExperimental: isExperimental(state),
     isOpen: isDashboardOpen(state),
-    snapshotInProgress: isSnapshotInProgress(state),
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    onCreateSnapshot() {
-      dispatch(createSnapshot());
-    },
-
     onExportGist() {
       dispatch(exportGist());
     },

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -8,14 +8,16 @@ import {
   getCurrentValidationState,
   getOpenTopBarMenu,
   isDashboardOpen,
+  isSnapshotInProgress,
   isTextSizeLarge,
   isUserTyping,
 } from '../selectors';
 import {
-  toggleTopBarMenu,
+  createSnapshot,
   notificationTriggered,
   toggleDashboard,
   toggleEditorTextSize,
+  toggleTopBarMenu,
 } from '../actions';
 import {
   signIn,
@@ -26,6 +28,7 @@ function mapStateToProps(state) {
   return {
     currentUser: getCurrentUser(state),
     isHamburgerMenuActive: isDashboardOpen(state),
+    isSnapshotInProgress: isSnapshotInProgress(state),
     isTextSizeLarge: isTextSizeLarge(state),
     isUserTyping: isUserTyping(state),
     openMenu: getOpenTopBarMenu(state),
@@ -41,6 +44,10 @@ function mapDispatchToProps(dispatch) {
 
     onClickMenu(menuKey) {
       dispatch(toggleTopBarMenu(menuKey));
+    },
+
+    onCreateSnapshot() {
+      dispatch(createSnapshot());
     },
 
     onLogOut() {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -149,6 +149,11 @@ body {
   width: auto;
 }
 
+.top-bar__snapshot_in-progress {
+  color: var(--color-dark-gray);
+  cursor: progress;
+}
+
 .top-bar__avatar {
   height: 2em;
   border-radius: 50%;


### PR DESCRIPTION
Moves the snapshot button to the top bar. Not much more to say about it.

![localhost-3001- smallest common laptop](https://user-images.githubusercontent.com/14214/29241654-d9aae8b6-7f4b-11e7-93df-f6ae717fc8a5.png)

Another step in #779 