### PR TITLE
Overhaul editor labels and show/hide

### DIFF
--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -23,10 +23,12 @@ function EditorContainer(props) {
       style={props.style}
     >
       <div
-        className="environment__label label"
+        className="environment__label"
         onClick={props.onHide}
       >
         {t(`languages.${props.language}`)}
+        {' '}
+        <span className="u__icon">&#xf078;</span>
       </div>
       {helpText}
       {props.children}

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -20,7 +20,7 @@ function EditorContainer({children, language, source, style, onHide, onRef}) {
       style={style}
     >
       <div
-        className="environment__label"
+        className="editors__label editors__label_expanded"
         onClick={onHide}
       >
         {t(`languages.${language}`)}

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -2,16 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
 
-function EditorContainer(props) {
+function EditorContainer({children, language, source, style, onHide, onRef}) {
   let helpText;
 
-  if (props.source === '') {
+  if (source === '') {
     helpText = (
       <div className="editors__help-text">
-        {t(
-          'editors.help-text',
-          {language: props.language},
-        )}
+        {t('editors.help-text', {language})}
       </div>
     );
   }
@@ -19,19 +16,19 @@ function EditorContainer(props) {
   return (
     <div
       className="editors__editor-container"
-      ref={props.onRef}
-      style={props.style}
+      ref={onRef}
+      style={style}
     >
       <div
         className="environment__label"
-        onClick={props.onHide}
+        onClick={onHide}
       >
-        {t(`languages.${props.language}`)}
+        {t(`languages.${language}`)}
         {' '}
         <span className="u__icon">&#xf078;</span>
       </div>
       {helpText}
-      {props.children}
+      {children}
     </div>
   );
 }

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {t} from 'i18next';
 import {DraggableCore} from 'react-draggable';
 import bindAll from 'lodash/bindAll';
 import isEmpty from 'lodash/isEmpty';
 import includes from 'lodash/includes';
 import partial from 'lodash/partial';
+import partition from 'lodash/partition';
 import {getNodeHeights} from '../util/resize';
 
 import EditorContainer from './EditorContainer';
@@ -56,10 +58,14 @@ export default class EditorsColumn extends React.Component {
     } = this.props;
 
     const children = [];
-    const languages = ['html', 'css', 'javascript'].filter(language =>
-      !includes(currentProject.hiddenUIComponents, `editor.${language}`),
+    const [hiddenLanguages, visibleLanguages] = partition(
+      ['html', 'css', 'javascript'],
+      language => includes(
+        currentProject.hiddenUIComponents,
+        `editor.${language}`,
+      ),
     );
-    languages.forEach((language, index) => {
+    visibleLanguages.forEach((language, index) => {
       children.push(
         <EditorContainer
           key={language}
@@ -71,9 +77,8 @@ export default class EditorsColumn extends React.Component {
         >
           <Editor
             errors={errors[language].items}
-            key={language}
             language={language}
-            percentageOfHeight={1 / languages.length}
+            percentageOfHeight={1 / visibleLanguages.length}
             projectKey={currentProject.projectKey}
             requestedFocusedLine={ui.editors.requestedFocusedLine}
             source={currentProject.sources[language]}
@@ -83,7 +88,7 @@ export default class EditorsColumn extends React.Component {
           />
         </EditorContainer>,
       );
-      if (index < languages.length - 1) {
+      if (index < visibleLanguages.length - 1) {
         children.push(
           <DraggableCore
             key={`divider:${language}`}
@@ -96,6 +101,25 @@ export default class EditorsColumn extends React.Component {
           </DraggableCore>,
         );
       }
+    });
+
+    hiddenLanguages.forEach((language) => {
+      children.push((
+        <div
+          className="editors__collapsed-editor"
+          key={language}
+          onClick={partial(
+            this.props.onComponentUnhide,
+            `editor.${language}`,
+          )}
+        >
+          <div className="editors__label editors__label_collapsed">
+            {t(`languages.${language}`)}
+            {' '}
+            <span className="u__icon">&#xf077;</span>
+          </div>
+        </div>
+      ));
     });
 
     if (isEmpty(children)) {
@@ -119,6 +143,7 @@ EditorsColumn.propTypes = {
     editors: PropTypes.object.isRequired,
   }).isRequired,
   onComponentHide: PropTypes.func.isRequired,
+  onComponentUnhide: PropTypes.func.isRequired,
   onDividerDrag: PropTypes.func.isRequired,
   onEditorInput: PropTypes.func.isRequired,
   onRef: PropTypes.func.isRequired,

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,34 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {t} from 'i18next';
-import classnames from 'classnames';
 import {ErrorReport, Preview} from '../containers';
 
 export default function Output({
   isDraggingColumnDivider,
-  isHidden,
   style,
-  onHide,
   onRef,
 }) {
   return (
     <div
-      className={classnames(
-        'environment__column',
-        {u__hidden: isHidden},
-      )}
+      className="environment__column"
       ref={onRef}
       style={Object.assign({}, style, {
         pointerEvents: isDraggingColumnDivider ? 'none' : 'all',
       })}
     >
       <div className="environment__columnContents output">
-        <div
-          className="environment__label label"
-          onClick={onHide}
-        >
-          {t('workspace.components.output')}
-        </div>
         <Preview />
         <ErrorReport />
       </div>
@@ -38,8 +25,6 @@ export default function Output({
 
 Output.propTypes = {
   isDraggingColumnDivider: PropTypes.bool.isRequired,
-  isHidden: PropTypes.bool.isRequired,
   style: PropTypes.object.isRequired,
-  onHide: PropTypes.func.isRequired,
   onRef: PropTypes.func.isRequired,
 };

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,62 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {t} from 'i18next';
 import classnames from 'classnames';
-import partial from 'lodash/partial';
 
-class Sidebar extends React.Component {
-  _renderHiddenComponents() {
-    const components = this.props.hiddenComponents.
-      map(componentName => (
-        <div
-          className="sidebar__minimized-component"
-          key={componentName}
-          onClick={partial(this.props.onComponentUnhide, componentName)}
-        >
-          {t(`workspace.components.${componentName}`)}
-        </div>
-      ));
-
-    return (
-      <div className="sidebar__minimized-components">
-        {components}
-      </div>
-    );
-  }
-
-  render() {
-    const sidebarClassnames = classnames(
-      'sidebar',
-      {
-        sidebar_yellow: this.props.validationState === 'validating',
-        sidebar_red: this.props.validationState === 'validation-error' ||
-          this.props.validationState === 'runtime-error',
-      },
-    );
-
-    return (
-      <div className={sidebarClassnames}>
-        <div
-          className={classnames(
-            'sidebar__arrow',
-            {
-              sidebar__arrow_show: !this.props.dashboardIsOpen,
-              sidebar__arrow_hide: this.props.dashboardIsOpen,
-            },
-          )}
-          onClick={this.props.onToggleDashboard}
-        />
-        {this._renderHiddenComponents()}
-      </div>
-    );
-  }
+function Sidebar({dashboardIsOpen, onToggleDashboard}) {
+  return (
+    <div className="sidebar">
+      <div
+        className={classnames(
+          'sidebar__arrow',
+          {
+            sidebar__arrow_show: !dashboardIsOpen,
+            sidebar__arrow_hide: dashboardIsOpen,
+          },
+        )}
+        onClick={onToggleDashboard}
+      />
+    </div>
+  );
 }
 
 Sidebar.propTypes = {
   dashboardIsOpen: PropTypes.bool.isRequired,
-  hiddenComponents: PropTypes.array.isRequired,
-  validationState: PropTypes.string.isRequired,
-  onComponentUnhide: PropTypes.func.isRequired,
   onToggleDashboard: PropTypes.func.isRequired,
 };
 

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -205,17 +205,11 @@ class Workspace extends React.Component {
   }
 
   _renderSidebar() {
-    let hiddenComponents = [];
-    if (!isNull(this.props.currentProject)) {
-      hiddenComponents = this.props.currentProject.hiddenUIComponents;
-    }
     return (
       <div className="layout__sidebar">
         <Sidebar
           dashboardIsOpen={this.props.ui.dashboard.isOpen}
-          hiddenComponents={hiddenComponents}
           validationState={this._getOverallValidationState()}
-          onComponentUnhide={this._handleComponentUnhide}
           onToggleDashboard={this._handleToggleDashboard}
         />
       </div>

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -269,6 +269,7 @@ class Workspace extends React.Component {
           style={{flex: rowsFlex[0]}}
           ui={ui}
           onComponentHide={this._handleComponentHide}
+          onComponentUnhide={this._handleComponentUnhide}
           onDividerDrag={this._handleEditorsDividerDrag}
           onEditorInput={this._handleEditorInput}
           onRef={partial(this._storeColumnRef, 0)}

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -175,20 +175,11 @@ class Workspace extends React.Component {
   }
 
   _renderOutput() {
-    const {
-      currentProject: {hiddenUIComponents},
-      isDraggingColumnDivider,
-      rowsFlex,
-    } = this.props;
+    const {isDraggingColumnDivider, rowsFlex} = this.props;
     return (
       <Output
         isDraggingColumnDivider={isDraggingColumnDivider}
-        isHidden={includes(hiddenUIComponents, 'output')}
         style={{flex: rowsFlex[1]}}
-        onHide={
-          partial(this._handleComponentHide,
-            'output')
-        }
         onRef={partial(this._storeColumnRef, 1)}
       />
     );

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -476,22 +476,6 @@ body {
   overflow-y: scroll;
 }
 
-.environment__label {
-  background-color: var(--color-gray);
-  color: var(--color-very-dark-gray);
-  cursor: pointer;
-  font-family: 'Roboto';
-  font-size: 14px;
-  padding: 0.5em;
-  position: absolute;
-  right: 0;
-  text-align: right;
-  top: 0;
-  user-select: none;
-  width: 8em;
-  z-index: 1;
-}
-
 /** @define editors */
 
 .editors {
@@ -512,6 +496,30 @@ body {
 .editors__editor {
   z-index: 0;
   flex: 1;
+}
+
+.editors__collapsed-editor {
+  border-top: 4px solid var(--color-dark-gray);
+  flex: none;
+}
+
+.editors__label {
+  background-color: var(--color-gray);
+  color: var(--color-very-dark-gray);
+  cursor: pointer;
+  font-family: 'Roboto';
+  font-size: 14px;
+  padding: 0.5em;
+  text-align: right;
+  user-select: none;
+}
+
+.editors__label_expanded {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 8em;
+  z-index: 1;
 }
 
 .editors__column-divider {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -477,9 +477,18 @@ body {
 }
 
 .environment__label {
+  background-color: var(--color-gray);
+  color: var(--color-very-dark-gray);
+  cursor: pointer;
+  font-family: 'Roboto';
+  font-size: 14px;
+  padding: 0.5em;
   position: absolute;
-  bottom: 1em;
-  right: 1em;
+  right: 0;
+  text-align: right;
+  top: 0;
+  user-select: none;
+  width: 8em;
   z-index: 1;
 }
 
@@ -529,23 +538,6 @@ body {
   font-family: Roboto;
   user-select: none;
   pointer-events: none;
-}
-
-/** @define label */
-
-.label {
-  background-color: black;
-  border-radius: 4px;
-  color: white;
-  cursor: pointer;
-  font-family: 'Inconsolata';
-  font-size: 0.8rem;
-  opacity: 0.2;
-  padding: 0.2rem;
-}
-
-.label:hover {
-  opacity: 0.5;
 }
 
 /** @define output */

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -241,34 +241,6 @@ body {
   width: 48px;
 }
 
-.sidebar__minimized-components {
-  flex: 0 0 auto;
-}
-
-.sidebar__minimized-component {
-  background-color: white;
-  text-align: center;
-  margin-top: 0.5em;
-  padding: 1em 0;
-  font-size: 0.7em;
-  position: relative;
-  cursor: pointer;
-}
-
-.sidebar__minimized-component::before {
-  display: block;
-  position: absolute;
-  width: 1em;
-  height: 1em;
-  top: 0;
-  right: 0;
-  content: "";
-  border-top: solid 0.5em var(--color-red);
-  border-right: solid 0.5em var(--color-red);
-  border-bottom: solid 0.5em transparent;
-  border-left: solid 0.5em transparent;
-}
-
 :root {
   --sidebar-arrow-stroke: 4px solid white;
 }


### PR DESCRIPTION
Editor labels are moved to the top-right, lighter color scheme, no transparency, and no rounded corners. Also chevrons.

When clicked, the editor is minimized. Minimized editor appears as a bar at the bottom of the editors column, basically a full-width version of the editor label, with no actual editor. The chevron points up. Clicking this bar expands the editor.

This did involve removing the label on the output, which does not exist in the redesign. This means that there is now no way to minimize the output. I think that might be okay since you can now drag the column divider to give the editors more space, although ideally it would be good to still be able to fully minimize it.

![localhost-3001- smallest common laptop 8](https://user-images.githubusercontent.com/14214/29389855-bfae228a-82ba-11e7-8577-9090f13178dc.png)
