### PR TITLE
Fixes for refresh button

### DIFF
--- a/src/actions/compiledProjects.js
+++ b/src/actions/compiledProjects.js
@@ -6,3 +6,8 @@ export const projectCompiled = createAction(
   identity,
   (_source, timestamp = Date.now()) => ({timestamp}),
 );
+
+export const refreshPreview = createAction(
+  'REFRESH_PREVIEW',
+  timestamp => ({timestamp}),
+);

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -30,7 +30,6 @@ import {
   notificationTriggered,
   userDismissedNotification,
   updateNotificationMetadata,
-  refreshPreview,
   popOutProject,
   toggleEditorTextSize,
   toggleTopBarMenu,
@@ -50,6 +49,7 @@ import {
 
 import {
   projectCompiled,
+  refreshPreview,
 } from './compiledProjects';
 
 export {

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -47,11 +47,6 @@ export const updateNotificationMetadata = createAction(
   (type, metadata) => ({type, metadata}),
 );
 
-export const refreshPreview = createAction(
-  'REFRESH_PREVIEW',
-  timestamp => ({timestamp}),
-);
-
 export const toggleEditorTextSize = createAction(
   'TOGGLE_EDITOR_TEXT_SIZE',
 );

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -7,7 +7,6 @@ import {
 } from '../actions';
 import {
   getCompiledProjects,
-  getLastRefreshTimestamp,
   isCurrentProjectSyntacticallyValid,
   isUserTyping,
 } from '../selectors';
@@ -18,7 +17,6 @@ function mapStateToProps(state) {
       !isUserTyping(state) &&
         !isCurrentProjectSyntacticallyValid(state)
     ),
-    lastRefreshTimestamp: getLastRefreshTimestamp(state),
     compiledProjects: getCompiledProjects(state),
   };
 }

--- a/src/reducers/compiledProjects.js
+++ b/src/reducers/compiledProjects.js
@@ -24,6 +24,21 @@ export default function compiledProjects(stateIn, action) {
     case 'CHANGE_CURRENT_PROJECT':
       return initialState;
 
+    case 'REFRESH_PREVIEW': {
+      if (state.isEmpty()) {
+        return state;
+      }
+
+      const {source, title} = state.last();
+      return trimRight(
+        state.push(new CompiledProject({
+          source,
+          title,
+          timestamp: action.payload.timestamp,
+        })),
+      );
+    }
+
     case 'PROJECT_COMPILED':
       return trimRight(
         state.push(new CompiledProject({

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -68,6 +68,17 @@ function errors(stateIn, action) {
       }
       return state.set(action.payload.language, passedLanguageErrors);
 
+    case 'REFRESH_PREVIEW':
+      return state.update(
+        'javascript',
+        (errorList) => {
+          if (errorList.state === 'runtime-error') {
+            return passedLanguageErrors;
+          }
+          return errorList;
+        },
+      );
+
     default:
       return state;
   }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -21,8 +21,7 @@ const defaultState = new Immutable.Map().
   })).
   set('workspace', DEFAULT_WORKSPACE).
   set('notifications', new Immutable.Map()).
-  set('topBar', new Immutable.Map({openMenu: null})).
-  set('lastRefreshTimestamp', null);
+  set('topBar', new Immutable.Map({openMenu: null}));
 
 function addNotification(state, type, severity, payload = {}) {
   return state.setIn(
@@ -156,9 +155,6 @@ export default function ui(stateIn, action) {
         return addNotification(state, 'empty-gist', 'error');
       }
       return addNotification(state, 'gist-export-error', 'error');
-
-    case 'REFRESH_PREVIEW':
-      return state.set('lastRefreshTimestamp', action.payload.timestamp);
 
     case 'APPLICATION_LOADED':
       if (action.payload.isExperimental) {

--- a/src/sagas/compiledProjects.js
+++ b/src/sagas/compiledProjects.js
@@ -24,7 +24,6 @@ export function* validatedSource() {
         nonBlockingAlertsAndPrompts: true,
         targetBaseTop: true,
         propagateErrorsToParent: true,
-        lastRefreshTimestamp: timestamp,
       },
     );
     yield put(projectCompiled(preview, timestamp));

--- a/src/selectors/getLastRefreshTimestamp.js
+++ b/src/selectors/getLastRefreshTimestamp.js
@@ -1,3 +1,0 @@
-export default function getLastRefreshTimestamp(state) {
-  return state.getIn(['ui', 'lastRefreshTimestamp']);
-}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -10,7 +10,6 @@ import getCurrentValidationState from './getCurrentValidationState';
 import getEnabledLibraries from './getEnabledLibraries';
 import getErrors from './getErrors';
 import getHiddenUIComponents from './getHiddenUIComponents';
-import getLastRefreshTimestamp from './getLastRefreshTimestamp';
 import getNotifications from './getNotifications';
 import getOpenTopBarMenu from './getOpenTopBarMenu';
 import getProject from './getProject';
@@ -38,7 +37,6 @@ export {
   getEnabledLibraries,
   getErrors,
   getHiddenUIComponents,
-  getLastRefreshTimestamp,
   getNotifications,
   getOpenTopBarMenu,
   getProject,

--- a/src/util/generatePreview.js
+++ b/src/util/generatePreview.js
@@ -85,9 +85,6 @@ export class PreviewGenerator {
     if (options.nonBlockingAlertsAndPrompts) {
       this._addAlertAndPromptHandling();
     }
-    if (options.lastRefreshTimestamp) {
-      this._addRefreshTimestamp(options.lastRefreshTimestamp);
-    }
 
     this._addJavascript(pick(options, 'breakLoops'));
   }
@@ -134,12 +131,6 @@ export class PreviewGenerator {
     const styleTag = this._previewDocument.createElement('style');
     styleTag.innerHTML = this._project.sources.css;
     this._previewHead.appendChild(styleTag);
-  }
-
-  _addRefreshTimestamp(timestamp) {
-    const dateString = `Last refresh on: ${String(new Date(timestamp))}`;
-    const comment = this._previewDocument.createComment(dateString);
-    this.previewBody.appendChild(comment);
   }
 
   _addJavascript({breakLoops = false}) {

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -17,7 +17,6 @@ import {
   editorFocusedRequestedLine,
   notificationTriggered,
   userDismissedNotification,
-  refreshPreview,
   toggleTopBarMenu,
 } from '../../../src/actions/ui';
 import {
@@ -43,7 +42,6 @@ const initialState = Immutable.fromJS({
   },
   workspace: DEFAULT_WORKSPACE,
   notifications: new Immutable.Map(),
-  lastRefreshTimestamp: null,
   topBar: {openMenu: null},
 });
 
@@ -280,13 +278,6 @@ test('userDismissedNotification', reducerTest(
   withNotification('some-error', 'error'),
   partial(userDismissedNotification, 'some-error'),
   initialState,
-));
-
-test('refreshPreview', reducerTest(
-  reducer,
-  initialState,
-  partial(refreshPreview, 1),
-  initialState.set('lastRefreshTimestamp', 1),
 ));
 
 test('applicationLoaded', (t) => {

--- a/test/unit/sagas/compiledProjects.js
+++ b/test/unit/sagas/compiledProjects.js
@@ -33,7 +33,6 @@ test('validatedSource', (t) => {
           nonBlockingAlertsAndPrompts: true,
           targetBaseTop: true,
           propagateErrorsToParent: true,
-          lastRefreshTimestamp: Date.now(),
         },
       ).
       next(preview).put(projectCompiled(preview, Date.now()));


### PR DESCRIPTION
Fixes a recent regression in the refresh button and adds functionality that has always been missing.

The regression: the refresh button stopped working entirely. Previously we refreshed the preview by artificially adding the idea of a “last refresh timestamp”, which was given as an argument to the preview generator, causing its output to change and thus the preview iframe to refresh.

Things work differently now.

Since the preview now has first-class state, all we need to do is add a copy of the current compiled project to the stack of compiled projects, which triggers the desired refresh behavior in the Preview component.

The always-missing feature: runtime errors are now cleared when you refresh the project.

Fixes #1212 