### PR TITLE
Fix runtime errors

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -75,17 +75,14 @@ class PreviewFrame extends React.Component {
       line = 1;
     }
 
-    this.props.onRuntimeError(
-      'javascript',
-      {
-        reason: normalizedError.type,
-        text: normalizedError.message,
-        raw: normalizedError.message,
-        row: line - 1,
-        column: data.error.column,
-        type: 'error',
-      },
-    );
+    this.props.onRuntimeError({
+      reason: normalizedError.type,
+      text: normalizedError.message,
+      raw: normalizedError.message,
+      row: line - 1,
+      column: data.error.column,
+      type: 'error',
+    });
   }
 
   _handleInfiniteLoop(line) {


### PR DESCRIPTION
Was passing in a first argument corresponding to the error language, but the signature of the handler function changed, no longer taking that argument. Remove it and runtime errors are back in business.