### PR TITLE
Updated chrome styles.

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -78,6 +78,8 @@
   --color-yellow: #ffd100;
   --color-red: #ff5e4f;
   --color-purple: #f0f;
+  --box-shadow: 0 0 0.1em 0 rgba(0, 0, 0, 0.5);
+  --font-size-menu: 1.7vh;
 }
 
 body {
@@ -357,17 +359,18 @@ body {
   color: var(--color-dark-gray);
   cursor: pointer;
   font-family: 'Roboto';
-  font-size: 2vh;
-  padding: 0.5em;
+  font-size: var(--font-size-menu);
+  padding: 0.5em 1em;
   text-align: right;
   user-select: none;
 }
 
 .editors__label_expanded {
+  background-color: rgba(226, 226, 226, 0.9);
+  box-shadow: var(--box-shadow);
   position: absolute;
   right: 0;
   top: 0;
-  width: 8em;
   z-index: 1;
 }
 
@@ -452,6 +455,7 @@ body {
 }
 
 .preview__title-bar {
+  box-shadow: var(--box-shadow);
   font-size: 2.2vh;
   height: 2.4vh;
   top: 0;

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -78,13 +78,13 @@
   --color-yellow: #ffd100;
   --color-red: #ff5e4f;
   --color-purple: #f0f;
-  --box-shadow: 0 0 0.1em 0 rgba(0, 0, 0, 0.5);
-  --font-size-menu: 1.7vh;
   --color-low-contrast-blue: #baecff;
   --color-blue: #00b8ff;
   --size-rounded-corners: 0.2em;
   --size-top-bar: 4em;
   --size-top-bar-menu-button: 2.8em;
+  --box-shadow: 0 0 0.1em 0 rgba(0, 0, 0, 0.5);
+  --font-size-menu: 1.7vh;
 }
 
 body {


### PR DESCRIPTION
Some style tweaks to the application chrome (specifically the code labels and preview header). Not only adds some general style finesse, but also makes the code labels smaller and slightly translucent, making them a bit less intrusive (https://github.com/popcodeorg/popcode/issues/1002). The styles also generally respect the updates coming to the top bar. (https://github.com/popcodeorg/popcode/pull/1181).

- Made the code labels font-size smaller (matches new top bar style)
- Added a subtle shadow to code labels and preview header (matches new top bar style)
- Added a bottom rounded corner to code labels (matches new top bar style)
- Made the code labels background slightly translucent
- Made the code labels width automatic.

## Before/After

![a3jj7buili](https://user-images.githubusercontent.com/3432105/32994965-23f41576-cd3c-11e7-947f-e2393b4b488a.gif)
