### PR TITLE
Group Bugsnag errors by message when stacktrace includes minified files

### DIFF
--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -1,15 +1,32 @@
 import 'bugsnag-js';
+import isNull from 'lodash/isNull';
 import config from '../config';
 import {getCurrentProject} from '../selectors';
+
+const MINIFIED_SOURCE_PATTERN = /firebase\/auth/;
 
 const Bugsnag = window.Bugsnag.noConflict();
 Bugsnag.apiKey = config.bugsnagApiKey;
 Bugsnag.releaseStage = config.nodeEnv;
 Bugsnag.appVersion = config.gitRevision;
+Bugsnag.enableNotifyUnhandledRejections();
 
-export function includeStoreInBugReports(store) {
-  Bugsnag.beforeNotify = (payload) => {
-    const state = store.getState();
+const bugsnagNotifyMiddleware = {
+  store: null,
+
+  beforeNotify(payload) {
+    if (MINIFIED_SOURCE_PATTERN.test(payload.stacktrace)) {
+      payload.metaData.groupingHash = payload.message;
+    }
+    this._attachStateToPayload(payload);
+  },
+
+  _attachStateToPayload(payload) {
+    if (isNull(this.store)) {
+      return;
+    }
+
+    const state = this.store.getState();
     if (state.get('user')) {
       payload.user = state.get('user').toJS();
     } else {
@@ -20,9 +37,14 @@ export function includeStoreInBugReports(store) {
     if (currentProject) {
       payload.metaData.currentProject = currentProject;
     }
-  };
-}
+  },
+};
 
-Bugsnag.enableNotifyUnhandledRejections();
+Bugsnag.beforeNotify =
+  bugsnagNotifyMiddleware.beforeNotify.bind(bugsnagNotifyMiddleware);
+
+export function includeStoreInBugReports(store) {
+  bugsnagNotifyMiddleware.store = store;
+}
 
 export default Bugsnag;


### PR DESCRIPTION
E.g. `firebase/auth` is minified and does not have a sourcemap, so the file numbers in stacktraces that include `firebase/auth` are meaningless and change with each release. So, for stacktraces that include stack frames in `firebase/auth`, we want to ignore the stacktrace and just group based on the error. This will allow us to more effectively ignore a couple of errors that come from `firebase/auth`, generate a lot of noise, but do not seem to have any user-facing effect.

Fixes #1115 
Fixes #1114 
Fixes #1095 
Fixes #1035 
Fixes #1092 
Fixes #1111 
Fixes #1110 
Fixes #1120 
Fixes #1089 
Fixes #1020 
Fixes #1116 
Fixes #1100 
Fixes #1093 
Fixes #1096 
Fixes #1091 
Fixes #1090 
Fixes #1037 
Fixes #1066 
Fixes #1057 
Fixes #1051 