### PR TITLE
Code improvements to click-outside

### DIFF
--- a/src/components/TopBar/ProjectPicker.jsx
+++ b/src/components/TopBar/ProjectPicker.jsx
@@ -24,7 +24,7 @@ const ProjectPicker = createMenu({
       </MenuItem>
     ));
   },
-})(ProjectPickerButton, ProjectPreview);
+})(ProjectPickerButton);
 
 ProjectPicker.propTypes = {
   currentProjectKey: PropTypes.string,

--- a/src/components/TopBar/createMenu.jsx
+++ b/src/components/TopBar/createMenu.jsx
@@ -59,7 +59,7 @@ export default function createMenu({
     };
   }
 
-  return function createMenuWithMappedProps(Label) {
+  return function createMenuWithMappedProps(MenuLaunchButton) {
     function Menu(props) {
       if (!isVisible(props)) {
         return null;
@@ -84,7 +84,7 @@ export default function createMenu({
           )}
           onClick={onToggle}
         >
-          <Label {...props} />
+          <MenuLaunchButton {...props} />
           {menu}
         </div>
       );


### PR DESCRIPTION
Followup to #1016 based on post-merge code review:

* Better parameter name for wrapped component in `createMenu`
* Remove unused second argument to `createMenu` in `ProjectPicker` component