### PR TITLE
Ensure instructions fit within container

### DIFF
--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -133,7 +133,7 @@ export default class EditorsColumn extends React.Component {
         ref={onRef}
         style={prefixAll(style)}
       >
-        <div className="environment__columnContents editors">{children}</div>
+        <div className="environment__column-contents editors">{children}</div>
       </div>
     );
   }

--- a/src/components/Instructions.jsx
+++ b/src/components/Instructions.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import {toReact as markdownToReact} from '../util/markdown';
 
 export default function Instructions({instructions, isOpen}) {
@@ -10,14 +9,11 @@ export default function Instructions({instructions, isOpen}) {
 
   return (
     <div
-      className={classnames(
-        'layout__instructions',
-        'instructions',
-        'u__flex-container',
-        'u__flex-container_column',
-      )}
+      className="layout__instructions"
     >
-      {instructions ? markdownToReact(instructions) : null}
+      <div className="instructions">
+        {instructions ? markdownToReact(instructions) : null}
+      </div>
     </div>
   );
 }

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -18,7 +18,7 @@ export default function Output({
         pointerEvents: ignorePointerEvents ? 'none' : 'all',
       }))}
     >
-      <div className="environment__columnContents output">
+      <div className="environment__column-contents output">
         <Preview />
         <Console />
         <ErrorReport />

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -375,7 +375,7 @@ body {
   min-width: 300px;
 }
 
-.environment__columnContents {
+.environment__column-contents {
   position: absolute;
   top: 0;
   bottom: 0;

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -131,6 +131,7 @@ body {
 
 .layout__instructions {
   flex: 0 0 25%;
+  position: relative;
 }
 
 /** @define top-bar */
@@ -296,10 +297,15 @@ body {
 
 .instructions {
   background-color: var(--color-low-contrast-gray);
+  bottom: 0;
   color: black;
+  left: 0;
+  line-height: 1.5em;
   overflow: scroll;
   padding: 1rem;
-  line-height: 1.5em;
+  position: absolute;
+  right: 0;
+  top: 0;
 
   /* postcss-bem-linter: ignore */
   & li {


### PR DESCRIPTION
We want the `main` area of the screen to fill up all available vertical space not needed by the navigation bar, but no more. The instructions pane should use the vertical space afforded by its parent, but no more; if it needs more space, it should scroll internally.

Previously we were simply setting the instructions to `overflow: auto` and crossing our fingers. Chrome interpreted this the way we wanted—keep the instructions the same height its container naturally wants to be from flex. However Firefox allowed the instructions to get as big as they needed to based on content size, pushing the `main` to be bigger than the way it flexed naturally.

So, add a layer of nesting in the instructions panel; the outer div takes the height of its container via the default `align-items: stretch` in the main columns flexbox; then the inner div is absolutely positioned to fill the outer div and scroll internally.

This is identical to the way that we ensure that the widths of the editor and output columns are determined solely by flex, without the possibility of their content affecting the flex calculation.

Fixes #1303