### PR TITLE
Downgrade jshint to 2.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "inline-style-prefixer": "^3.0.8",
     "js-cookie": "^2.1.3",
     "jschannel": "^1.0.2",
-    "jshint": "^2.9.3",
+    "jshint": "2.9.4",
     "keymirror": "^0.1.1",
     "lodash": "^4.15.0",
     "loop-breaker": "^0.1.0-alpha.7",

--- a/test/unit/validations/javascript.js
+++ b/test/unit/validations/javascript.js
@@ -27,6 +27,12 @@ test('invalid LHS error followed by comment', validationTest(
   {reason: 'invalid-left-hand-string', row: 1, payload: {value: '"str"'}},
 ));
 
+test('for loop with only initializer', validationTest(
+  'for(var count=1){',
+  partialRight(javascript, analyzer),
+  {reason: 'unexpected-token', row: 0, payload: {token: ')'}},
+));
+
 test('undeclared variable', validationTest(
   'TinyTurtle.whatever();',
   partialRight(javascript, analyzer),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5387,9 +5387,9 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-jshint@^2.9.3:
-  version "2.9.5"
-  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.5.tgz#1e7252915ce681b40827ee14248c46d34e9aa62c"
+jshint@2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.4.tgz#5e3ba97848d5290273db514aee47fe24cf592934"
   dependencies:
     cli "~1.0.0"
     console-browserify "1.1.x"


### PR DESCRIPTION
JSHint 2.9.5 freezes when given certain invalid/incomplete for loop syntax. This appears to be a regression in the latest patchlevel and is fine in 2.9.4. Downgrade until the problem is fixed.

Fixes #1227