### PR TITLE
Upgrade brace

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "PrettyCSS": "^0.3.15",
     "array-to-sentence": "^1.1.0",
     "bowser": "^1.4.5",
-    "brace": "^0.10.0",
+    "brace": "^0.11.0",
     "bugsnag-js": "^3.0.1",
     "classnames": "^2.1.5",
     "css": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,11 +1483,9 @@ brace-expansion@^1.0.0, brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/brace/-/brace-0.10.0.tgz#edef4eb9b0928ba1ee5f717ffc157749a6dd5d76"
-  dependencies:
-    w3c-blob "0.0.1"
+brace@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.0.tgz#155cd80607687dc8cb908f0df94e62a033c1d563"
 
 braces@^0.1.2:
   version "0.1.5"
@@ -9840,10 +9838,6 @@ void-elements@^2.0.0:
 void-elements@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
-
-w3c-blob@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/w3c-blob/-/w3c-blob-0.0.1.tgz#b0cd352a1a50f515563420ffd5861f950f1d85b8"
 
 watchpack@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Upgrades from 0.10 to 0.11. No changelog. Still seems to work.