### PR TITLE
Reduce bundle size a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
 - yarn check
 - yarn test
 - gulp build --production
+- bundlesize
 before_deploy:
 - gulp syncFirebase
 deploy:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* eslint-disable comma-dangle */
 /* eslint-disable import/unambiguous */
 /* eslint-disable import/no-commonjs */
 /* eslint-disable import/no-nodejs-modules */
@@ -53,22 +52,22 @@ gulp.task('env', () => {
 
 gulp.task('static', () => gulp.
   src(path.join(staticDir, '**/*')).
-  pipe(gulp.dest(distDir))
+  pipe(gulp.dest(distDir)),
 );
 
 gulp.task('fonts', () => gulp.
   src([
     path.join(
       bowerComponents,
-      'inconsolata-webfont/fonts/inconsolata-regular.*'
+      'inconsolata-webfont/fonts/inconsolata-regular.*',
     ),
     path.join(bowerComponents, 'fontawesome/fonts/fontawesome-webfont.*'),
     path.join(
       bowerComponents,
-      'roboto-webfont-bower/fonts/Roboto-{Bold,Regular}-webfont.*'
+      'roboto-webfont-bower/fonts/Roboto-{Bold,Regular}-webfont.*',
     ),
   ]).
-  pipe(gulp.dest(path.join(distDir, 'fonts')))
+  pipe(gulp.dest(path.join(distDir, 'fonts'))),
 );
 
 gulp.task('css', () => {
@@ -99,7 +98,7 @@ gulp.task('js', ['env'], () => {
       compress: {warnings: false},
       output: {comments: false},
       sourceMap: true,
-    })
+    }),
   );
 
   return pify(webpack)(productionWebpackConfig);
@@ -109,7 +108,7 @@ gulp.task('build', ['static', 'fonts', 'css', 'js']);
 
 gulp.task('syncFirebase', async() => {
   const data = await pify(fs).readFile(
-    path.resolve(__dirname, 'config/firebase-auth.json')
+    path.resolve(__dirname, 'config/firebase-auth.json'),
   );
   const firebaseSecret = process.env.FIREBASE_SECRET;
   if (!firebaseSecret) {
@@ -152,8 +151,8 @@ gulp.task('browserSync', ['static'], () => {
           {
             lazy: false,
             stats: 'errors-only',
-          }
-        )
+          },
+        ),
       ],
     },
   });
@@ -165,6 +164,6 @@ gulp.task('purgeCache', () =>
     key: process.env.CLOUDFLARE_KEY,
   }).zones.purgeCache(
     process.env.CLOUDFLARE_ZONE,
-    {purge_everything: true}
-  )
+    {purge_everything: true},
+  ),
 );

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,9 +22,7 @@ module.exports = function(config) {
 
     frameworks: ['tap', 'sinon'],
 
-    files: [
-      'test/index.js',
-    ],
+    files: ['test/index.js'],
 
     preprocessors: {
       'test/index.js': ['webpack', 'sourcemap'],

--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
     "lint": "eslint --ext .js,.jsx --plugin react src test *.js && stylelint src/**/*.css",
     "fixlint": "eslint --ext .js,.jsx --plugin react --fix src test *.js",
     "toc": "doctoc README.md --github --title '## Table of Contents'",
-    "preview": "rm -rvf dist && gulp build --production && static dist"
+    "preview": "rm -rvf dist && gulp build --production && static dist",
+    "analyze-bundle": "gulp js --production && source-map-explorer ./dist/application.js"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -163,8 +163,8 @@
     "dev": "yarn install && gulp dev",
     "test": "karma start --single-run --no-auto-watch",
     "autotest": "karma start --no-single-run --auto-watch",
-    "lint": "eslint --ext .js,.jsx --plugin react src test && stylelint src/**/*.css",
-    "fixlint": "eslint --ext .js,.jsx --plugin react --fix src test",
+    "lint": "eslint --ext .js,.jsx --plugin react src test *.js && stylelint src/**/*.css",
+    "fixlint": "eslint --ext .js,.jsx --plugin react --fix src test *.js",
     "toc": "doctoc README.md --github --title '## Table of Contents'",
     "preview": "rm -rvf dist && gulp build --production && static dist"
   },

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "react-addons-perf": "^15.4.2",
     "redux-saga-test-plan": "^3.0.2",
     "sinon": "^3.2.1",
+    "source-map-explorer": "^1.4.0",
     "string-replace-loader": "^1.0.5",
     "stylelint-selector-bem-pattern": "^1.0.0",
     "substitute-loader": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "brfs": "^1.4.3",
     "browser-sync": "^2.14.3",
     "bulkify": "^1.4.2",
+    "bundlesize": "^0.14.4",
     "check-dependencies": "^1.0.1",
     "circular-dependency-plugin": "^4.2.0",
     "cloudflare": "^2.1.1",
@@ -238,5 +239,8 @@
   },
   "optionalDependencies": {
     "fsevents": "*"
-  }
+  },
+  "bundlesize": [{
+    "path": "./dist/*application.js"
+  }]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,6 +206,11 @@ module.exports = {
         ),
         use: ['null-loader'],
       },
+      {
+        test: /\.js$/,
+        include: matchModule('moment/locale'),
+        use: ['null-loader'],
+      },
     ],
   },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 /* eslint-disable import/unambiguous */
 /* eslint-disable import/no-commonjs */
-/* eslint-disable comma-dangle */
 
 const fs = require('fs');
 const path = require('path');
@@ -22,13 +21,13 @@ if (process.env.DEBUG === 'true') {
   targets = {browsers: 'last 1 Chrome version'};
 } else {
   targets = JSON.parse(
-    fs.readFileSync(path.resolve(__dirname, 'config/browsers.json'))
+    fs.readFileSync(path.resolve(__dirname, 'config/browsers.json')),
   );
 }
 const babelrc = {
   presets: [
     'react',
-    ['env', {targets, modules: false}]
+    ['env', {targets, modules: false}],
   ],
   compact: false,
   cacheDirectory: true,
@@ -42,10 +41,10 @@ const babelrc = {
 
 function matchModule(modulePath) {
   const modulePattern = new RegExp(
-    escapeRegExp(path.join('/node_modules', modulePath))
+    escapeRegExp(path.join('/node_modules', modulePath)),
   );
   const moduleDependencyPattern = new RegExp(
-    escapeRegExp(path.join('/node_modules', modulePath, 'node_modules'))
+    escapeRegExp(path.join('/node_modules', modulePath, 'node_modules')),
   );
 
   return filePath =>
@@ -55,7 +54,7 @@ function matchModule(modulePath) {
 function directoryContentsExcept(directory, exceptions) {
   const fullExceptions = map(
     exceptions,
-    exception => path.resolve(directory, exception)
+    exception => path.resolve(directory, exception),
   );
 
   return filePath =>
@@ -80,7 +79,7 @@ module.exports = {
         ],
         use: [
           {loader: 'babel-loader', options: babelrc},
-          'eslint-loader'
+          'eslint-loader',
         ],
       },
       {
@@ -118,10 +117,12 @@ module.exports = {
       },
       {
         include: path.resolve(__dirname, 'locales'),
-        use: [{
-          loader: 'i18next-resource-store-loader',
-          options: 'include=\\.json$',
-        }],
+        use: [
+          {
+            loader: 'i18next-resource-store-loader',
+            options: 'include=\\.json$',
+          },
+        ],
       },
       {
         include: matchModule('htmllint'),
@@ -134,29 +135,31 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        include: [
-          matchModule('htmllint'),
-        ],
-        use: [{
-          loader: 'string-replace-loader',
-          options: {
-            search: 'require(plugin)',
-            replace: 'undefined',
+        include: [matchModule('htmllint')],
+        use: [
+          {
+            loader: 'string-replace-loader',
+            options: {
+              search: 'require(plugin)',
+              replace: 'undefined',
+            },
           },
-        }],
+        ],
       },
       {
         test: /\.js$/,
         include: [
           path.resolve(
             __dirname,
-            'node_modules/stylelint/lib/utils/isAutoprefixable'
+            'node_modules/stylelint/lib/utils/isAutoprefixable',
           ),
         ],
-        use: [{
-          loader: 'substitute-loader',
-          options: {content: '() => false'},
-        }],
+        use: [
+          {
+            loader: 'substitute-loader',
+            options: {content: '() => false'},
+          },
+        ],
       },
       {
         test: /\.js$/,
@@ -199,10 +202,10 @@ module.exports = {
           [
             'index.js',
             'declaration-block-trailing-semicolon/index.js',
-          ]
+          ],
         ),
         use: ['null-loader'],
-      }
+      },
     ],
   },
 
@@ -214,7 +217,7 @@ module.exports = {
       LOG_REDUX_ACTIONS: 'false',
       NODE_ENV: 'development',
       WARN_ON_DROPPED_ERRORS: 'false',
-      GOOGLE_ANALYTICS_TRACKING_ID: 'UA-90316486-2'
+      GOOGLE_ANALYTICS_TRACKING_ID: 'UA-90316486-2',
     }),
     new CircularDependencyPlugin({
       exclude: /node_modules/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,6 +1480,10 @@ bs-recipes@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.4.tgz#0d2d4d48a718c8c044769fdc4f89592dc8b69585"
 
+btoa@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.1.2.tgz#3e40b81663f81d2dd6596a4cb714a8dc16cfabe0"
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -2067,7 +2071,7 @@ conventional-commits-parser@^0.1.2:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@1.X, convert-source-map@^1.5.0:
+convert-source-map@1.X, convert-source-map@^1.1.1, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
@@ -2479,6 +2483,10 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+docopt@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"
 
 doctoc@^1.2.0:
   version "1.3.0"
@@ -3290,6 +3298,12 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file-url@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-1.1.0.tgz#a0f9cf3eb6904c9b1d3a6790b83a976fc40217bb"
+  dependencies:
+    meow "^3.7.0"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -5935,6 +5949,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
+
 openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
@@ -7507,6 +7525,10 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.0, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
@@ -7838,6 +7860,20 @@ sort-keys@^1.0.0:
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-map-explorer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-explorer/-/source-map-explorer-1.4.0.tgz#58b503045d0d6907d9d9a7bb4e2131b5686f7a69"
+  dependencies:
+    btoa "^1.1.2"
+    convert-source-map "^1.1.1"
+    docopt "^0.6.2"
+    file-url "^1.0.1"
+    glob "^7.1.2"
+    open "0.0.5"
+    source-map "^0.5.1"
+    temp "^0.8.3"
+    underscore "^1.8.3"
 
 source-map-resolve@^0.3.0:
   version "0.3.1"
@@ -8316,6 +8352,13 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
 tempfile@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
@@ -8599,7 +8642,7 @@ underscore@1.7.x:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
-underscore@~1.8.3:
+underscore@^1.8.3, underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,11 +394,18 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-axios@^0.15.2:
+axios@0.15.3, axios@^0.15.2:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
   dependencies:
     follow-redirects "1.0.0"
+
+axios@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.16.2.tgz#ba4f92f17167dfbab40983785454b9ac149c3c6d"
+  dependencies:
+    follow-redirects "^1.2.3"
+    is-buffer "^1.1.5"
 
 babel-cli@^6.23.0:
   version "6.26.0"
@@ -1535,9 +1542,27 @@ bulkify@^1.4.2:
     static-module "^1.1.2"
     through2 "~0.4.1"
 
+bundlesize@^0.14.4:
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/bundlesize/-/bundlesize-0.14.4.tgz#ad53c4a1a4ba71810967575c550bc04f3d18d421"
+  dependencies:
+    axios "^0.16.2"
+    bytes "^2.5.0"
+    ci-env "^1.4.0"
+    commander "^2.11.0"
+    github-build "^1.2.0"
+    glob "^7.1.2"
+    gzip-size "^3.0.0"
+    prettycli "^1.4.3"
+    read-pkg-up "^2.0.0"
+
 bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
+
+bytes@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
 
 cache-base@^0.8.4:
   version "0.8.5"
@@ -1642,6 +1667,14 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
+chalk@2.1.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1651,14 +1684,6 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 character-entities-html4@^1.0.0:
   version "1.1.1"
@@ -1701,6 +1726,10 @@ chokidar@1.7.0, chokidar@^1.4.1, chokidar@^1.6.1, chokidar@^1.7.0:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
+
+ci-env@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ci-env/-/ci-env-1.4.0.tgz#7e4c4ed1d10cedce734293e04dde94fcdfe74d67"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -2304,7 +2333,7 @@ debug-fabulous@>=0.1.1:
     memoizee "^0.4.5"
     object-assign "4.1.0"
 
-debug@2, debug@2.6.8, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@2, debug@2.6.8, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.5, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -2586,6 +2615,10 @@ duplexer2@0.0.2, duplexer2@~0.0.2:
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 easy-extender@2.3.2:
   version "2.3.2"
@@ -3452,6 +3485,12 @@ follow-redirects@1.0.0:
   dependencies:
     debug "^2.2.0"
 
+follow-redirects@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.2.4.tgz#355e8f4d16876b43f577b0d5ce2668b9723214ea"
+  dependencies:
+    debug "^2.4.5"
+
 for-each@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
@@ -3676,6 +3715,12 @@ github-api@^3.0.0:
     debug "^2.2.0"
     js-base64 "^2.1.9"
     utf8 "^2.1.1"
+
+github-build@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/github-build/-/github-build-1.2.0.tgz#b0bdb705ae4088218577e863c1a301030211051f"
+  dependencies:
+    axios "0.15.3"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3928,6 +3973,12 @@ gulplog@^1.0.0:
   resolved "https://registry.yarnpkg.com/gulplog/-/gulplog-1.0.0.tgz#e28c4d45d05ecbbed818363ce8f9c5926229ffe5"
   dependencies:
     glogg "^1.0.0"
+
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  dependencies:
+    duplexer "^0.1.1"
 
 handlebars@^4.0.2:
   version "4.0.10"
@@ -6791,6 +6842,12 @@ preserve@^0.2.0:
 pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
+
+prettycli@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/prettycli/-/prettycli-1.4.3.tgz#b28ec2aad9de07ae1fd75ef294fb54cbdee07ed5"
+  dependencies:
+    chalk "2.1.0"
 
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.7"


### PR DESCRIPTION
Step 1 of N in reducing the size of the initial bundle load. This removes non-English `moment` locales (since English is currently the only supported localization across the application). Trims bundle size by about 7%.

Also adds `source-map-explorer`, which is proving to be a really useful tool for tracking down the biggest contributors to bundle size.

Relevant to #348 