### PR TITLE
Restore latest htmllint, disable rules by default

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -118,7 +118,9 @@
       "only-head-body-in-html": "Only `<head>` and `<body>` tags may be direct children of `<html>`",
       "invalid-tag-in-head": "This tag is not allowed inside the `<head>`.",
       "only-one-head-and-body": "You may only have one `<head>` and one `<body>` tag in your document.",
-      "misplaced-close-tag": "This closing `</{{-open}}>` tag should go to before the `</{{-close}}>` tag on line {{-mismatch}}."
+      "misplaced-close-tag": "This closing `</{{-open}}>` tag should go to before the `</{{-close}}>` tag on line {{-mismatch}}.",
+      "duplicated-class": "You shouldn’t have the class `{{-classes}}` more than once on the same element.",
+      "self-closing-tag": "You don’t need to end self-closing tags with `/>`. Just use `<{{-tag}}>`."
     },
     "css": {
       "missing-opening-curly": "You should have a `{` at the end of this line.",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "hast-util-sanitize": "^1.1.1",
     "highlight.js": "^9.12.0",
     "html-inspector": "^0.8.2",
-    "htmllint": "~0.5.0",
+    "htmllint": "https://github.com/htmllint/htmllint.git#eee0dd1",
     "i18next": "^9.0.0",
     "immutable": "^3.7.5",
     "inline-style-prefixer": "^3.0.8",

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -101,6 +101,8 @@ const htmlLintOptions = {
   'indent-style': 'spaces',
   'indent-width': 4,
   'line-end-style': false,
+  'head-valid-content-model': true,
+  'html-valid-content-model': true,
   'tag-bans': [
     'b',
     'big',

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -1,3 +1,6 @@
+import clone from 'lodash/clone';
+import defaults from 'lodash/defaults';
+import reduce from 'lodash/reduce';
 import Validator from '../Validator';
 import importLinters from '../importLinters';
 
@@ -55,7 +58,8 @@ const errorMap = {
   E018: (error, source) => {
     const lines = source.split('\n');
     const tagNameExpr = /(.*?)\s*\/>/;
-    const [, tag] = tagNameExpr.exec(lines[error.line - 1].slice(error.column));
+    const [, tag] =
+      tagNameExpr.exec(lines[error.line - 1].slice(error.column));
 
     return {
       reason: 'self-closing-tag',
@@ -108,26 +112,14 @@ const htmlLintOptions = {
   'attr-no-dup': true,
   'attr-quote-style': 'quoted',
   'attr-req-value': true,
-  'attr-validate': false,
   'class-no-dup': true,
   'doctype-first': true,
   'doctype-html5': true,
   'head-req-title': true,
   'head-valid-content-model': true,
   'html-valid-content-model': true,
-  'id-class-no-ad': false,
-  'id-class-style': false,
   'id-no-dup': true,
-  'img-req-alt': false,
   'img-req-src': true,
-  'indent-style': false,
-  'indent-width': false,
-  'input-radio-req-name': false,
-  'input-req-label': false,
-  'label-req-for': false,
-  'lang-style': false,
-  'line-end-style': false,
-  'spec-char-escape': false,
   'tag-bans': [
     'b',
     'big',
@@ -137,11 +129,9 @@ const htmlLintOptions = {
     'tt',
     'strike',
   ],
-  'tag-close': false,
   'tag-name-match': true,
   'tag-name-lowercase': true,
   'tag-self-close': 'never',
-  'title-max-length': false,
   'title-no-dup': true,
 };
 
@@ -152,8 +142,14 @@ class HtmllintValidator extends Validator {
 
   async _getRawErrors() {
     const {htmllint} = await importLinters();
+    const options = reduce(
+      htmllint.rules,
+      (acc, {name}) => defaults(acc, {[name]: false}),
+      clone(htmlLintOptions),
+    );
+
     try {
-      const results = await htmllint(this._source, htmlLintOptions);
+      const results = await htmllint(this._source, options);
       return results;
     } catch (e) {
       return [];

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -52,9 +52,25 @@ const errorMap = {
 
   E017: () => ({reason: 'lower-case-tag-name'}),
 
+  E018: (error, source) => {
+    const lines = source.split('\n');
+    const tagNameExpr = /(.*?)\s*\/>/;
+    const [, tag] = tagNameExpr.exec(lines[error.line - 1].slice(error.column));
+
+    return {
+      reason: 'self-closing-tag',
+      payload: {tag},
+    };
+  },
+
   E027: () => ({reason: 'missing-title'}),
 
   E028: () => ({reason: 'duplicated-title'}),
+
+  E041: ({data: {classes}}) => ({
+    reason: 'duplicated-class',
+    payload: {classes},
+  }),
 
   E042: (error, source) => {
     const lines = source.split('\n');
@@ -91,18 +107,27 @@ const htmlLintOptions = {
   'attr-name-style': 'dash',
   'attr-no-dup': true,
   'attr-quote-style': 'quoted',
+  'attr-req-value': true,
+  'attr-validate': false,
+  'class-no-dup': true,
   'doctype-first': true,
   'doctype-html5': true,
   'head-req-title': true,
+  'head-valid-content-model': true,
+  'html-valid-content-model': true,
+  'id-class-no-ad': false,
   'id-class-style': false,
   'id-no-dup': true,
   'img-req-alt': false,
   'img-req-src': true,
-  'indent-style': 'spaces',
-  'indent-width': 4,
+  'indent-style': false,
+  'indent-width': false,
+  'input-radio-req-name': false,
+  'input-req-label': false,
+  'label-req-for': false,
+  'lang-style': false,
   'line-end-style': false,
-  'head-valid-content-model': true,
-  'html-valid-content-model': true,
+  'spec-char-escape': false,
   'tag-bans': [
     'b',
     'big',
@@ -115,7 +140,8 @@ const htmlLintOptions = {
   'tag-close': false,
   'tag-name-match': true,
   'tag-name-lowercase': true,
-  'title-max-length': 0,
+  'tag-self-close': 'never',
+  'title-max-length': false,
   'title-no-dup': true,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,7 +1527,7 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bulk-require@^1.0.0:
+bulk-require@^1.0.0, bulk-require@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bulk-require/-/bulk-require-1.0.1.tgz#cb3d039e698139a444fc574b261d6b3b2cf44c89"
   dependencies:
@@ -4176,14 +4176,14 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
-htmllint@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/htmllint/-/htmllint-0.5.0.tgz#4ba7c89907d9b990f7f6a88100fc1ca630b5a6e4"
+"htmllint@https://github.com/htmllint/htmllint.git#eee0dd1":
+  version "0.6.0"
+  resolved "https://github.com/htmllint/htmllint.git#eee0dd1ff154b320174528180009b601a4b4ef29"
   dependencies:
-    bulk-require "^1.0.0"
-    htmlparser2 "^3.7.3"
-    lodash "^4.3.0"
-    promise "^7.1.1"
+    bulk-require "^1.0.1"
+    htmlparser2 "^3.9.2"
+    lodash "^4.17.4"
+    promise "^8.0.1"
 
 htmlparser2@3.8.x:
   version "3.8.3"
@@ -4195,7 +4195,7 @@ htmlparser2@3.8.x:
     entities "1.0"
     readable-stream "1.1"
 
-htmlparser2@^3.7.3, htmlparser2@~3.9.2:
+htmlparser2@^3.9.2, htmlparser2@~3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -6903,6 +6903,12 @@ promise-retry@^1.1.1:
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+promise@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
   dependencies:
     asap "~2.0.3"
 


### PR DESCRIPTION
We had to temporarily roll `htmllint` back to version 0.5.0, because we discovered that when using the latest version, the interpreter will [lock up under certain circumstances](https://github.com/htmllint/htmllint/issues/209). Having dug deeper, I narrowed the issue down to a new rule, `attr-validate`, which can encounter catastrophic backtracking with the right invalid attribute.

By disabling `attr-validate`, we can go back to using latest `htmllint` without problems. However, I went a step further and future-proofed our `htmllint` validator by automatically disabling all rules that we don’t explicitly enable to use for validation. Thus we won’t get caught by a novel, default-enabled rule in the future.

Finally, while I was in there, set up a couple of new `htmllint` validations:

* `duplicated-class`, which disallows writing the same class name twice on the same element
* `self-closing-tag`, which bans explicit `/>` on self-closing tags