### PR TITLE
Always show project picker when user is logged in

### DIFF
--- a/src/components/TopBar/ProjectPicker.jsx
+++ b/src/components/TopBar/ProjectPicker.jsx
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
 import partial from 'lodash/partial';
 import PropTypes from 'prop-types';
@@ -9,8 +10,10 @@ import createMenu, {MenuItem} from './createMenu';
 const ProjectPicker = createMenu({
   name: 'projectPicker',
 
-  isVisible({currentProjectKey, projectKeys}) {
-    return currentProjectKey && projectKeys.length > 1;
+  isVisible({currentProjectKey, isUserAuthenticated, projectKeys}) {
+    return Boolean(currentProjectKey) &&
+      !isEmpty(projectKeys) &&
+      isUserAuthenticated;
   },
 
   renderItems({currentProjectKey, projectKeys, onChangeCurrentProject}) {

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -76,6 +76,7 @@ export default function TopBar({
       />
       <ProjectPicker
         currentProjectKey={currentProjectKey}
+        isUserAuthenticated={isUserAuthenticated}
         projectKeys={projectKeys}
         onChangeCurrentProject={onChangeCurrentProject}
       />


### PR DESCRIPTION
Previous logic was to show the project picker if there were at least two non-pristine projects in the workspace. Seems reasonable—why show a project picker if there aren’t multiple projects to choose between?

The problem is that the project picker only shows non-pristine projects (projects we have saved), so there is a bug:

1. In a Popcode session, log in and create a project, which is auto-saved.
2. In a later Popcode session, log back in.
3. Because it’s a new session, you are looking at  a new (pristine) project. There is exactly one saved project in the workspace.
4. So, the picker does not appear, because it requires at least two saved projects.

So, instead, show the project picker as long as:

* The user is logged in
* There are *any* non-pristine projects

As well as fixing the bug described above, this also is better UX for the first session—as soon as you start working logged in, the **My Projects** picker appears, which provides a signal that your project has been saved. (We could certainly do more there, but it’s an improvement).

Incidentally, this also restores the way the button behaved before the recent redesign.

Fixes #1117 