### PR TITLE
Move New Project and Load Project into top bar

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,16 +1,16 @@
 {
   "top-bar": {
+    "create-snapshot": "Snapshot",
+    "libraries": "Libraries",
+    "load-project": "My Projects",
     "session": {
       "log-in-prompt": "Log in to save",
       "log-out-prompt": "Log out"
-    },
-    "create-snapshot": "Snapshot",
-    "libraries": "Libraries"
+    }
   },
   "dashboard": {
     "menu": {
       "new-project": "New Project",
-      "load-project": "Load Project",
       "export-gist": "Export Gist",
       "send-feedback": "Send Feedback",
       "export-repo": "Export Repo"

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -3,6 +3,7 @@
     "create-snapshot": "Snapshot",
     "libraries": "Libraries",
     "load-project": "My Projects",
+    "new-project": "New Project",
     "session": {
       "log-in-prompt": "Log in to save",
       "log-out-prompt": "Log out"
@@ -10,7 +11,6 @@
   },
   "dashboard": {
     "menu": {
-      "new-project": "New Project",
       "export-gist": "Export Gist",
       "send-feedback": "Send Feedback",
       "export-repo": "Export Repo"

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "postcss": "^6.0.6",
     "postcss-cssnext": "^3.0.2",
     "raw-loader": "^0.5.1",
+    "react-addons-perf": "^15.4.2",
     "redux-saga-test-plan": "^3.0.2",
     "sinon": "^2.3.1",
     "string-replace-loader": "^1.0.5",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -48,10 +48,6 @@ function toggleDashboard() {
   return {type: 'DASHBOARD_TOGGLED'};
 }
 
-function toggleDashboardSubmenu(submenu) {
-  return {type: 'DASHBOARD_SUBMENU_TOGGLED', payload: {submenu}};
-}
-
 export {
   createProject,
   createSnapshot,
@@ -64,7 +60,6 @@ export {
   hideComponent,
   unhideComponent,
   toggleDashboard,
-  toggleDashboardSubmenu,
   focusLine,
   editorFocusedRequestedLine,
   dragRowDivider,

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
 import partial from 'lodash/partial';
-import isNull from 'lodash/isNull';
 import classnames from 'classnames';
 import config from '../config';
 import ProjectList from './ProjectList';
@@ -35,7 +34,6 @@ class Dashboard extends React.Component {
           {t('dashboard.menu.new-project')}
         </div>
       );
-
       loadProjectButton =
         this._renderSubmenuToggleButton('projectList', 'load-project');
     }
@@ -91,15 +89,9 @@ class Dashboard extends React.Component {
   }
 
   _renderProjects() {
-    if (isNull(this.props.currentProject)) {
-      return null;
-    }
-
     return (
       <ProjectList
-        currentProject={this.props.currentProject}
-        projects={this.props.allProjects}
-        onProjectSelected={this.props.onProjectSelected}
+        projectKeys={this.props.projectKeys}
       />
     );
   }
@@ -154,16 +146,14 @@ class Dashboard extends React.Component {
 
 Dashboard.propTypes = {
   activeSubmenu: PropTypes.string,
-  allProjects: PropTypes.array.isRequired,
-  currentProject: PropTypes.object,
   currentUser: PropTypes.object.isRequired,
   gistExportInProgress: PropTypes.bool.isRequired,
   isExperimental: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
+  projectKeys: PropTypes.array.isRequired,
   onExportGist: PropTypes.func.isRequired,
   onExportRepo: PropTypes.func.isRequired,
   onNewProject: PropTypes.func.isRequired,
-  onProjectSelected: PropTypes.func.isRequired,
   onSubmenuToggled: PropTypes.func.isRequired,
 };
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -6,17 +6,7 @@ import config from '../config';
 
 class Dashboard extends React.Component {
   _renderMenu() {
-    let newProjectButton, loadProjectButton, exportRepoButton;
-    if (this.props.currentUser.authenticated) {
-      newProjectButton = (
-        <div
-          className="dashboard__menu-item dashboard__menu-item_grid"
-          onClick={this.props.onNewProject}
-        >
-          {t('dashboard.menu.new-project')}
-        </div>
-      );
-    }
+    let exportRepoButton;
 
     if (this.props.isExperimental && this.props.currentUser.authenticated) {
       exportRepoButton = (
@@ -31,8 +21,6 @@ class Dashboard extends React.Component {
 
     return (
       <div className="dashboard__menu dashboard__menu_grid">
-        {newProjectButton}
-        {loadProjectButton}
         <div
           className={
             classnames(
@@ -115,7 +103,6 @@ Dashboard.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onExportGist: PropTypes.func.isRequired,
   onExportRepo: PropTypes.func.isRequired,
-  onNewProject: PropTypes.func.isRequired,
 };
 
 Dashboard.defaultProps = {

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,28 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
-import partial from 'lodash/partial';
 import classnames from 'classnames';
 import config from '../config';
-import ProjectList from './ProjectList';
 
 class Dashboard extends React.Component {
-  _renderSubmenuToggleButton(submenu, label) {
-    return (
-      <div
-        className={classnames(
-          'dashboard__menu-item',
-          'dashboard__menu-item_grid',
-          {'dashboard__menu-item_active':
-            this.props.activeSubmenu === submenu},
-        )}
-        onClick={partial(this.props.onSubmenuToggled, submenu)}
-      >
-        {t(`dashboard.menu.${label}`)}
-      </div>
-    );
-  }
-
   _renderMenu() {
     let newProjectButton, loadProjectButton, exportRepoButton;
     if (this.props.currentUser.authenticated) {
@@ -34,8 +16,6 @@ class Dashboard extends React.Component {
           {t('dashboard.menu.new-project')}
         </div>
       );
-      loadProjectButton =
-        this._renderSubmenuToggleButton('projectList', 'load-project');
     }
 
     if (this.props.isExperimental && this.props.currentUser.authenticated) {
@@ -81,21 +61,6 @@ class Dashboard extends React.Component {
     );
   }
 
-  _renderSubmenu() {
-    if (this.props.activeSubmenu === 'projectList') {
-      return this._renderProjects();
-    }
-    return null;
-  }
-
-  _renderProjects() {
-    return (
-      <ProjectList
-        projectKeys={this.props.projectKeys}
-      />
-    );
-  }
-
   _renderLinks() {
     return (
       <div className="dashboard__links">
@@ -136,7 +101,6 @@ class Dashboard extends React.Component {
     return (
       <div className={sidebarClassnames}>
         {this._renderMenu()}
-        {this._renderSubmenu()}
         <div className="dashboard__spacer" />
         {this._renderLinks()}
       </div>
@@ -145,20 +109,16 @@ class Dashboard extends React.Component {
 }
 
 Dashboard.propTypes = {
-  activeSubmenu: PropTypes.string,
   currentUser: PropTypes.object.isRequired,
   gistExportInProgress: PropTypes.bool.isRequired,
   isExperimental: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  projectKeys: PropTypes.array.isRequired,
   onExportGist: PropTypes.func.isRequired,
   onExportRepo: PropTypes.func.isRequired,
   onNewProject: PropTypes.func.isRequired,
-  onSubmenuToggled: PropTypes.func.isRequired,
 };
 
 Dashboard.defaultProps = {
-  activeSubmenu: null,
   currentProject: null,
 };
 

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -1,37 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
-import classnames from 'classnames';
-import partial from 'lodash/partial';
 import {generateTextPreview} from '../util/generatePreview';
-
-const MAX_LENGTH = 50;
+import ProjectPreview from './ProjectPreview';
 
 function ProjectList({currentProject, projects, onProjectSelected}) {
-  const projectPreviews = projects.map((project) => {
-    const preview = generateTextPreview(project);
-    const isSelected =
-      project.projectKey === currentProject.projectKey;
-
-    return (
-      <div
-        className={classnames(
-          'project-preview',
-          'dashboard__menu-item',
-          {'dashboard__menu-item_active': isSelected},
-        )}
-        key={project.projectKey}
-        onClick={partial(onProjectSelected, project)}
-      >
-        <div className="project-preview__timestamp">
-          {moment(project.updatedAt).fromNow()}
-        </div>
-        <div>
-          {preview.slice(0, MAX_LENGTH)}
-        </div>
-      </div>
-    );
-  });
+  const projectPreviews = projects.map(project => (
+    <ProjectPreview
+      isSelected={project.projectKey === currentProject.projectKey}
+      key={project.projectKey}
+      preview={generateTextPreview(project)}
+      project={project}
+      onProjectSelected={onProjectSelected}
+    />
+  ));
 
   return (
     <div className="dashboard__menu dashboard__menu_scrollable">

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {generateTextPreview} from '../util/generatePreview';
-import ProjectPreview from './ProjectPreview';
+import {ProjectPreview} from '../containers';
 
-function ProjectList({currentProject, projects, onProjectSelected}) {
-  const projectPreviews = projects.map(project => (
+function ProjectList({projectKeys}) {
+  const projectPreviews = projectKeys.map(projectKey => (
     <ProjectPreview
-      isSelected={project.projectKey === currentProject.projectKey}
-      key={project.projectKey}
-      preview={generateTextPreview(project)}
-      project={project}
-      onProjectSelected={onProjectSelected}
+      key={projectKey}
+      projectKey={projectKey}
     />
   ));
 
@@ -22,9 +18,7 @@ function ProjectList({currentProject, projects, onProjectSelected}) {
 }
 
 ProjectList.propTypes = {
-  currentProject: PropTypes.object.isRequired,
-  projects: PropTypes.array.isRequired,
-  onProjectSelected: PropTypes.func.isRequired,
+  projectKeys: PropTypes.array.isRequired,
 };
 
 

--- a/src/components/ProjectPreview.jsx
+++ b/src/components/ProjectPreview.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import moment from 'moment';
+import partial from 'lodash/partial';
+
+const MAX_LENGTH = 50;
+
+export default function ProjectPreview({
+  isSelected,
+  preview,
+  project,
+  onProjectSelected,
+}) {
+  return (
+    <div
+      className={classnames(
+        'project-preview',
+        'dashboard__menu-item',
+        {'dashboard__menu-item_active': isSelected},
+      )}
+      key={project.projectKey}
+      onClick={partial(onProjectSelected, project)}
+    >
+      <div className="project-preview__timestamp">
+        {moment(project.updatedAt).fromNow()}
+      </div>
+      <div>
+        {preview.slice(0, MAX_LENGTH)}
+      </div>
+    </div>
+  );
+}
+
+ProjectPreview.propTypes = {
+  isSelected: PropTypes.bool.isRequired,
+  preview: PropTypes.string.isRequired,
+  project: PropTypes.object.isRequired,
+  onProjectSelected: PropTypes.func.isRequired,
+};

--- a/src/components/ProjectPreview.jsx
+++ b/src/components/ProjectPreview.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import moment from 'moment';
-import partial from 'lodash/partial';
 
 const MAX_LENGTH = 50;
 
@@ -20,7 +19,7 @@ export default function ProjectPreview({
         {'dashboard__menu-item_active': isSelected},
       )}
       key={project.projectKey}
-      onClick={partial(onProjectSelected, project)}
+      onClick={onProjectSelected}
     >
       <div className="project-preview__timestamp">
         {moment(project.updatedAt).fromNow()}

--- a/src/components/ProjectPreview.jsx
+++ b/src/components/ProjectPreview.jsx
@@ -15,8 +15,8 @@ export default function ProjectPreview({
     <div
       className={classnames(
         'project-preview',
-        'dashboard__menu-item',
-        {'dashboard__menu-item_active': isSelected},
+        'top-bar__menu-item',
+        {'top-bar__menu-item_active': isSelected},
       )}
       key={project.projectKey}
       onClick={onProjectSelected}
@@ -24,7 +24,7 @@ export default function ProjectPreview({
       <div className="project-preview__timestamp">
         {moment(project.updatedAt).fromNow()}
       </div>
-      <div>
+      <div className="project-preview__label">
         {preview.slice(0, MAX_LENGTH)}
       </div>
     </div>

--- a/src/components/TopBar/NewProjectButton.jsx
+++ b/src/components/TopBar/NewProjectButton.jsx
@@ -1,0 +1,23 @@
+import {t} from 'i18next';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function NewProjectButton({isUserAuthenticated, onClick}) {
+  if (!isUserAuthenticated) {
+    return false;
+  }
+
+  return (
+    <div
+      className="top-bar__menu-button"
+      onClick={onClick}
+    >
+      {t('top-bar.new-project')}
+    </div>
+  );
+}
+
+NewProjectButton.propTypes = {
+  isUserAuthenticated: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/src/components/TopBar/ProjectList.jsx
+++ b/src/components/TopBar/ProjectList.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {ProjectPreview} from '../containers';
+import {ProjectPreview} from '../../containers';
 
-function ProjectList({projectKeys}) {
+function ProjectList({isOpen, projectKeys}) {
+  if (!isOpen) {
+    return null;
+  }
+
   const projectPreviews = projectKeys.map(projectKey => (
     <ProjectPreview
       key={projectKey}
@@ -11,13 +15,14 @@ function ProjectList({projectKeys}) {
   ));
 
   return (
-    <div className="dashboard__menu dashboard__menu_scrollable">
+    <div className="top-bar__menu">
       {projectPreviews}
     </div>
   );
 }
 
 ProjectList.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
   projectKeys: PropTypes.array.isRequired,
 };
 

--- a/src/components/TopBar/ProjectsButton.jsx
+++ b/src/components/TopBar/ProjectsButton.jsx
@@ -1,15 +1,18 @@
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import {t} from 'i18next';
-import LibraryPicker from './LibraryPicker';
+import ProjectList from './ProjectList';
 
-export default function LibraryPickerButton({
-  enabledLibraries,
+export default function ProjectsButton({
   isOpen,
+  projectKeys,
   onClick,
-  onLibraryToggled,
 }) {
+  if (projectKeys.length < 2) {
+    return null;
+  }
+
   return (
     <div
       className={classnames(
@@ -18,23 +21,21 @@ export default function LibraryPickerButton({
       )}
       onClick={onClick}
     >
-      {t('top-bar.libraries')}
+      {t('top-bar.load-project')}
       {' '}
       <span className="u__icon">
         &#xf0d7;
       </span>
-      <LibraryPicker
-        enabledLibraries={enabledLibraries}
+      <ProjectList
         isOpen={isOpen}
-        onLibraryToggled={onLibraryToggled}
+        projectKeys={projectKeys}
       />
     </div>
   );
 }
 
-LibraryPickerButton.propTypes = {
-  enabledLibraries: PropTypes.arrayOf(PropTypes.string).isRequired,
+ProjectsButton.propTypes = {
   isOpen: PropTypes.bool.isRequired,
+  projectKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   onClick: PropTypes.func.isRequired,
-  onLibraryToggled: PropTypes.func.isRequired,
 };

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -6,6 +6,7 @@ import Wordmark from '../../static/images/wordmark.svg';
 import Pop from '../Pop';
 import CurrentUser from './CurrentUser';
 import LibraryPickerButton from './LibraryPickerButton';
+import ProjectsButton from './ProjectsButton';
 import SnapshotButton from './SnapshotButton';
 import TextSize from './TextSize';
 
@@ -31,6 +32,7 @@ export default function TopBar({
   isSnapshotInProgress,
   isTextSizeLarge,
   openMenu,
+  projectKeys,
   validationState,
   onClickHamburgerMenu,
   onClickMenu,
@@ -61,6 +63,11 @@ export default function TopBar({
         <Wordmark />
       </div>
       <div className="top-bar__spacer" />
+      <ProjectsButton
+        isOpen={openMenu === 'projectPicker'}
+        projectKeys={projectKeys}
+        onClick={partial(onClickMenu, 'projectPicker')}
+      />
       <LibraryPickerButton
         enabledLibraries={enabledLibraries}
         isOpen={openMenu === 'libraryPicker'}
@@ -92,6 +99,7 @@ TopBar.propTypes = {
   isTextSizeLarge: PropTypes.bool.isRequired,
   isUserTyping: PropTypes.bool.isRequired,
   openMenu: PropTypes.string,
+  projectKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   validationState: PropTypes.string.isRequired,
   onClickHamburgerMenu: PropTypes.func.isRequired,
   onClickMenu: PropTypes.func.isRequired,

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -6,6 +6,7 @@ import Wordmark from '../../static/images/wordmark.svg';
 import Pop from '../Pop';
 import CurrentUser from './CurrentUser';
 import LibraryPickerButton from './LibraryPickerButton';
+import NewProjectButton from './NewProjectButton';
 import ProjectsButton from './ProjectsButton';
 import SnapshotButton from './SnapshotButton';
 import TextSize from './TextSize';
@@ -28,6 +29,7 @@ export default function TopBar({
   currentUser,
   enabledLibraries,
   isHamburgerMenuActive,
+  isUserAuthenticated,
   isUserTyping,
   isSnapshotInProgress,
   isTextSizeLarge,
@@ -36,6 +38,7 @@ export default function TopBar({
   validationState,
   onClickHamburgerMenu,
   onClickMenu,
+  onCreateNewProject,
   onCreateSnapshot,
   onLibraryToggled,
   onLogOut,
@@ -63,6 +66,10 @@ export default function TopBar({
         <Wordmark />
       </div>
       <div className="top-bar__spacer" />
+      <NewProjectButton
+        isUserAuthenticated={isUserAuthenticated}
+        onClick={onCreateNewProject}
+      />
       <ProjectsButton
         isOpen={openMenu === 'projectPicker'}
         projectKeys={projectKeys}
@@ -97,12 +104,14 @@ TopBar.propTypes = {
   isHamburgerMenuActive: PropTypes.bool.isRequired,
   isSnapshotInProgress: PropTypes.bool.isRequired,
   isTextSizeLarge: PropTypes.bool.isRequired,
+  isUserAuthenticated: PropTypes.bool.isRequired,
   isUserTyping: PropTypes.bool.isRequired,
   openMenu: PropTypes.string,
   projectKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   validationState: PropTypes.string.isRequired,
   onClickHamburgerMenu: PropTypes.func.isRequired,
   onClickMenu: PropTypes.func.isRequired,
+  onCreateNewProject: PropTypes.func.isRequired,
   onCreateSnapshot: PropTypes.func.isRequired,
   onLibraryToggled: PropTypes.func.isRequired,
   onLogOut: PropTypes.func.isRequired,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,6 +3,7 @@ import ErrorReport from './ErrorReport';
 import NotificationList from './NotificationList';
 import Preview from './Preview';
 import TopBar from './TopBar';
+import ProjectPreview from './ProjectPreview';
 
 export {
   Dashboard,
@@ -10,4 +11,5 @@ export {
   NotificationList,
   Preview,
   TopBar,
+  ProjectPreview,
 };

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -4,11 +4,8 @@ import {
   createProject,
   exportGist,
   exportRepo,
-  toggleDashboardSubmenu,
 } from '../actions';
 import {
-  getActiveSubmenu,
-  getAllProjectKeys,
   getCurrentProject,
   getCurrentUser,
   isDashboardOpen,
@@ -18,13 +15,11 @@ import {
 
 function mapStateToProps(state) {
   return {
-    activeSubmenu: getActiveSubmenu(state),
     currentProject: getCurrentProject(state),
     currentUser: getCurrentUser(state),
     gistExportInProgress: isGistExportInProgress(state),
     isExperimental: isExperimental(state),
     isOpen: isDashboardOpen(state),
-    projectKeys: getAllProjectKeys(state),
   };
 }
 
@@ -40,10 +35,6 @@ function mapDispatchToProps(dispatch) {
 
     onNewProject() {
       dispatch(createProject());
-    },
-
-    onSubmenuToggled(submenu) {
-      dispatch(toggleDashboardSubmenu(submenu));
     },
   };
 }

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -1,7 +1,6 @@
 import {connect} from 'react-redux';
 import {Dashboard} from '../components';
 import {
-  changeCurrentProject,
   createProject,
   exportGist,
   exportRepo,
@@ -9,7 +8,7 @@ import {
 } from '../actions';
 import {
   getActiveSubmenu,
-  getAllProjects,
+  getAllProjectKeys,
   getCurrentProject,
   getCurrentUser,
   isDashboardOpen,
@@ -20,12 +19,12 @@ import {
 function mapStateToProps(state) {
   return {
     activeSubmenu: getActiveSubmenu(state),
-    allProjects: getAllProjects(state),
     currentProject: getCurrentProject(state),
     currentUser: getCurrentUser(state),
     gistExportInProgress: isGistExportInProgress(state),
     isExperimental: isExperimental(state),
     isOpen: isDashboardOpen(state),
+    projectKeys: getAllProjectKeys(state),
   };
 }
 
@@ -41,10 +40,6 @@ function mapDispatchToProps(dispatch) {
 
     onNewProject() {
       dispatch(createProject());
-    },
-
-    onProjectSelected(project) {
-      dispatch(changeCurrentProject(project.projectKey));
     },
 
     onSubmenuToggled(submenu) {

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -1,7 +1,6 @@
 import {connect} from 'react-redux';
 import {Dashboard} from '../components';
 import {
-  createProject,
   exportGist,
   exportRepo,
 } from '../actions';
@@ -31,10 +30,6 @@ function mapDispatchToProps(dispatch) {
 
     onExportRepo() {
       dispatch(exportRepo());
-    },
-
-    onNewProject() {
-      dispatch(createProject());
     },
   };
 }

--- a/src/containers/ProjectPreview.js
+++ b/src/containers/ProjectPreview.js
@@ -1,0 +1,33 @@
+import {connect} from 'react-redux';
+import {ProjectPreview} from '../components';
+import {changeCurrentProject} from '../actions';
+import {
+  makeGetProjectPreview,
+  getCurrentProjectKey,
+  getProject,
+} from '../selectors';
+
+function makeMapStateToProps() {
+  const getProjectPreview = makeGetProjectPreview();
+
+  return function mapStateToProps(state, {projectKey}) {
+    return {
+      preview: getProjectPreview(state, {projectKey}),
+      isSelected: projectKey === getCurrentProjectKey(state),
+      project: getProject(state, {projectKey}),
+    };
+  };
+}
+
+function mapDispatchToProps(dispatch, {projectKey}) {
+  return {
+    onProjectSelected() {
+      dispatch(changeCurrentProject(projectKey));
+    },
+  };
+}
+
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps,
+)(ProjectPreview);

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -9,6 +9,7 @@ import {
   getCurrentValidationState,
   getEnabledLibraries,
   getOpenTopBarMenu,
+  getAllProjectKeys,
   isDashboardOpen,
   isSnapshotInProgress,
   isTextSizeLarge,
@@ -37,6 +38,7 @@ function mapStateToProps(state) {
     isTextSizeLarge: isTextSizeLarge(state),
     isUserTyping: isUserTyping(state),
     openMenu: getOpenTopBarMenu(state),
+    projectKeys: getAllProjectKeys(state),
     validationState: getCurrentValidationState(state),
   };
 }

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -13,9 +13,11 @@ import {
   isDashboardOpen,
   isSnapshotInProgress,
   isTextSizeLarge,
+  isUserAuthenticated,
   isUserTyping,
 } from '../selectors';
 import {
+  createProject,
   createSnapshot,
   notificationTriggered,
   toggleDashboard,
@@ -36,6 +38,7 @@ function mapStateToProps(state) {
     isHamburgerMenuActive: isDashboardOpen(state),
     isSnapshotInProgress: isSnapshotInProgress(state),
     isTextSizeLarge: isTextSizeLarge(state),
+    isUserAuthenticated: isUserAuthenticated(state),
     isUserTyping: isUserTyping(state),
     openMenu: getOpenTopBarMenu(state),
     projectKeys: getAllProjectKeys(state),
@@ -51,6 +54,10 @@ function mapDispatchToProps(dispatch) {
 
     onClickMenu(menuKey) {
       dispatch(toggleTopBarMenu(menuKey));
+    },
+
+    onCreateNewProject() {
+      dispatch(createProject());
     },
 
     onCreateSnapshot() {

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -2,6 +2,7 @@ import Dashboard from './Dashboard';
 import ErrorReport from './ErrorReport';
 import NotificationList from './NotificationList';
 import Preview from './Preview';
+import ProjectPreview from './ProjectPreview';
 import TopBar from './TopBar';
 
 export {
@@ -9,5 +10,6 @@ export {
   ErrorReport,
   NotificationList,
   Preview,
+  ProjectPreview,
   TopBar,
 };

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -192,6 +192,9 @@ body {
   position: absolute;
   top: 100%;
   min-width: 100%;
+  max-height: 50vh;
+  max-width: 300%;
+  overflow: scroll;
 }
 
 .top-bar__menu-item {
@@ -199,8 +202,9 @@ body {
   box-sizing: border-box;
   color: var(--color-very-dark-gray);
   font-weight: normal;
+  line-height: 1.2em;
   min-width: 100%;
-  padding: 0 0.5em;
+  padding: 1em 0.5em;
   white-space: nowrap;
 }
 
@@ -435,11 +439,9 @@ body {
 
 /** @define project-preview */
 
-.project-preview__timestamp {
-  text-align: right;
-  color: var(--color-gray);
-  font-style: italic;
-  font-weight: normal;
+.project-preview__label {
+  font-size: 0.8em;
+  white-space: normal;
 }
 
 /** @define workspace */

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -24,8 +24,7 @@ const defaultState = new Immutable.Map().
   set(
     'dashboard',
     new Immutable.Map().
-      set('isOpen', false).
-      set('activeSubmenu', null),
+      set('isOpen', false),
   ).
   set('topBar', new Immutable.Map({openMenu: null})).
   set('lastRefreshTimestamp', null);
@@ -63,18 +62,7 @@ export default function ui(stateIn, action) {
       return state.setIn(['editors', 'typing'], false);
 
     case 'DASHBOARD_TOGGLED':
-      return state.updateIn(['dashboard', 'isOpen'], isOpen => !isOpen).
-        setIn(['dashboard', 'activeSubmenu'], null);
-
-    case 'DASHBOARD_SUBMENU_TOGGLED':
-      return state.updateIn(['dashboard', 'activeSubmenu'], (submenu) => {
-        const newSubmenu = action.payload.submenu;
-        if (submenu === newSubmenu) {
-          return null;
-        }
-
-        return newSubmenu;
-      });
+      return state.updateIn(['dashboard', 'isOpen'], isOpen => !isOpen);
 
     case 'FOCUS_LINE':
       return state.setIn(
@@ -146,9 +134,6 @@ export default function ui(stateIn, action) {
       return state.updateIn(
         ['topBar', 'openMenu'],
         menu => menu === 'currentUser' ? null : menu,
-      ).updateIn(
-        ['dashboard', 'activeSubmenu'],
-        submenu => submenu === 'projectList' ? null : submenu,
       );
 
     case 'SNAPSHOT_CREATED':

--- a/src/selectors/getActiveSubmenu.js
+++ b/src/selectors/getActiveSubmenu.js
@@ -1,3 +1,0 @@
-export default function getActiveSubmenu(state) {
-  return state.getIn(['ui', 'dashboard', 'activeSubmenu']);
-}

--- a/src/selectors/getAllProjectKeys.js
+++ b/src/selectors/getAllProjectKeys.js
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  state => state.get('projects').keySeq(),
+  keys => keys.toJS(),
+);

--- a/src/selectors/getAllProjectKeys.js
+++ b/src/selectors/getAllProjectKeys.js
@@ -1,6 +1,10 @@
 import {createSelector} from 'reselect';
 
 export default createSelector(
-  state => state.get('projects').keySeq(),
-  keys => keys.toJS(),
+  state => state.get('projects'),
+  projects => projects.
+    filter(project => project.updatedAt).
+    sortBy(project => -project.updatedAt).
+    keySeq().
+    toJS(),
 );

--- a/src/selectors/getProject.js
+++ b/src/selectors/getProject.js
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  (state, {projectKey}) => state.getIn(['projects', projectKey]),
+  project => project.toJS(),
+);

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,4 +1,5 @@
 import getActiveSubmenu from './getActiveSubmenu';
+import getAllProjectKeys from './getAllProjectKeys';
 import getAllProjects from './getAllProjects';
 import getCurrentProject from './getCurrentProject';
 import getCurrentProjectKey from './getCurrentProjectKey';
@@ -10,6 +11,7 @@ import getErrors from './getErrors';
 import getLastRefreshTimestamp from './getLastRefreshTimestamp';
 import getNotifications from './getNotifications';
 import getOpenTopBarMenu from './getOpenTopBarMenu';
+import getProject from './getProject';
 import isCurrentlyValidating from './isCurrentlyValidating';
 import isCurrentProjectSyntacticallyValid
   from './isCurrentProjectSyntacticallyValid';
@@ -19,9 +21,11 @@ import isGistExportInProgress from './isGistExportInProgress';
 import isSnapshotInProgress from './isSnapshotInProgress';
 import isTextSizeLarge from './isTextSizeLarge';
 import isUserTyping from './isUserTyping';
+import makeGetProjectPreview from './makeGetProjectPreview';
 
 export {
   getActiveSubmenu,
+  getAllProjectKeys,
   getAllProjects,
   getCurrentProject,
   getCurrentProjectKey,
@@ -33,6 +37,7 @@ export {
   getLastRefreshTimestamp,
   getNotifications,
   getOpenTopBarMenu,
+  getProject,
   isCurrentlyValidating,
   isCurrentProjectSyntacticallyValid,
   isDashboardOpen,
@@ -41,4 +46,5 @@ export {
   isSnapshotInProgress,
   isTextSizeLarge,
   isUserTyping,
+  makeGetProjectPreview,
 };

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -19,6 +19,7 @@ import isExperimental from './isExperimental';
 import isGistExportInProgress from './isGistExportInProgress';
 import isSnapshotInProgress from './isSnapshotInProgress';
 import isTextSizeLarge from './isTextSizeLarge';
+import isUserAuthenticated from './isUserAuthenticated';
 import isUserTyping from './isUserTyping';
 import makeGetProjectPreview from './makeGetProjectPreview';
 
@@ -43,6 +44,7 @@ export {
   isGistExportInProgress,
   isSnapshotInProgress,
   isTextSizeLarge,
+  isUserAuthenticated,
   isUserTyping,
   makeGetProjectPreview,
 };

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,4 +1,3 @@
-import getActiveSubmenu from './getActiveSubmenu';
 import getAllProjectKeys from './getAllProjectKeys';
 import getAllProjects from './getAllProjects';
 import getCurrentProject from './getCurrentProject';
@@ -24,7 +23,6 @@ import isUserTyping from './isUserTyping';
 import makeGetProjectPreview from './makeGetProjectPreview';
 
 export {
-  getActiveSubmenu,
   getAllProjectKeys,
   getAllProjects,
   getCurrentProject,

--- a/src/selectors/isUserAuthenticated.js
+++ b/src/selectors/isUserAuthenticated.js
@@ -1,0 +1,3 @@
+export default function isUserAuthenticated(state) {
+  return state.getIn(['user', 'authenticated']);
+}

--- a/src/selectors/makeGetProjectPreview.js
+++ b/src/selectors/makeGetProjectPreview.js
@@ -1,0 +1,9 @@
+import {createSelector} from 'reselect';
+import {generateTextPreview} from '../util/generatePreview';
+
+export default function makeGetProjectPreview() {
+  return createSelector(
+    (state, {projectKey}) => state.getIn(['projects', projectKey]),
+    project => generateTextPreview(project.toJS()),
+  );
+}

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -72,7 +72,6 @@ class PreviewGenerator {
     this.previewBody = this._ensureElement('body');
     this._firstScriptTag = this.previewDocument.querySelector('script');
 
-    this.previewText = (this.previewDocument.title || '').trim();
     this._attachLibraries(
       pick(options, ['nonBlockingAlertsAndPrompts']),
     );
@@ -232,7 +231,8 @@ function generatePreview(project, options) {
 }
 
 function generateTextPreview(project) {
-  return new PreviewGenerator(project).previewText;
+  const {title} = parser.parseFromString(project.sources.html, 'text/html');
+  return (title || '').trim();
 }
 
 export {sourceDelimiter, generateTextPreview};

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -45,7 +45,6 @@ const initialState = Immutable.fromJS({
   notifications: new Immutable.Map(),
   dashboard: {
     isOpen: false,
-    activeSubmenu: null,
   },
   lastRefreshTimestamp: null,
   topBar: {openMenu: null},
@@ -157,27 +156,6 @@ test('userDoneTyping', reducerTest(
 ));
 
 test('userLoggedOut', (t) => {
-  const libraryPickerOpen = initialState.setIn(
-    ['dashboard', 'activeSubmenu'],
-    'libraryPicker',
-  );
-  t.test('with active submenu that is not projects', reducerTest(
-    reducer,
-    libraryPickerOpen,
-    userLoggedOut,
-    libraryPickerOpen,
-  ));
-
-  t.test('with projectList active submenu', reducerTest(
-    reducer,
-    initialState.setIn(
-      ['dashboard', 'activeSubmenu'],
-      'projectList',
-    ),
-    userLoggedOut,
-    initialState,
-  ));
-
   t.test('with no top bar menu open', reducerTest(
     reducer,
     initialState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,7 +3057,7 @@ faye-websocket@0.9.3:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.9:
+fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
   dependencies:
@@ -6446,6 +6446,13 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-addons-perf@^15.4.2:
+  version "15.4.2"
+  resolved "https://registry.yarnpkg.com/react-addons-perf/-/react-addons-perf-15.4.2.tgz#110bdcf5c459c4f77cb85ed634bcd3397536383b"
+  dependencies:
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
 
 react-copy-to-clipboard@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This completes the composition of the top bar:

![localhost-3001- smallest common laptop 7](https://user-images.githubusercontent.com/14214/29343582-117a8c0e-8200-11e7-8ef3-27a693d15645.png)

Along with this move, also made a couple of improvements to performance. First, used the memoized selector factory pattern to ensure that we don’t unnecessarily re-render project previews when unrelated things in the environment change. Also refactored the preview generation itself so that it doesn’t do unnecessary extra work aside from just parsing the document and grabbing the title.

Goes to #779 