### PR TITLE
Readability improvements for instructions

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -299,6 +299,22 @@ body {
   color: black;
   overflow: scroll;
   padding: 1rem;
+  line-height: 1.5em;
+
+  /* postcss-bem-linter: ignore */
+  & li {
+    margin-bottom: 0.5em;
+  }
+
+  /* postcss-bem-linter: ignore */
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    line-height: 1.2em;
+  }
 
   /* postcss-bem-linter: ignore */
   & img {
@@ -314,7 +330,8 @@ body {
   }
 
   /* postcss-bem-linter: ignore */
-  & p code.hljs {
+  & p code.hljs,
+  & li code.hljs {
     padding: 0;
   }
 }


### PR DESCRIPTION
* Open up the line height for headers and paragraph/list item text
* Remove padding from `code` blocks inside list items (as we already do for `code` inside paragraphs)
* Add a bit of bottom margin to list items

![](https://cl.ly/3q3E1F2U0R1e/Image%202017-12-17%20at%2019.55.03.png)