### PR TITLE
Clear compiled projects when a project is created or switched to

### DIFF
--- a/src/reducers/compiledProjects.js
+++ b/src/reducers/compiledProjects.js
@@ -18,6 +18,12 @@ export default function compiledProjects(stateIn, action) {
   }
 
   switch (action.type) {
+    case 'PROJECT_CREATED':
+      return initialState;
+
+    case 'CHANGE_CURRENT_PROJECT':
+      return initialState;
+
     case 'PROJECT_COMPILED':
       return trimRight(
         state.push(new CompiledProject({


### PR DESCRIPTION
If you create a new project, or start the process of switching to an existing project, we want to clear the preview state. Otherwise:

* When you create a new project, the old project sticks around
* When switching projects, the preview is unpleasantly flashy between old and new state

Fixes #1204