### PR TITLE
Create new htmllint.Linter instance for each run

### DIFF
--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -141,15 +141,16 @@ class HtmllintValidator extends Validator {
   }
 
   async _getRawErrors() {
-    const {htmllint} = await importLinters();
+    const {htmllint: {Linter, rules}} = await importLinters();
+    const linter = new Linter(rules);
     const options = reduce(
-      htmllint.rules,
+      linter.rules.options,
       (acc, {name}) => defaults(acc, {[name]: false}),
       clone(htmlLintOptions),
     );
 
     try {
-      const results = await htmllint(this._source, options);
+      const results = await linter.lint(this._source, options);
       return results;
     } catch (e) {
       return [];


### PR DESCRIPTION
For [certain sequences of inputs](https://github.com/htmllint/htmllint/issues), an `htmllint` linter instance will produce false positive errors for a valid final input. I didn’t dig into exactly why, but it’s clearly retaining some kind of state that it shouldn’t be.

So: just instantiate a new `Linter` instance for each pass.  Unfortunately the `Linter` constructor isn’t _totally_ trivial, but it doesn’t appear to do anything particularly slow, so hopefully this should be fine from a performance standpoint.

Fixes #949