### PR TITLE
Remove remaining use of data URIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "PrettyCSS": "^0.3.13",
     "ajv": "^5.2.2",
     "array-to-sentence": "^1.1.0",
-    "base64-js": "^1.0.2",
     "bowser": "^1.4.5",
     "brace": "^0.10.0",
     "bugsnag-js": "^3.0.1",
@@ -147,7 +146,6 @@
     "rxjs": "^5.0.2",
     "slowparse": "^1.1.4",
     "stylelint": "^8.0.0",
-    "text-encoding": "^0.6.0",
     "uuid": "^3.1.0",
     "void-elements": "^3.1.0"
   },

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,7 +1,0 @@
-import base64 from 'base64-js';
-import {TextEncoder} from 'text-encoding';
-import spinnerPageHtml from '../templates/github-export.html';
-
-export const spinnerPage = base64.fromByteArray(
-  new TextEncoder('utf-8').encode(spinnerPageHtml),
-);

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -4,13 +4,10 @@ import flatMap from 'lodash/flatMap';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 import uniq from 'lodash/uniq';
-import base64 from 'base64-js';
-import {TextEncoder} from 'text-encoding';
 import loopBreaker from 'loop-breaker';
 import libraries from '../config/libraries';
 import previewFrameLibraries from '../config/previewFrameLibraries';
 
-const textEncoder = new TextEncoder('utf-8');
 const parser = new DOMParser();
 
 const sourceDelimiter = '/*__POPCODESTART__*/';
@@ -204,12 +201,9 @@ class PreviewGenerator {
   }
 
   _attachCssLibrary(css) {
-    const linkTag = this.previewDocument.createElement('link');
-    linkTag.rel = 'stylesheet';
-
-    const base64encoded = base64.fromByteArray(textEncoder.encode(css));
-    linkTag.href = `data:text/css;charset=utf-8;base64,${base64encoded}`;
-    this._previewHead.appendChild(linkTag);
+    const styleTag = this.previewDocument.createElement('style');
+    styleTag.textContent = String(css);
+    this._previewHead.appendChild(styleTag);
   }
 
   _attachJavascriptLibrary(javascript) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8019,7 +8019,7 @@ tempfile@^1.1.1:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
 
-text-encoding@0.6.4, text-encoding@^0.6.0:
+text-encoding@0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 


### PR DESCRIPTION
Only one remaining place used data URIs, and it wasn’t particularly
necessary—link tags to include CSS libraries in the header. Instead just
use a `<style>` tag and inline the CSS.

Fixes #997 