### PR TITLE
Support Chromium

### DIFF
--- a/config/browsers.json
+++ b/config/browsers.json
@@ -1,5 +1,6 @@
 {
   "firefox": "28",
   "chrome": "23",
+  "chromium": "23",
   "safari": "7.1"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,8 @@ forOwn(supportedBrowsers, (version, browser) => {
   let browserForCssnext = browser;
   if (browser === 'msie') {
     browserForCssnext = 'ie';
+  } else if (browser === 'chromium') {
+    return;
   }
   cssnextBrowsers.push(`${browserForCssnext} >= ${version}`);
 });


### PR DESCRIPTION
No reason we can’t support Chromium; Bowser considers it different from Chrome. So, add Chromium to the browser support list.

It’s stripped out when passing to `cssnext` as `browserslist` doesn’t consider Chromium a separate browser.

Fixes #1177 