### PR TITLE
Use built-in unhandled rejection notifications in Bugsnag

### DIFF
--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -1,6 +1,4 @@
 import 'bugsnag-js';
-import isError from 'lodash/isError';
-import isString from 'lodash/isString';
 import config from '../config';
 import {getCurrentProject} from '../selectors';
 
@@ -25,17 +23,6 @@ export function includeStoreInBugReports(store) {
   };
 }
 
-window.addEventListener('unhandledrejection', ({reason}) => {
-  if (isError(reason)) {
-    Bugsnag.notifyException(reason);
-  } else if (isString(reason)) {
-    Bugsnag.notify('UnhandledRejection', reason);
-  } else {
-    Bugsnag.notify(
-      'UnhandledRejection',
-      JSON.stringify(reason) || 'No reason given',
-    );
-  }
-});
+Bugsnag.enableNotifyUnhandledRejections();
 
 export default Bugsnag;


### PR DESCRIPTION
Bugsnag got that feature at some point, so there’s no need to hand-roll an event listener.