### PR TITLE
Set NODE_ENV in actual environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - 8.5.0
 env:
   global:
+  - NODE_ENV=production
   - CXX=g++-4.8
   - LOG_REDUX_ACTIONS=false
   - FIREBASE_APP=popcode
@@ -24,13 +25,15 @@ addons:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.2
   - export PATH="$HOME/.yarn/bin:$PATH"
+install:
+  - yarn install --production=false --frozen-lockfile --non-interactive
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 script:
 - yarn check
 - yarn test
-- gulp build --production
+- gulp build
 - bundlesize
 before_deploy:
 - gulp syncFirebase

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,11 +7,9 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 const gulp = require('gulp');
-const yargs = require('yargs');
 const concat = require('gulp-concat');
 const sourcemaps = require('gulp-sourcemaps');
 const cssnano = require('cssnano');
-const gutil = require('gulp-util');
 const forOwn = require('lodash/forOwn');
 const git = require('git-rev-sync');
 const postcss = require('gulp-postcss');
@@ -45,9 +43,6 @@ forOwn(supportedBrowsers, (version, browser) => {
 
 gulp.task('env', () => {
   process.env.GIT_REVISION = git.short();
-  if (yargs.argv.production) {
-    process.env.NODE_ENV = 'production';
-  }
 });
 
 gulp.task('static', () => gulp.
@@ -72,7 +67,7 @@ gulp.task('fonts', () => gulp.
 
 gulp.task('css', () => {
   const processors = [cssnext({browsers: cssnextBrowsers})];
-  if (gutil.env.production) {
+  if (process.env.NODE_ENV === 'production') {
     processors.push(cssnano());
   }
 

--- a/package.json
+++ b/package.json
@@ -212,7 +212,6 @@
     "gulp-concat": "^2.6.0",
     "gulp-postcss": "^7.0.0",
     "gulp-sourcemaps": "^2.6.0",
-    "gulp-util": "^3.0.7",
     "i18next-resource-store-loader": "^0.1.1",
     "immutable-devtools": "0.0.7",
     "imports-loader": "^0.7.1",
@@ -245,8 +244,7 @@
     "transform-loader": "^0.2.3",
     "webpack": "^3.1.0",
     "webpack-dev-middleware": "^1.8.2",
-    "webpack-hot-middleware": "^2.12.2",
-    "yargs": "^8.0.1"
+    "webpack-hot-middleware": "^2.12.2"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,7 +3933,7 @@ gulp-sourcemaps@^2.6.0:
     through2 "2.X"
     vinyl "1.X"
 
-gulp-util@^3.0.0, gulp-util@^3.0.7, gulp-util@^3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -9332,7 +9332,7 @@ yargs@6.4.0:
     y18n "^3.2.1"
     yargs-parser "^4.1.0"
 
-yargs@^8.0.1, yargs@^8.0.2:
+yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:


### PR DESCRIPTION
`NODE_ENV` should be set to `production` in the actual environment, rather than relying on `yargs` in Gulp to take care of it. That way the env is consistent across the entire build, and we don’t need to depend on the order in which things run.