### PR TITLE
Fix #584 text-shadow with multiple values

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "bugs": "https://trello.com/b/ONaFg6wh/popcode",
   "license": "MIT",
   "dependencies": {
-    "PrettyCSS": "^0.3.13",
+    "PrettyCSS": "^0.3.15",
     "ajv": "^5.2.2",
     "array-to-sentence": "^1.1.0",
     "bowser": "^1.4.5",

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -53,7 +53,8 @@ const errorMap = {
   },
 
   'extra-tokens-after-value': (error, source) => {
-    const lineNumber = error.token.line;
+    const errorToken = error.token;
+    const lineNumber = errorToken.line;
 
     if (lineNumber > 1) {
       const lines = source.split('\n');
@@ -61,7 +62,7 @@ const errorMap = {
       const thisLine = lines[lineNumber - 1];
 
       if (
-        error.token.charNum - 1 === /\S/.exec(thisLine).index &&
+        errorToken.charNum - 1 === /\S/.exec(thisLine).index &&
         !endsWith(trim(previousLine), ';')
       ) {
         return {
@@ -74,7 +75,7 @@ const errorMap = {
 
     return ({
       reason: 'extra-tokens-after-value',
-      payload: {token: error.token.content},
+      payload: {token: errorToken.content},
     });
   },
 

--- a/test/unit/validations/css.js
+++ b/test/unit/validations/css.js
@@ -26,6 +26,15 @@ test('valid filter', validationTest(
   css,
 ));
 
+test('valid text-shadow declaration', validationTest(
+  `p {
+    text-shadow: rgba(0,0,0,0.1) 0 -5px, rgba(0,0,0,0.1) 0 -1px, \
+     rgba(255,255,255,0.1) 1px 0, rgba(255,255,255,0.1) 0 1px, \
+     rgba(0,0,0,0.1) -1px -1px, rgba(255,255,255,0.1) 1px 1px; 
+  }`,
+  css,
+));
+
 test('bogus flex value', validationTest(
   '.flex-item { flex: bogus; }',
   css,

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,11 +30,11 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-PrettyCSS@^0.3.13:
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/PrettyCSS/-/PrettyCSS-0.3.14.tgz#e71372fac131b7333af4c3f64e356e67551b9ba5"
+PrettyCSS@^0.3.15:
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/PrettyCSS/-/PrettyCSS-0.3.15.tgz#5f7e4690b9957737972b87ce950095a762b085d3"
   dependencies:
-    option-parser "~0.1.3"
+    option-parser "~1.0.0"
 
 abbrev@1:
   version "1.1.0"
@@ -5943,9 +5943,9 @@ optimist@>=0.3.4, optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-option-parser@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/option-parser/-/option-parser-0.1.3.tgz#cfe33c0fe95f805d9c0ac79e91224bbfa26a9c17"
+option-parser@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/option-parser/-/option-parser-1.0.0.tgz#9d470f969b7cb0cd2bb5b75e998be9961ba57206"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
Fixes bug https://github.com/popcodeorg/popcode/issues/584

Gave commas between CSS parenthesis statements like `rgba` leeway in the PrettyCSS validation.

I found that doing so inadvertently created another bug where multiple commas would flag as valid. I added another check to deal with this as well as added the requisite validations in the test case.