### PR TITLE
Improved scrolling behavior for console

### DIFF
--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -18,12 +18,14 @@ export default function Console({
   }
 
   const console = (
-    <div className="console__repl output__item">
-      {history.map((entry, key) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <ConsoleEntry entry={entry} key={key} />
-      )).valueSeq()}
-      <ConsoleInput onInput={onInput} />
+    <div className="console__scroll-container output__item">
+      <div className="console__repl">
+        <ConsoleInput onInput={onInput} />
+        {history.map((entry, key) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <ConsoleEntry entry={entry} key={key} />
+        )).valueSeq().reverse()}
+      </div>
     </div>
   );
 

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -457,7 +457,7 @@ body {
 /** @define console */
 
 .console {
-  flex: 0 0 auto;
+  flex: none;
 }
 
 .console__label {
@@ -465,15 +465,27 @@ body {
   background-color: var(--color-low-contrast-gray);
 }
 
-.console__repl {
-  padding: 0.5em;
-  font-family: 'Inconsolata';
+.console__scroll-container {
   height: 40vh;
+  padding: 0.5em;
+}
+
+.console__repl {
+  display: flex;
+  flex-direction: column-reverse;
+  font-family: 'Inconsolata';
+  max-height: 100%;
+  overflow: auto;
 }
 
 .console__entry,
 .console__input {
   margin-bottom: 0.5em;
+  flex: none;
+}
+
+.console__input {
+  height: 1em;
 }
 
 .console__entry {


### PR DESCRIPTION
Console now scrolls like most other consoles: once there are enough entries to overflow the available space, the extra entries overflow the top of the viewport, with the input stuck to the bottom. You can scroll up to see older entries.

Implemented with a fairly bananas feature of Flexbox, `flex-direction: column-reverse`, which just basically turns the contents of the flex container upside down.

Closes #1251 

![console](https://user-images.githubusercontent.com/14214/34075714-f91bf212-e29c-11e7-8c81-7f83b1b62b24.gif)