### PR TITLE
Set error state to validating when snapshot is imported

### DIFF
--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -41,6 +41,9 @@ function errors(stateIn, action) {
     case 'GIST_IMPORTED':
       return validatingErrors;
 
+    case 'SNAPSHOT_IMPORTED':
+      return validatingErrors;
+
     case 'TOGGLE_LIBRARY':
       return validatingErrors;
 


### PR DESCRIPTION
When we import a snapshot, we validate the code, which is correct—however, this was not reflected in the `errors` state, which was not set to `validating` for that period. So, right when a snapshot came in, the UI attempted to render it before validation had completed. In the case where e.g. JavaScript had syntax errors, this would cause the preview to throw an exception, causing the entire application to crash.

Fix the issue by properly setting the validation state on snapshot import, preventing the preview from attempting to render.