### PR TITLE
Enlarge login button target area

### DIFF
--- a/src/components/TopBar/CurrentUser.jsx
+++ b/src/components/TopBar/CurrentUser.jsx
@@ -18,13 +18,9 @@ export default function CurrentUser({
         'top-bar__menu-button',
         'top-bar__menu-button_primary',
       )}
+      onClick={onStartLogIn}
     >
-      <span
-        className="top-bar__log-in-prompt"
-        onClick={onStartLogIn}
-      >
-        {t('top-bar.session.log-in-prompt')}
-      </span>
+      {t('top-bar.session.log-in-prompt')}
     </div>
   );
 }


### PR DESCRIPTION
Hello, I remove login `<span>` and move its event listeners into parent `<div>`. Issue #1222

A couple observations:
- `<div>` is the login button, but its click area was limited to its child `<span>`.  To fix this, I move `<span>`'s event listeners into `<div>`.
- `<span>` has a class `top-bar__log-in-prompt`, but I don't see that class defined anywhere. That's why I didn't add the class to `<div>`.