### PR TITLE
Prevent top bar zoom

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -116,7 +116,7 @@ body {
   background-color: var(--color-green);
   display: flex;
   flex: 0 0 auto;
-  font-size: 18px;
+  font-size: 2vh;
   font-weight: bold;
   align-items: center;
   padding: 0 1em;


### PR DESCRIPTION
Generally when we zoom in on Popcode, it’s because we need to see the editor/output more clearly. Expanding the size of the top bar just takes up valuable space.

So, use “one weird trick” to keep the top bar from growing: specify the base font size for the `top-bar` container in `vh` rather than `px`.  Since the rest of the top bar sizing is built around the base font size, the top bar stays the same size regardless of zoom.

Note that this doesn’t work in very old browsers, although it does work in Chrome 38, which is the oldest Chrome version that sees substantial usage with Popcode. It also doesn’t work in Safari. However in browsers where it doesn’t do what we want, it degrades gracefully (it looks fine normally, and the top bar still expands when you zoom in).

![](https://cl.ly/373G2R1F3K2g/Screen%20Recording%202017-10-04%20at%2020.31.gif)