### PR TITLE
Use container div to correctly size preview iframe

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -110,11 +110,13 @@ class PreviewFrame extends React.Component {
     }
 
     return (
-      <iframe
-        className="preview__frame"
-        sandbox={sandboxOptions}
-        {...srcProps}
-      />
+      <div className="preview__frame-container">
+        <iframe
+          className="preview__frame"
+          sandbox={sandboxOptions}
+          {...srcProps}
+        />
+      </div>
     );
   }
 }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -554,14 +554,19 @@ body {
   display: flex;
 }
 
+.preview__frame-container {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 1.5em;
+  z-index: 0;
+}
+
 .preview__frame {
   border: 0;
-  z-index: 0;
-  position: absolute;
-  top: 1.5em;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  height: 100%;
+  width: 100%;
 }
 
 .preview__title-bar {


### PR DESCRIPTION
Fun fact: [you can’t use `top`/`left`/`right`/`bottom` to size an absolutely-positioned iframe!](https://www.w3.org/TR/CSS21/visudet.html#abs-replaced-height).  You need to give iframes explicit `height` and `width`, full stop.

The solution is pretty simple—add a container `<div>` that we size using the absolute position boundaries, then give the iframe a `height` and `width` of 100%.

Fixes #989
Fixes #990