### PR TITLE
Upgrade to jQuery 3.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "foundation": "^5.5.3",
     "handlebars": "^4.0.5",
     "inconsolata-webfont": "^1.0.3",
-    "jquery": "^2.2.3",
+    "jquery": "^3.2.1",
     "lodash": "^4.11.2",
     "mustache.js": "mustache#^2.2.1",
     "normalize-css": "normalize.css#^4.1.1",


### PR DESCRIPTION
Upgrades from jQuery 2.2.3 to jQuery 3.2.1. This is a major version upgrade with [numerous breaking changes](https://jquery.com/upgrade-guide/3.0/), but none of them look like they would have any overlap with the kind of jQuery students write in Popcode. In fact, the only thing that even comes close is the behavior of `show()`, which is in fact the proximate motivation for this upgrade: calling `show()` on an element that was hidden with a CSS tag selector inside a sandboxed iframe threw an error in jQuery 2. Now it just sets its `display` value to `block` (regardless of whether this is the correct `display` for the element in question).

Fixes #581
Fixes #1190