### PR TITLE
loginState channel emits object wrapper for userCredential

### DIFF
--- a/src/channels/loginState.js
+++ b/src/channels/loginState.js
@@ -1,4 +1,6 @@
 import {eventChannel} from 'redux-saga';
 import {onAuthStateChanged} from '../clients/firebase';
 
-export default eventChannel(onAuthStateChanged);
+export default eventChannel(
+  emit => onAuthStateChanged(userCredential => emit({userCredential})),
+);

--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -9,19 +9,16 @@ import {auth, database, githubAuthProvider} from '../services/appFirebase';
 const VALID_SESSION_UID_COOKIE = 'firebaseAuth.validSessionUid';
 const SESSION_TTL_MS = 5 * 60 * 1000;
 
-/* eslint-disable promise/prefer-await-to-callbacks */
-export function onAuthStateChanged(callback) {
+export function onAuthStateChanged(listener) {
   const unsubscribe = auth.onAuthStateChanged(async(user) => {
     if (isNull(user)) {
-      callback({user, credential: null});
+      listener(null);
     } else {
-      const userCredential = await userCredentialForUserData(user);
-      callback(userCredential);
+      listener(await userCredentialForUserData(user));
     }
   });
   return unsubscribe;
 }
-/* eslint-enable promise/prefer-await-to-callbacks */
 
 function workspace(uid) {
   return database.ref(`workspaces/${uid}`);

--- a/src/sagas/user.js
+++ b/src/sagas/user.js
@@ -20,8 +20,8 @@ export function* applicationLoaded() {
 }
 
 function* handleInitialAuth() {
-  const userCredential = yield take(loginState);
-  if (isNil(userCredential.user)) {
+  const {userCredential} = yield take(loginState);
+  if (isNil(userCredential)) {
     yield put(userLoggedOut());
   } else {
     if (isNil(userCredential.credential)) {
@@ -41,8 +41,8 @@ function* handleInitialAuth() {
 
 function* handleAuthChange() {
   while (true) {
-    const userCredential = yield take(loginState);
-    if (isNil(userCredential.user)) {
+    const {userCredential} = yield take(loginState);
+    if (isNil(userCredential)) {
       yield put(userLoggedOut());
     } else {
       yield put(userAuthenticated(userCredential));

--- a/test/unit/sagas/user.js
+++ b/test/unit/sagas/user.js
@@ -33,7 +33,7 @@ test('applicationLoaded', (t) => {
     testSaga(applicationLoadedSaga, applicationLoaded()).
       next().call(startSessionHeartbeat).
       next().take(loginState).
-      next({}).put(userLoggedOut());
+      next({userCredential: null}).put(userLoggedOut());
 
     assert.end();
   });
@@ -43,7 +43,7 @@ test('applicationLoaded', (t) => {
     testSaga(applicationLoadedSaga, applicationLoaded()).
       next().call(startSessionHeartbeat).
       next().take(loginState).
-      next(userCredential).call(getSessionUid).
+      next({userCredential}).call(getSessionUid).
       next(userCredential.user.uid).put(userAuthenticated(userCredential));
 
     assert.end();
@@ -54,7 +54,7 @@ test('applicationLoaded', (t) => {
     testSaga(applicationLoadedSaga, applicationLoaded()).
       next().call(startSessionHeartbeat).
       next().take(loginState).
-      next(userCredential).call(getSessionUid).
+      next({userCredential}).call(getSessionUid).
       next(undefined).call(signOut);
 
     assert.end();


### PR DESCRIPTION
Channels aren’t allowed to emit `null` or `undefined`, so simply wrap the `userCredential` emitted by `onAuthStateChanged` in an object with a single `userCredential` key, which itself may or may not be null.

Fixes #1153