### PR TITLE
Add all loaded projects to store in single Redux action

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -57,7 +57,4 @@ export const gistImportError = createAction(
   gistId => ({gistId}),
 );
 
-export const projectLoaded = createAction(
-  'PROJECT_LOADED',
-  project => ({project}),
-);
+export const projectsLoaded = createAction('PROJECTS_LOADED');

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -96,8 +96,8 @@ export default function reduceProjects(stateIn, action) {
   }
 
   switch (action.type) {
-    case 'PROJECT_LOADED':
-      return addProject(state, action.payload.project);
+    case 'PROJECTS_LOADED':
+      return action.payload.reduce(addProject, state);
 
     case 'UPDATE_PROJECT_SOURCE':
       return state.setIn(

--- a/src/sagas/projects.js
+++ b/src/sagas/projects.js
@@ -15,7 +15,7 @@ import {
   gistImportError,
   gistNotFound,
   projectCreated,
-  projectLoaded,
+  projectsLoaded,
 } from '../actions/projects';
 import {
   snapshotImported,
@@ -90,9 +90,7 @@ export function* userAuthenticated() {
 
   const projects = yield call(loadAllProjects, getCurrentUserId(state));
 
-  for (const project of projects) {
-    yield put(projectLoaded(project));
-  }
+  yield put(projectsLoaded(projects));
 }
 
 export function* toggleLibrary() {

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -14,7 +14,7 @@ import {
   changeCurrentProject,
   gistImported,
   projectCreated,
-  projectLoaded,
+  projectsLoaded,
   toggleLibrary,
   hideComponent,
   unhideComponent,
@@ -171,17 +171,20 @@ test('gistImported', (t) => {
   ));
 });
 
-tap(project(), projectIn =>
-  test('loadProject', reducerTest(
+tap([project(), project()], projectsIn =>
+  test('projectsLoaded', reducerTest(
     reducer,
     states.initial,
-    partial(projectLoaded, projectIn),
-    new Immutable.Map().set(
-      projectIn.projectKey,
-      buildProject(
+    partial(projectsLoaded, projectsIn),
+    projectsIn.reduce(
+      (map, projectIn) => map.set(
         projectIn.projectKey,
-        projectIn.sources,
-      ).set('updatedAt', projectIn.updatedAt),
+        buildProject(
+          projectIn.projectKey,
+          projectIn.sources,
+        ).set('updatedAt', projectIn.updatedAt),
+      ),
+      new Immutable.Map(),
     ),
   )),
 );

--- a/test/unit/sagas/projects.js
+++ b/test/unit/sagas/projects.js
@@ -13,7 +13,7 @@ import {
 import {
   gistImportError,
   gistNotFound,
-  projectLoaded,
+  projectsLoaded,
   toggleLibrary,
   updateProjectSource,
 } from '../../../src/actions/projects';
@@ -208,7 +208,7 @@ test('userAuthenticated', (assert) => {
     next().inspect(effect => assert.ok(effect.SELECT)).
     next(scenario.state).fork(saveCurrentProject, scenario.state).
     next().call(loadAllProjects, scenario.user.get('id')).
-    next(projects).put(projectLoaded(projects[0]));
+    next(projects).put(projectsLoaded(projects));
   assert.end();
 });
 


### PR DESCRIPTION
Completely unnecessary inefficiency when loading projects from Firebase: we were iterating over each project and dispatching a separate `PROJECT_LOADED` action for each one. This caused N discrete Redux store updates, and thus N discrete React state updates, for N projects loaded.  Resulted in a definitely noticeable lag when loading projects into my workspace.

Instead, switch to a `PROJECTS_LOADED` action which adds all projects to the Redux store in a single dispatch.

Might help with (but probably won’t fix) #1117 