### PR TITLE
editor labels hidden on focus

### DIFF
--- a/src/components/EditorContainer.jsx
+++ b/src/components/EditorContainer.jsx
@@ -20,6 +20,8 @@ function EditorContainer({children, language, source, style, onHide, onRef}) {
       ref={onRef}
       style={prefixAll(style)}
     >
+      {helpText}
+      {children}
       <div
         className="editors__label editors__label_expanded"
         onClick={onHide}
@@ -28,8 +30,6 @@ function EditorContainer({children, language, source, style, onHide, onRef}) {
         {' '}
         <span className="u__icon">&#xf078;</span>
       </div>
-      {helpText}
-      {children}
     </div>
   );
 }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -359,6 +359,16 @@ body {
   z-index: 1;
 }
 
+/* postcss-bem-linter: ignore */
+.ace_focus ~ .editors__label {
+  visibility: hidden;
+
+  /* postcss-bem-linter: ignore */
+  & .u__icon {
+    visibility: visible;
+  }
+}
+
 .editors__column-divider {
   background-color: var(--color-light-gray);
   cursor: ew-resize;


### PR DESCRIPTION
This is in regards to Issue #1002 

Low-key I'm expecting disagreement with this solution but it was just so simple I couldn't not 😝 CSS-only solution, with small HTML reorg so the selectors would work. When I was messing with it I didn't like the label fully disappearing because it felt unclear how to close, so I left the chevron with a transparent background. 

Had to ignore the linter because the ace editor native classes don't use BEM. Theoretically I know I should be able to use `ignoreSelectors` in the rules but I couldn't get it to work in less time than I wrote this CSS so I let it go, but would appreciate a nudge in the right direction of how to get that working.