### PR TITLE
Fix dynamic flex in older browsers

### DIFF
--- a/config/browsers.json
+++ b/config/browsers.json
@@ -1,5 +1,5 @@
 {
   "firefox": "28",
-  "chrome": "22",
+  "chrome": "23",
   "safari": "7.1"
 }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "htmllint": "https://github.com/htmllint/htmllint.git#eee0dd1",
     "i18next": "^9.0.0",
     "immutable": "^3.7.5",
+    "inline-style-prefixer": "^3.0.8",
     "js-cookie": "^2.1.3",
     "jshint": "^2.9.3",
     "keymirror": "^0.1.1",

--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import prefixAll from 'inline-style-prefixer/static';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {t} from 'i18next';
 
 function EditorContainer({children, language, source, style, onHide, onRef}) {
@@ -17,7 +18,7 @@ function EditorContainer({children, language, source, style, onHide, onRef}) {
     <div
       className="editors__editor-container"
       ref={onRef}
-      style={style}
+      style={prefixAll(style)}
     >
       <div
         className="editors__label editors__label_expanded"

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import prefixAll from 'inline-style-prefixer/static';
 import {t} from 'i18next';
 import {DraggableCore} from 'react-draggable';
 import bindAll from 'lodash/bindAll';
@@ -127,7 +128,11 @@ export default class EditorsColumn extends React.Component {
     }
 
     return (
-      <div className="environment__column" ref={onRef} style={style}>
+      <div
+        className="environment__column"
+        ref={onRef}
+        style={prefixAll(style)}
+      >
         <div className="environment__columnContents editors">{children}</div>
       </div>
     );

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import prefixAll from 'inline-style-prefixer/static';
 import ErrorReport from '../containers/ErrorReport';
 import Preview from '../containers/Preview';
 
@@ -12,9 +13,9 @@ export default function Output({
     <div
       className="environment__column"
       ref={onRef}
-      style={Object.assign({}, style, {
+      style={prefixAll(Object.assign({}, style, {
         pointerEvents: ignorePointerEvents ? 'none' : 'all',
-      })}
+      }))}
     >
       <div className="environment__columnContents output">
         <Preview />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,7 +1296,7 @@ bower@^1.7.9:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.0.tgz#55dbebef0ad9155382d9e9d3e497c1372345b44a"
 
-bowser@^1.4.5:
+bowser@^1.4.5, bowser@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.3.tgz#504bdb43118ca8db9cbbadf28fd60f265af96e4f"
 
@@ -2226,6 +2226,12 @@ css-color-function@^1.3.0:
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
+
+css-in-js-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
 
 css-unit-converter@^1.1.1:
   version "1.1.1"
@@ -4263,6 +4269,10 @@ https-proxy-agent@1.0.0, https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 i18next-resource-store-loader@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/i18next-resource-store-loader/-/i18next-resource-store-loader-0.1.2.tgz#0e2b7aa498e47a3d89cb2f28dcc58fe3ff502b26"
@@ -4345,6 +4355,13 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inline-style-prefixer@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
+  dependencies:
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@^3.0.6:
   version "3.2.3"


### PR DESCRIPTION
We are changing flex-related values in JavaScript, but we support browsers that only take flex properties with vendor prefixes. So, use the `inline-style-prefixer` library to add appropriate vendor prefixes to the JavaScript style objects.

Also drop support for Chrome 22, which additionally has an outdated and overly strict interpretation of percentage heights that breaks Popcode’s layout. Happily, Chrome 23 works fine. According to Google Analytics, Popcode has only been loaded once using Chrome 22 since May 1, and I’m guessing this was me in BrowserStack.