### PR TITLE
Use appendChild rather than append

### DIFF
--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -129,7 +129,7 @@ class PreviewGenerator {
   _addRefreshTimestamp(timestamp) {
     const dateString = `Last refresh on: ${String(new Date(timestamp))}`;
     const comment = this.previewDocument.createComment(dateString);
-    this.previewBody.append(comment);
+    this.previewBody.appendChild(comment);
   }
 
   _addJavascript({breakLoops = false}) {


### PR DESCRIPTION
This probably wasn’t intentional, but [`append()`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append) is a fairly new/experimental DOM API method that is only supported by very new browser versions.

Instead, use `appendChild`, which was invented during the Big Bang.

Fixes #1036
Fixes #1063