### PR TITLE
No Zoom Workspace

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -345,7 +345,7 @@ body {
   color: var(--color-dark-gray);
   cursor: pointer;
   font-family: 'Roboto';
-  font-size: 14px;
+  font-size: 2vh;
   padding: 0.5em;
   text-align: right;
   user-select: none;
@@ -362,13 +362,13 @@ body {
 .editors__column-divider {
   background-color: var(--color-light-gray);
   cursor: ew-resize;
-  min-width: 4px;
+  width: 0.5vh;
 }
 
 .editors__row-divider {
   background-color: var(--color-light-gray);
   cursor: ns-resize;
-  min-height: 4px;
+  height: 0.5vh;
 }
 
 .editors__help-text {
@@ -423,7 +423,7 @@ body {
   left: 0;
   position: absolute;
   right: 0;
-  top: 1.5em;
+  top: 4.4vh;
   z-index: 0;
 }
 
@@ -434,14 +434,15 @@ body {
 }
 
 .preview__title-bar {
+  font-size: 2.2vh;
+  height: 2.4vh;
   top: 0;
   left: 0;
   right: 0;
+  padding: 1vh;
   position: absolute;
   text-align: center;
-  height: 1.5em;
   font-weight: bold;
-  line-height: 1.5em;
   vertical-align: middle;
   background-color: var(--color-low-contrast-gray);
   z-index: 2;


### PR DESCRIPTION
Modified styles to prevent zooming on the entire workspace.

This uses a similar strategy employed in the TopBar to prevent zooming in on other page elements, making it easier to see the code when presenting.

![4frot03qke-1](https://user-images.githubusercontent.com/3432105/32741571-abc0d2c2-c874-11e7-8e58-71c14bcd91ba.gif)
