### PR TITLE
Add dns-prefetch links

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -6,6 +6,10 @@
     <meta name="description" content="Popcode is a web-based HTML, CSS, and JavaScript coding environment that is designed for students.">
     <link rel="stylesheet" href="application.css">
     <link rel="icon" type="image/png" href="images/favicon.ico">
+    <link rel="dns-prefetch" href="//api.github.com">
+    <link rel="dns-prefetch" href="//www.google-analytics.com">
+    <link rel="dns-prefetch" href="//www.googleapis.com">
+    <link rel="dns-prefetch" href="//apis.google.com">
   </head>
   <body>
     <div id="main">


### PR DESCRIPTION
Hi, I am adding four `<link rel="dns-prefecth">`. Issue #1199.

Links point to GitHub, Google Analytics and Google APIs. I check the Network tab and see Popcode interacting with their domains. 

I'm omitting Firebase for now because I'm not sure which domain to use.

Fixes #1199 