### PR TITLE
Fall back to ZeroClipboard if native clipboard API is unavailable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,10 @@ gulp.task('env', () => {
 });
 
 gulp.task('static', () => gulp.
-  src(path.join(staticDir, '**/*')).
+  src([
+    path.join(staticDir, '**/*'),
+    path.join('node_modules/zeroclipboard/dist/ZeroClipboard.swf'),
+  ]).
   pipe(gulp.dest(distDir)),
 );
 

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -36,6 +36,7 @@
     "repo-export-complete": "Your repo export is ready!",
     "snapshot-created": "Your snapshot is ready!",
     "click-to-copy": "Click here to copy it",
+    "copy-prompt": "Press ⌘-C to copy this link!",
     "snapshot-export-error": "Something went wrong trying to create that snapshot. Please try again.",
     "snapshot-import-error": "Something went wrong trying to load that snapshot. Please try again.",
     "snapshot-not-found": "That snapshot doesn’t seem to exist. Check the link and try again."

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "brace": "^0.10.0",
     "bugsnag-js": "^3.0.1",
     "classnames": "^2.1.5",
+    "clipboard": "^1.7.1",
     "css": "^2.2.1",
     "enumify": "^1.0.4",
     "es6-set": "^0.1.4",
@@ -138,7 +139,6 @@
     "prop-types": "^15.5.10",
     "qs": "^6.1.0",
     "react": "^15.4.1",
-    "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "^15.4.1",
     "react-draggable": "^3.0.3",
     "react-ga": "^2.1.2",
@@ -161,7 +161,8 @@
     "strip-markdown": "^3.0.0",
     "stylelint": "^8.0.0",
     "uuid": "^3.1.0",
-    "void-elements": "^3.1.0"
+    "void-elements": "^3.1.0",
+    "zeroclipboard": "^2.3.0"
   },
   "engines": {
     "node": "8.5.0",

--- a/src/components/CopyToClipboard.jsx
+++ b/src/components/CopyToClipboard.jsx
@@ -1,0 +1,74 @@
+import bindAll from 'lodash/bindAll';
+import Clipboard from 'clipboard';
+import noop from 'lodash/noop';
+import React from 'react';
+import PropTypes from 'prop-types';
+import ZeroClipboard from 'zeroclipboard';
+
+export default class CopyToClipboard extends React.Component {
+  constructor() {
+    super();
+    bindAll(this, '_handleClick', '_handleChildLifecycle');
+  }
+
+  _handleClick() {
+    if (Clipboard.isSupported()) {
+      return;
+    }
+
+    const {promptText, text} = this.props;
+    prompt(promptText, text); // eslint-disable-line no-alert
+  }
+
+  _handleChildLifecycle(element) {
+    if (Clipboard.isSupported()) {
+      this._attachClipboard(element);
+    } else {
+      this._attachZeroClipboard(element);
+    }
+  }
+
+  _attachClipboard(element) {
+    if (element) {
+      this._clipboard = new Clipboard(element, {text: () => this.props.text});
+      this._clipboard.on('success', this.props.onCopy);
+    } else {
+      this._clipboard.destroy();
+      Reflect.deleteProperty(this, 'clipboard');
+    }
+  }
+
+  _attachZeroClipboard(element) {
+    if (element) {
+      this._zeroClipboard = new ZeroClipboard(element);
+      this._zeroClipboard.on('copy', (event) => {
+        const clipboard = event.clipboardData;
+        clipboard.setData('text/plain', this.props.text);
+        this.props.onCopy();
+      });
+    } else {
+      this._zeroClipboard.destroy();
+      Reflect.deleteProperty(this, '_zeroClipboard');
+    }
+  }
+
+  render() {
+    const {children} = this.props;
+
+    return React.cloneElement(
+      React.Children.only(children),
+      {onClick: this._handleClick, ref: this._handleChildLifecycle},
+    );
+  }
+}
+
+CopyToClipboard.propTypes = {
+  children: PropTypes.element.isRequired,
+  promptText: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  onCopy: PropTypes.func,
+};
+
+CopyToClipboard.defaultProps = {
+  onCopy: noop,
+};

--- a/src/components/notifications/SnapshotNotification.jsx
+++ b/src/components/notifications/SnapshotNotification.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
 import partial from 'lodash/partial';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
+import CopyToClipboard from '../CopyToClipboard';
 
 export default function SnapshotNotification({
   metadata: {isCopied},
@@ -25,7 +25,8 @@ export default function SnapshotNotification({
     <span>
       {t('notifications.snapshot-created')}{' '}
       <CopyToClipboard
-        text={uri}
+        promptText={t('notifications.copy-prompt')}
+        text={uri.href}
         onCopy={
           partial(onUpdateMetadata, {isCopied: true})
         }

--- a/src/init/ZeroClipboard.js
+++ b/src/init/ZeroClipboard.js
@@ -1,0 +1,6 @@
+import ZeroClipboard from 'zeroclipboard';
+
+ZeroClipboard.config({
+  bubbleEvents: false,
+  cacheBust: false,
+});

--- a/src/init/index.js
+++ b/src/init/index.js
@@ -1,3 +1,4 @@
 import 'babel-polyfill';
 import 'es6-set/implement';
 import './DOMParserShim';
+import './ZeroClipboard';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,6 +1783,14 @@ cli@~1.0.0:
     exit "0.1.2"
     glob "^7.1.1"
 
+clipboard@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -2112,12 +2120,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-copy-to-clipboard@^3:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
-  dependencies:
-    toggle-selection "^1.0.3"
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -2443,6 +2445,10 @@ del@^2.0.2:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.1.3.tgz#9a8251a777d7025faa55737bc3b071742127a9fd"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3862,6 +3868,12 @@ glogg@^1.0.0:
   resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.0.tgz#7fe0f199f57ac906cf512feead8f90ee4a284fc5"
   dependencies:
     sparkles "^1.0.0"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 got@^6.3.0:
   version "6.7.1"
@@ -7044,13 +7056,6 @@ react-addons-perf@^15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-copy-to-clipboard@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.0.tgz#23ccdd7c4d9ec2cc763839e2a55b1220aeb4f33d"
-  dependencies:
-    copy-to-clipboard "^3"
-    prop-types "^15.5.8"
-
 react-dom@^15.4.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
@@ -7643,6 +7648,10 @@ samsam@1.x, samsam@^1.1.3:
 sax@>=0.6.0, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.4.1:
   version "5.4.1"
@@ -8521,6 +8530,10 @@ timers-ext@^0.1.2:
     es5-ext "~0.10.14"
     next-tick "1"
 
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
+
 tmp@0.0.31, tmp@^0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
@@ -8573,10 +8586,6 @@ to-regex@^3.0.1:
     define-property "^0.2.5"
     extend-shallow "^2.0.1"
     regex-not "^1.0.0"
-
-toggle-selection@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 topo@1.x.x:
   version "1.1.0"
@@ -9345,3 +9354,7 @@ yargs@~3.10.0:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+zeroclipboard@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/zeroclipboard/-/zeroclipboard-2.3.0.tgz#592ebd833a4308688b0739697d3dbf989002c9af"


### PR DESCRIPTION
Many classrooms use browser versions that are too old to support the native clipboard API. While `copy-to-clipboard` falls back directly to showing a prompt, we can provide a better UI for most older browsers by falling back to `ZeroClipboard`, which uses Flash to create a seamless copy-paste experience.

From a user standpoint, the ZeroClipboard workflow is exactly the same as the modern browser workflow. If ZeroClipboard is unavailable, we then finally fall back to the prompt approach.

Fixes #1038 