### PR TITLE
Add support for confirm and prompt functions

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -8,6 +8,7 @@ import {sourceDelimiter} from '../util/generatePreview';
 
 const sandboxOptions = [
   'allow-forms',
+  'allow-modals',
   'allow-popups',
   'allow-scripts',
   'allow-top-navigation',

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -49,10 +49,6 @@ const alertAndPromptReplacementScript = `(${function() {
       },
       configurable: true,
     },
-    prompt: {
-      value: (message, defaultValue = '') => defaultValue,
-      configurable: true,
-    },
   });
 
   delete window.swal; // eslint-disable-line prefer-reflect


### PR DESCRIPTION
I've found confirm and prompt to be great ways to introduce user input and conditionals.  Ideally, we'd be able to support them using SweetAlert, but unfortunately, SweetAlert calls are asynchronous and use a Promise-based API which would only add to the complexity of introducing these topics.