### PR TITLE
Don’t auto-close in the console input

### DIFF
--- a/src/components/ConsoleInput.jsx
+++ b/src/components/ConsoleInput.jsx
@@ -1,10 +1,8 @@
-import ACE from 'brace';
 import bindAll from 'lodash/bindAll';
 import isNil from 'lodash/isNil';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import createAceSessionWithoutWorker
-  from '../util/createAceSessionWithoutWorker';
+import {createAceEditor, createAceSessionWithoutWorker} from '../util/ace';
 
 export default class ConsoleInput extends Component {
   constructor() {
@@ -16,21 +14,16 @@ export default class ConsoleInput extends Component {
     const {onInput} = this.props;
 
     if (containerElement) {
-      const computedStyle = getComputedStyle(containerElement);
-      const editorOptions = {
-        fontFamily: computedStyle.getPropertyValue('font-family'),
-        fontSize: computedStyle.getPropertyValue('font-size'),
-        highlightActiveLine: false,
-        maxLines: 1,
-        minLines: 1,
-      };
-      const editor = this._editor = ACE.edit(containerElement);
+      const editor = this._editor = createAceEditor(containerElement);
       const session = createAceSessionWithoutWorker('javascript');
       editor.setSession(session);
       editor.renderer.setShowGutter(false);
-      session.setUseWrapMode(true);
       editor.moveCursorTo(0, 0);
-      editor.setOptions(editorOptions);
+      editor.setOptions({
+        highlightActiveLine: false,
+        maxLines: 1,
+        minLines: 1,
+      });
       editor.resize();
       editor.focus();
 

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ACE from 'brace';
 import bindAll from 'lodash/bindAll';
 import get from 'lodash/get';
 import throttle from 'lodash/throttle';
 import noop from 'lodash/noop';
-import createAceSessionWithoutWorker
-  from '../util/createAceSessionWithoutWorker';
+import {createAceEditor, createAceSessionWithoutWorker} from '../util/ace';
 
 import 'brace/ext/searchbox';
 import 'brace/mode/html';
@@ -98,16 +96,10 @@ class Editor extends React.Component {
 
   _setupEditor(containerElement) {
     if (containerElement) {
-      this._editor = ACE.edit(containerElement);
-      this._editor.$blockScrolling = Infinity;
+      this._editor = createAceEditor(containerElement);
       this._startNewSession(this.props.source);
-      this._disableAutoClosing();
       this._resizeEditor();
       this._editor.on('focus', this._resizeEditor);
-      this._editor.setOptions({
-        fontFamily: 'Inconsolata',
-        fontSize: '14px',
-      });
     } else {
       this._editor.destroy();
     }
@@ -121,13 +113,8 @@ class Editor extends React.Component {
     }
   }
 
-  _disableAutoClosing() {
-    this._editor.setBehavioursEnabled(false);
-  }
-
   _startNewSession(source) {
     const session = createAceSessionWithoutWorker(this.props.language, source);
-    session.setUseWrapMode(true);
     session.on('change', () => {
       this.props.onInput(this._editor.getValue());
     });

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -368,6 +368,7 @@ body {
   display: flex;
   flex-direction: column;
   font-family: 'Inconsolata';
+  font-size: 14px;
 }
 
 .editors__editor-container {
@@ -474,6 +475,7 @@ body {
   display: flex;
   flex-direction: column-reverse;
   font-family: 'Inconsolata';
+  font-size: 14px;
   max-height: 100%;
   overflow: auto;
 }

--- a/src/util/ace.js
+++ b/src/util/ace.js
@@ -1,0 +1,25 @@
+import ACE from 'brace';
+
+function disableAutoClosing(editor) {
+  editor.setBehavioursEnabled(false);
+}
+
+export function createAceEditor(element) {
+  const editor = ACE.edit(element);
+  editor.$blockScrolling = Infinity;
+  const computedStyle = getComputedStyle(element.parentElement);
+  disableAutoClosing(editor);
+  editor.setOptions({
+    fontFamily: computedStyle.getPropertyValue('font-family'),
+    fontSize: computedStyle.getPropertyValue('font-size'),
+  });
+  return editor;
+}
+
+export function createAceSessionWithoutWorker(language, source = '') {
+  const session = ACE.createEditSession(source, null);
+  session.setUseWrapMode(true);
+  session.setUseWorker(false);
+  session.setMode(`ace/mode/${language}`);
+  return session;
+}

--- a/src/util/createAceSessionWithoutWorker.js
+++ b/src/util/createAceSessionWithoutWorker.js
@@ -1,8 +1,0 @@
-import ACE from 'brace';
-
-export default function createAceSessionWithoutWorker(language, source = '') {
-  const session = ACE.createEditSession(source, null);
-  session.setUseWorker(false);
-  session.setMode(`ace/mode/${language}`);
-  return session;
-}


### PR DESCRIPTION
E.g. if the student types `{` and presses enter, that should be that.

Extracts the creation of an ACE editor with universal defaults into a module.

Fixes #1253 