### PR TITLE
Catch Firebase auth/internal-error silently

### DIFF
--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -106,6 +106,9 @@ function mapDispatchToProps(dispatch) {
               notificationTriggered('auth-third-party-cookies-disabled'),
             );
             break;
+          case 'auth/internal-error':
+            dispatch(notificationTriggered('auth-error'));
+            break;
           default:
             dispatch(notificationTriggered('auth-error'));
             if (isError(e)) {


### PR DESCRIPTION
No reason to report this to Bugsnag—just show the user an error message
and prompt to try again.

Fixes #1118
Fixes #1119
Fixes #1041