### PR TITLE
Stringifies console value in preview frame, closes #1254

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -124,7 +124,7 @@ class PreviewFrame extends React.Component {
   }
 
   _handleConsoleValueMessage({key, value}) {
-    this.props.onConsoleValue(key, value);
+    this.props.onConsoleValue(key, JSON.stringify(value));
   }
 
   _handleInfiniteLoop(line) {


### PR DESCRIPTION
Closes #1254.

Followed the advice on the issue: prevent the app from crashing first by stringifying the value and worry about pretty printing in #1252. Still thought a bit about how we'll accomplish that and have some links I'll share on the latter issue...

<img width="952" alt="screen shot 2017-12-12 at 5 51 07 pm" src="https://user-images.githubusercontent.com/5139846/33912824-5ac686a2-df65-11e7-987c-bc89ec05ecaf.png">
