### PR TITLE
Integrate source-map-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "redux-saga-test-plan": "^3.0.2",
     "sinon": "^3.2.1",
     "source-map-explorer": "^1.4.0",
+    "source-map-loader": "^0.2.2",
     "string-replace-loader": "^1.0.5",
     "stylelint-selector-bem-pattern": "^1.0.0",
     "substitute-loader": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,6 +166,11 @@ module.exports = (env = 'development') => {
           ],
         },
         {
+          test: /\.js$/,
+          use: ['source-map-loader'],
+          enforce: 'pre',
+        },
+        {
           test: /\.json$/,
           use: ['json-loader'],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,15 +368,15 @@ async@1.5.2, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
+async@^0.9.0, async@~0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+
 async@^2.1.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
-
-async@~0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
 async@~1.0.0:
   version "1.0.0"
@@ -5356,7 +5356,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.5:
+loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.5, loader-utils@~0.2.2:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -8352,6 +8352,14 @@ source-map-explorer@^1.4.0:
     source-map "^0.5.1"
     temp "^0.8.3"
     underscore "^1.8.3"
+
+source-map-loader@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.2.tgz#1249348ff6a66ea64a2957fc98f74cb6bba67505"
+  dependencies:
+    async "^0.9.0"
+    loader-utils "~0.2.2"
+    source-map "~0.1.33"
 
 source-map-resolve@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
Many packages (notably Firebase) come with pre-compiled/minified code, with sourcemaps shipping alongside. The `source-map-loader` integrates the pre-packaged sourcemaps into the final bundle’s sourcemaps, giving us better visibility into what’s going on in library code.