### PR TITLE
Error message for lists (ul, ol, dl) with text children #1178

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -80,7 +80,7 @@
         "width": "Don't use the `width` attribute. Instead, use the CSS `width` property"
       },
       "lower-case-attribute-name": "Use lower case for attribute names",
-      "invalid-list-children": "The `<{{-tag}}>` tag must contain `<{{-children}}>`",
+      "text-elements-as-list-children": "The text `{{-textContent}}` inside the `<{{-tag}}>` tag must be surrounded by `<{{-children}}>` tags",
       "invalid-tag-location": "The `<{{-tag}}>` tag can’t go inside the `<{{-parent}}>` tag.",
       "invalid-tag-parent": "The `<{{-tag}}>` tag needs to be inside the `{{-parent}}`",
       "attribute-quotes": "You need to put the value of the `{{-attribute}}` attribute in quotation marks\nTry: `{{-attribute}}=\"myvalue\"`",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -80,6 +80,7 @@
         "width": "Don't use the `width` attribute. Instead, use the CSS `width` property"
       },
       "lower-case-attribute-name": "Use lower case for attribute names",
+      "invalid-list-children": "The `<{{-tag}}>` tag must contain `<{{-children}}>`",
       "invalid-tag-location": "The `<{{-tag}}>` tag can’t go inside the `<{{-parent}}>` tag.",
       "invalid-tag-parent": "The `<{{-tag}}>` tag needs to be inside the `{{-parent}}`",
       "attribute-quotes": "You need to put the value of the `{{-attribute}}` attribute in quotation marks\nTry: `{{-attribute}}=\"myvalue\"`",

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -166,7 +166,7 @@ test('ol with child text outside <li>', validationTest(
     payload: {
       tag: 'ol',
       children: 'li',
-      textContent: 'Invalid to have non-empty text nodes'
+      textContent: 'Invalid to have non-empty text nodes',
     },
   },
 ));

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -143,6 +143,26 @@ test('uppercase attributes', validationTest(
   {reason: 'lower-case-attribute-name', row: htmlWithBody.offset},
 ));
 
+test('ul with child text outside <li>', validationTest(
+  htmlWithBody('<ul>Invalid to have non-empty text nodes</ul>'),
+  html,
+  {
+    reason: 'invalid-list-children',
+    row: htmlWithBody.offset,
+    payload: {tag: 'ul', children: 'li'},
+  },
+));
+
+test('ol with child text outside <li>', validationTest(
+  htmlWithBody('<ol>Invalid to have non-empty text nodes</ol>'),
+  html,
+  {
+    reason: 'invalid-list-children',
+    row: htmlWithBody.offset,
+    payload: {tag: 'ol', children: 'li'},
+  },
+));
+
 test('li not inside ul', validationTest(
   htmlWithBody('<li>Orphaned List Item</li>'),
   html,

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -147,9 +147,13 @@ test('ul with child text outside <li>', validationTest(
   htmlWithBody('<ul>Invalid to have non-empty text nodes</ul>'),
   html,
   {
-    reason: 'invalid-list-children',
+    reason: 'text-elements-as-list-children',
     row: htmlWithBody.offset,
-    payload: {tag: 'ul', children: 'li'},
+    payload: {
+      tag: 'ul',
+      children: 'li',
+      textContent: 'Invalid to have non-empty text nodes',
+    },
   },
 ));
 
@@ -157,9 +161,13 @@ test('ol with child text outside <li>', validationTest(
   htmlWithBody('<ol>Invalid to have non-empty text nodes</ol>'),
   html,
   {
-    reason: 'invalid-list-children',
+    reason: 'text-elements-as-list-children',
     row: htmlWithBody.offset,
-    payload: {tag: 'ol', children: 'li'},
+    payload: {
+      tag: 'ol',
+      children: 'li',
+      textContent: 'Invalid to have non-empty text nodes'
+    },
   },
 ));
 


### PR DESCRIPTION
Closes #1178 

This is a common student mistake I see, which is that students forget to write `<li>` inside their lists, and therefore don't actually get what they expect. I've added an error message for this use case, because for the purposes of teaching this is the only valid syntax we should expect.

Example of the error message:
<img width="746" alt="screenshot 2017-11-12 20 58 47" src="https://user-images.githubusercontent.com/666475/32706568-4eec7516-c7ec-11e7-86b4-22344409ed40.png">
