### PR TITLE
Styling tweaks to instructions markdown

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -250,6 +250,24 @@ body {
   color: black;
   overflow: scroll;
   padding: 1rem;
+
+  /* postcss-bem-linter: ignore */
+  & img {
+    max-width: 100%;
+  }
+
+  /* postcss-bem-linter: ignore */
+  & pre code.hljs {
+    /* Highlight.js puts `style="display: inline;"` on code blocks which causes
+    the lines to collapse into eachother */
+    display: inline-block !important;
+    white-space: pre-wrap;
+  }
+
+  /* postcss-bem-linter: ignore */
+  & p code.hljs {
+    padding: 0;
+  }
 }
 
 /** @define project-preview */
@@ -595,11 +613,4 @@ body {
   font-weight: normal;
   user-select: none;
   text-decoration: none;
-}
-
-/* stylelint-disable-next-line plugin/selector-bem-pattern */
-code.hljs {
-  /* Highlight.js puts `style="display: inline;"` on code blocks which causes
-   the lines to collapse into eachother */
-  display: inline-block !important;
 }


### PR DESCRIPTION
Makes 3 style improvements, including one suggested by https://github.com/popcodeorg/popcode/issues/1032. Thanks @jwang1919 for the test gist!

1. ([gist](https://gist.github.com/inlinestyle/882e2a262c80045163efca50e519f34f))  Constrain width of images
![image](https://user-images.githubusercontent.com/1098749/30526888-35b8bf64-9bf0-11e7-8a18-0daec71999ff.png)
2. ([gist](https://gist.github.com/inlinestyle/882e2a262c80045163efca50e519f34f)) Constrain width of code blocks via `whitespace: pre-wrap` (both visible code blocks are wrapped on the second line)
![image](https://user-images.githubusercontent.com/1098749/30526899-49dcd930-9bf0-11e7-9028-6705616554db.png)
3. ([gist](https://gist.github.com/jwang1919/ca79bdb9b543ae6e6bac57d28e14c1cf)) Vertically center inline code fragments and prevent them from bleeding into adjacent lines of text
![image](https://user-images.githubusercontent.com/1098749/30526877-23a14c74-9bf0-11e7-8111-36be9e4ec750.png)
