### PR TITLE
Evaluate console.(log, debug, etc) and send to the Popcode console

### DIFF
--- a/src/actions/console.js
+++ b/src/actions/console.js
@@ -23,3 +23,8 @@ export const evaluateConsoleEntry = createAction(
 export const clearConsoleEntries = createAction(
   'CLEAR_CONSOLE_ENTRIES',
 );
+
+export const consoleLogProduced = createAction(
+  'CONSOLE_LOG_PRODUCED',
+  (value, key = uuid().toString()) => ({key, value}),
+);

--- a/src/actions/console.js
+++ b/src/actions/console.js
@@ -26,6 +26,6 @@ export const clearConsoleEntries = createAction(
 
 export const consoleLogProduced = createAction(
   'CONSOLE_LOG_PRODUCED',
-  value => ({value}),
-  (_value, key = uuid().toString()) => ({key}),
+  (value, compiledProjectKey) => ({value, compiledProjectKey}),
+  (_value, _compiledProjectKey, key = uuid().toString()) => ({key}),
 );

--- a/src/actions/console.js
+++ b/src/actions/console.js
@@ -26,5 +26,6 @@ export const clearConsoleEntries = createAction(
 
 export const consoleLogProduced = createAction(
   'CONSOLE_LOG_PRODUCED',
-  (value, key = uuid().toString()) => ({key, value}),
+  value => ({value}),
+  (_value, key = uuid().toString()) => ({key}),
 );

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -55,6 +55,7 @@ import {
 import {
   clearConsoleEntries,
   consoleErrorProduced,
+  consoleLogProduced,
   consoleValueProduced,
   evaluateConsoleEntry,
 } from './console';
@@ -63,6 +64,7 @@ export {
   clearConsoleEntries,
   consoleValueProduced,
   consoleErrorProduced,
+  consoleLogProduced,
   createProject,
   createSnapshot,
   changeCurrentProject,

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -9,6 +9,7 @@ export default function Preview({
   consoleEntries,
   showingErrors,
   onConsoleError,
+  onConsoleLog,
   onConsoleValue,
   onPopOutProject,
   onRefreshClick,
@@ -25,6 +26,7 @@ export default function Preview({
       isActive={key === compiledProjects.keySeq().last()}
       key={compiledProject.compiledProjectKey}
       onConsoleError={onConsoleError}
+      onConsoleLog={onConsoleLog}
       onConsoleValue={onConsoleValue}
       onRuntimeError={onRuntimeError}
     />
@@ -56,6 +58,7 @@ Preview.propTypes = {
   consoleEntries: ImmutablePropTypes.iterable.isRequired,
   showingErrors: PropTypes.bool.isRequired,
   onConsoleError: PropTypes.func.isRequired,
+  onConsoleLog: PropTypes.func.isRequired,
   onConsoleValue: PropTypes.func.isRequired,
   onPopOutProject: PropTypes.func.isRequired,
   onRefreshClick: PropTypes.func.isRequired,

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -30,7 +30,7 @@ class PreviewFrame extends React.Component {
 
     if (this._channel && isActive) {
       for (const [key, {expression}] of newProps.consoleEntries) {
-        if (!previousConsoleEntries.has(key)) {
+        if (!previousConsoleEntries.has(key) && expression) {
           this._evaluateConsoleExpression(key, expression);
         }
       }
@@ -110,6 +110,10 @@ class PreviewFrame extends React.Component {
     });
   }
 
+  _handleConsoleLog(output) {
+    this.props.onConsoleLog(output);
+  }
+
   _attachToFrame(frame) {
     this._frame = frame;
 
@@ -131,6 +135,9 @@ class PreviewFrame extends React.Component {
 
     this._channel.bind('error', (_trans, params) => {
       this._handleErrorMessage(params);
+    });
+    this._channel.bind('log', (_trans, params) => {
+      this._handleConsoleLog(params.output);
     });
   }
 
@@ -155,6 +162,7 @@ PreviewFrame.propTypes = {
   consoleEntries: ImmutablePropTypes.iterable.isRequired,
   isActive: PropTypes.bool.isRequired,
   onConsoleError: PropTypes.func.isRequired,
+  onConsoleLog: PropTypes.func.isRequired,
   onConsoleValue: PropTypes.func.isRequired,
   onRuntimeError: PropTypes.func.isRequired,
 };

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -111,7 +111,8 @@ class PreviewFrame extends React.Component {
   }
 
   _handleConsoleLog(output) {
-    this.props.onConsoleLog(output);
+    const {compiledProjectKey} = this.props.compiledProject;
+    this.props.onConsoleLog(output, compiledProjectKey);
   }
 
   _attachToFrame(frame) {

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -110,7 +110,8 @@ class PreviewFrame extends React.Component {
     });
   }
 
-  _handleConsoleLog(output) {
+  _handleConsoleLog(consoleArgs) {
+    const output = consoleArgs.map(arg => JSON.stringify(arg)).join(' ');
     const {compiledProjectKey} = this.props.compiledProject;
     this.props.onConsoleLog(output, compiledProjectKey);
   }
@@ -138,7 +139,7 @@ class PreviewFrame extends React.Component {
       this._handleErrorMessage(params);
     });
     this._channel.bind('log', (_trans, params) => {
-      this._handleConsoleLog(params.output);
+      this._handleConsoleLog(params.args);
     });
   }
 

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -3,6 +3,7 @@ import Preview from '../components/Preview';
 import {
   addRuntimeError,
   consoleErrorProduced,
+  consoleLogProduced,
   consoleValueProduced,
   popOutProject,
   refreshPreview,
@@ -33,6 +34,10 @@ function mapDispatchToProps(dispatch) {
 
     onConsoleValue(key, value, compiledProjectKey) {
       dispatch(consoleValueProduced(key, value, compiledProjectKey));
+    },
+
+    onConsoleLog(value) {
+      dispatch(consoleLogProduced(value));
     },
 
     onPopOutProject() {

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -36,8 +36,8 @@ function mapDispatchToProps(dispatch) {
       dispatch(consoleValueProduced(key, value, compiledProjectKey));
     },
 
-    onConsoleLog(value) {
-      dispatch(consoleLogProduced(value));
+    onConsoleLog(value, compiledProjectKey) {
+      dispatch(consoleLogProduced(value, compiledProjectKey));
     },
 
     onPopOutProject() {

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import handleErrors from './previewSupport/handleErrors';
 import handleConsoleExpressions
   from './previewSupport/handleConsoleExpressions';

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,8 +1,10 @@
 import handleErrors from './previewSupport/handleErrors';
 import handleConsoleExpressions
   from './previewSupport/handleConsoleExpressions';
+import handleConsoleLogs from './previewSupport/handleConsoleLogs';
 import overrideAlert from './previewSupport/overrideAlert';
 
 handleErrors();
 handleConsoleExpressions();
+handleConsoleLogs();
 overrideAlert();

--- a/src/previewSupport/handleConsoleLogs.js
+++ b/src/previewSupport/handleConsoleLogs.js
@@ -14,6 +14,16 @@ function reducer(accumulator, currentValue) {
   return `${accumulator} ${JSON.stringify(evaluatedValue)}`;
 }
 
+function notifyChannel(args) {
+  if (args.length > 0) {
+    const output = args.reduce(reducer);
+    channel.notify({
+      method: 'log',
+      params: {output},
+    });
+  }
+}
+
 export default function handleConsoleLogs() {
   /* eslint-disable no-console */
   const browserConsoleLog = console.log.bind(console);
@@ -23,35 +33,34 @@ export default function handleConsoleLogs() {
   const browserConsoleError = console.error.bind(console);
   /* eslint-enable no-console */
 
-
   Object.defineProperties(console, {
     log: {
       value: (...args) => {
-        const output = args.reduce(reducer);
-        channel.notify({
-          method: 'log',
-          params: {output},
-        });
+        notifyChannel(args);
         browserConsoleLog(...args);
       },
     },
     debug: {
       value: (...args) => {
+        notifyChannel(args);
         browserConsoleDebug(...args);
       },
     },
     info: {
       value: (...args) => {
+        notifyChannel(args);
         browserConsoleInfo(...args);
       },
     },
     warn: {
       value: (...args) => {
+        notifyChannel(args);
         browserConsoleWarn(...args);
       },
     },
     error: {
       value: (...args) => {
+        notifyChannel(args);
         browserConsoleError(...args);
       },
     },

--- a/src/previewSupport/handleConsoleLogs.js
+++ b/src/previewSupport/handleConsoleLogs.js
@@ -1,3 +1,19 @@
+import isString from 'lodash/isString';
+import channel from './channel';
+// eslint-disable-next-line no-eval
+const globalEval = window.eval;
+
+function reducer(accumulator, currentValue) {
+  let evaluatedValue;
+  if (isString(currentValue)) {
+    evaluatedValue = currentValue;
+  } else {
+    evaluatedValue = globalEval(currentValue);
+  }
+
+  return `${accumulator} ${JSON.stringify(evaluatedValue)}`;
+}
+
 export default function handleConsoleLogs() {
   /* eslint-disable no-console */
   const browserConsoleLog = console.log.bind(console);
@@ -7,9 +23,15 @@ export default function handleConsoleLogs() {
   const browserConsoleError = console.error.bind(console);
   /* eslint-enable no-console */
 
+
   Object.defineProperties(console, {
     log: {
       value: (...args) => {
+        const output = args.reduce(reducer);
+        channel.notify({
+          method: 'log',
+          params: {output},
+        });
         browserConsoleLog(...args);
       },
     },

--- a/src/previewSupport/handleConsoleLogs.js
+++ b/src/previewSupport/handleConsoleLogs.js
@@ -1,0 +1,37 @@
+export default function handleConsoleLogs() {
+  /* eslint-disable no-console */
+  const browserConsoleLog = console.log.bind(console);
+  const browserConsoleDebug = console.debug.bind(console);
+  const browserConsoleInfo = console.info.bind(console);
+  const browserConsoleWarn = console.warn.bind(console);
+  const browserConsoleError = console.error.bind(console);
+  /* eslint-enable no-console */
+
+  Object.defineProperties(console, {
+    log: {
+      value: (...args) => {
+        browserConsoleLog(...args);
+      },
+    },
+    debug: {
+      value: (...args) => {
+        browserConsoleDebug(...args);
+      },
+    },
+    info: {
+      value: (...args) => {
+        browserConsoleInfo(...args);
+      },
+    },
+    warn: {
+      value: (...args) => {
+        browserConsoleWarn(...args);
+      },
+    },
+    error: {
+      value: (...args) => {
+        browserConsoleError(...args);
+      },
+    },
+  });
+}

--- a/src/previewSupport/handleConsoleLogs.js
+++ b/src/previewSupport/handleConsoleLogs.js
@@ -1,31 +1,31 @@
 import channel from './channel';
 
+const consoleFunctions = ['log', 'info', 'warn', 'error', 'debug'];
+
 function notifyChannel(args) {
   if (args.length > 0) {
-    const output = args.map(arg => JSON.stringify(arg)).join(' ');
     channel.notify({
       method: 'log',
-      params: {output},
+      params: {args},
     });
   }
 }
 
 export default function handleConsoleLogs() {
-  const consoleFunctions = ['log', 'info', 'warn', 'error'];
-
-  // eslint-disable-next-line no-console
-  if (console.debug) {
-    consoleFunctions.push('debug');
-  }
-
   consoleFunctions.forEach((functionName) => {
+    let browserFunction;
     // eslint-disable-next-line no-console
-    const browserFunction = console[functionName].bind(console);
-    // eslint-disable-next-line prefer-reflect
-    Object.defineProperty(console, functionName, {
+    if (console[functionName]) {
+      // eslint-disable-next-line no-console
+      browserFunction = console[functionName].bind(console);
+    }
+
+    Reflect.defineProperty(console, functionName, {
       value: (...args) => {
         notifyChannel(args);
-        browserFunction(...args);
+        if (browserFunction) {
+          browserFunction(...args);
+        }
       },
     });
   });

--- a/src/records/ConsoleEntry.js
+++ b/src/records/ConsoleEntry.js
@@ -1,7 +1,7 @@
 import {Record} from 'immutable';
 
 export default Record({
-  expression: '',
+  expression: null,
   value: null,
   error: null,
   evaluatedByCompiledProjectKey: null,

--- a/src/reducers/console.js
+++ b/src/reducers/console.js
@@ -43,7 +43,10 @@ export default function console(stateIn, {type, payload, meta}) {
     case 'CONSOLE_LOG_PRODUCED':
       return state.set(
         meta.key,
-        new ConsoleEntry({value: payload.value}),
+        new ConsoleEntry({
+          value: payload.value,
+          evaluatedByCompiledProjectKey: payload.compiledProjectKey,
+        }),
       );
     default:
       return state;

--- a/src/reducers/console.js
+++ b/src/reducers/console.js
@@ -40,6 +40,11 @@ export default function console(stateIn, {type, payload, meta}) {
       );
     case 'CLEAR_CONSOLE_ENTRIES':
       return initialState;
+    case 'CONSOLE_LOG_PRODUCED':
+      return state.set(
+        payload.key,
+        new ConsoleEntry({expression: '', value: payload.value}),
+      );
     default:
       return state;
   }

--- a/src/reducers/console.js
+++ b/src/reducers/console.js
@@ -42,8 +42,8 @@ export default function console(stateIn, {type, payload, meta}) {
       return initialState;
     case 'CONSOLE_LOG_PRODUCED':
       return state.set(
-        payload.key,
-        new ConsoleEntry({expression: '', value: payload.value}),
+        meta.key,
+        new ConsoleEntry({value: payload.value}),
       );
     default:
       return state;

--- a/test/unit/reducers/console.js
+++ b/test/unit/reducers/console.js
@@ -58,8 +58,11 @@ test('consoleErrorProduced', reducerTest(
 test('consoleLogProduced', reducerTest(
   reducer,
   initialState,
-  partial(consoleLogProduced, 'A console message', '456'),
+  partial(consoleLogProduced, 'A console message', 123456789, '456'),
   new OrderedMap({
-    456: new ConsoleEntry({value: 'A console message'}),
+    456: new ConsoleEntry({
+      value: 'A console message',
+      evaluatedByCompiledProjectKey: 123456789,
+    }),
   }),
 ));

--- a/test/unit/reducers/console.js
+++ b/test/unit/reducers/console.js
@@ -4,6 +4,7 @@ import test from 'tape';
 import {ConsoleEntry, ConsoleError} from '../../../src/records';
 import {
   consoleErrorProduced,
+  consoleLogProduced,
   consoleValueProduced,
   evaluateConsoleEntry,
 } from '../../../src/actions';
@@ -51,5 +52,14 @@ test('consoleErrorProduced', reducerTest(
       }),
       evaluatedByCompiledProjectKey: 123456789,
     }),
+  }),
+));
+
+test('consoleLogProduced', reducerTest(
+  reducer,
+  initialState,
+  partial(consoleLogProduced, 'A console message', '456'),
+  new OrderedMap({
+    456: new ConsoleEntry({expression: '', value: 'A console message'}),
   }),
 ));

--- a/test/unit/reducers/console.js
+++ b/test/unit/reducers/console.js
@@ -60,6 +60,6 @@ test('consoleLogProduced', reducerTest(
   initialState,
   partial(consoleLogProduced, 'A console message', '456'),
   new OrderedMap({
-    456: new ConsoleEntry({expression: '', value: 'A console message'}),
+    456: new ConsoleEntry({value: 'A console message'}),
   }),
 ));


### PR DESCRIPTION
In the preview frame, we capture console.log and its cousins and send the output to the Popcode console, before deferring to the browser implementation.

For now we treat all of these functions exactly the same - console.log is the only one used in the ScriptEd curriculum as far as I know.

Fixes: #1249 