### PR TITLE
Scoped evaluation of console statement

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -45,8 +45,8 @@ class PreviewFrame extends React.Component {
     this._channel.call({
       method: 'evaluateExpression',
       params: expression,
-      success: (formattedResult) => {
-        this.props.onConsoleValue(key, formattedResult);
+      success: (result) => {
+        this.props.onConsoleValue(key, JSON.stringify(result));
       },
       error: (name, message) => {
         this.props.onConsoleError(key, name, message);

--- a/src/previewSupport/createScopedEvaluationChain.js
+++ b/src/previewSupport/createScopedEvaluationChain.js
@@ -1,0 +1,19 @@
+// eslint-disable-next-line no-unused-vars
+function createScopedEvaluationChain(__yieldScopedEval) {
+  function __makeEvaluateExpression(evalInClosure) {
+    return function(expr) {
+      return evalInClosure(
+        `
+        __yieldScopedEval(__makeEvaluateExpression(function(expr) {
+          return eval(expr);
+        }));
+        ${expr}
+        `,
+      );
+    };
+  }
+  // eslint-disable-next-line no-eval
+  return __makeEvaluateExpression(expr => eval(expr));
+}
+
+export default createScopedEvaluationChain;

--- a/src/previewSupport/handleConsoleExpressions.js
+++ b/src/previewSupport/handleConsoleExpressions.js
@@ -1,11 +1,13 @@
 import channel from './channel';
+import createScopedEvaluationChain from './createScopedEvaluationChain';
 
-// eslint-disable-next-line no-eval
-const globalEval = window.eval;
+let evalNext = createScopedEvaluationChain((next) => {
+  evalNext = next;
+});
 
 export default function handleConsoleExpressions() {
   channel.bind(
     'evaluateExpression',
-    (_trans, expression) => JSON.stringify(globalEval(expression)),
+    (_trans, expression) => evalNext(expression),
   );
 }


### PR DESCRIPTION
We want console statements to be evaluated such that each statement is evaluated in the context of all the previous statements, but variables defined in the console are _not_ global variables (i.e. they should not be accessible from the project’s JS code).

Creates a `createScopedEvaluationChain` which does some fancy footwork to evaluate each statement, return the value, and also yield a function that will evaluate the next statement in the context created by the last one.

Closes #1266 