### PR TITLE
Catch uncaught errors during Firebase auth

### DIFF
--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -95,9 +95,18 @@ async function userCredentialForUserData(user) {
 }
 
 export async function signIn() {
-  const userCredential = await auth.signInWithPopup(githubAuthProvider);
-  await saveUserCredential(userCredential);
-  return userCredential;
+  const originalOnerror = window.onerror;
+  window.onerror = message => message.toLowerCase().includes('network error');
+
+  try {
+    const userCredential = await auth.signInWithPopup(githubAuthProvider);
+    await saveUserCredential(userCredential);
+    return userCredential;
+  } finally {
+    setTimeout(() => {
+      window.onerror = originalOnerror;
+    });
+  }
 }
 
 export function signOut() {

--- a/src/util/Bugsnag.js
+++ b/src/util/Bugsnag.js
@@ -1,32 +1,15 @@
 import 'bugsnag-js';
-import isNull from 'lodash/isNull';
 import config from '../config';
 import {getCurrentProject} from '../selectors';
-
-const MINIFIED_SOURCE_PATTERN = /firebase\/auth/;
 
 const Bugsnag = window.Bugsnag.noConflict();
 Bugsnag.apiKey = config.bugsnagApiKey;
 Bugsnag.releaseStage = config.nodeEnv;
 Bugsnag.appVersion = config.gitRevision;
-Bugsnag.enableNotifyUnhandledRejections();
 
-const bugsnagNotifyMiddleware = {
-  store: null,
-
-  beforeNotify(payload) {
-    if (MINIFIED_SOURCE_PATTERN.test(payload.stacktrace)) {
-      payload.metaData.groupingHash = payload.message;
-    }
-    this._attachStateToPayload(payload);
-  },
-
-  _attachStateToPayload(payload) {
-    if (isNull(this.store)) {
-      return;
-    }
-
-    const state = this.store.getState();
+export function includeStoreInBugReports(store) {
+  Bugsnag.beforeNotify = (payload) => {
+    const state = store.getState();
     if (state.get('user')) {
       payload.user = state.get('user').toJS();
     } else {
@@ -37,14 +20,9 @@ const bugsnagNotifyMiddleware = {
     if (currentProject) {
       payload.metaData.currentProject = currentProject;
     }
-  },
-};
-
-Bugsnag.beforeNotify =
-  bugsnagNotifyMiddleware.beforeNotify.bind(bugsnagNotifyMiddleware);
-
-export function includeStoreInBugReports(store) {
-  bugsnagNotifyMiddleware.store = store;
+  };
 }
+
+Bugsnag.enableNotifyUnhandledRejections();
 
 export default Bugsnag;


### PR DESCRIPTION
There has been a longstanding issue where, if a slow network condition occurs during signing, Firebase will not only reject the sign in promise but also throw an uncaught global network error. This has historically been very noisy in Bugsnag.

So, set up some armor plating around it—specifically, if during the course of Firebase sign-in there is a global error whose message case-insensitively contains the string “network error”, we ignore the global error.

Also, revert the previous attempt to deal with these annoying errors, namely code that tries to vary error grouping logic based on the backtrace.  This was premised on the idea that we know the sourcemapped backtrace of the error in the application environment, which is of course entirely incorrect (unless dev tools happen to be open), because the sourcemaps aren’t loaded.

Fixes #1028 
Fixes #1056 
Fixes #1093 
Fixes #1110 
Fixes #1111 
Fixes #1116 
Fixes #1143 
Fixes #1160 
Fixes #1162 