### PR TITLE
Don’t assume non-null current project when selecting enabled libraries

### DIFF
--- a/src/selectors/getEnabledLibraries.js
+++ b/src/selectors/getEnabledLibraries.js
@@ -1,7 +1,8 @@
 import {createSelector} from 'reselect';
+import get from 'lodash/get';
 import getCurrentProject from './getCurrentProject';
 
 export default createSelector(
   [getCurrentProject],
-  currentProject => currentProject.enabledLibraries,
+  currentProject => get(currentProject, ['enabledLibraries'], []),
 );


### PR DESCRIPTION
If there is no current project, there are no enabled libraries.

Fixes #980
Fixes #981