### PR TITLE
bump bootstrap to v4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "angular": "^1.5.5",
-    "bootstrap": "^3.3.6",
+    "bootstrap": "^4.0.0",
     "ember": "^2.5.1",
     "fontawesome": "^4.6.3",
     "foundation": "^5.5.3",


### PR DESCRIPTION
The main bootstrap page is now at v4.0.0-beta
http://getbootstrap.com/
I was thinking we would just teach from the main examples on the website, since it might cause confusion to keep going back to the 3.3 docs