### PR TITLE
Update webpack invocation in browserSync gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,7 @@ gulp.task('dev', ['browserSync', 'static', 'fonts', 'css'], () => {
 });
 
 gulp.task('browserSync', ['static'], () => {
-  const compiler = webpack(webpackConfiguration);
+  const compiler = webpack(webpackConfiguration(process.env.NODE_ENV));
   compiler.plugin('invalid', browserSync.reload);
   browserSync.init({
     server: {


### PR DESCRIPTION
Forgot to change one of the usages of `webpackConfiguration` in the gulpfile! This fixes that. Sorry to anyone who got `yarn dev` errors.