### PR TITLE
Rotate Bugsnag API key

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ module.exports = {
 
   feedbackUrl: 'https://gitreports.com/issue/popcodeorg/popcode',
 
-  bugsnagApiKey: '400134511e506b91ae6c24ac962af962',
+  bugsnagApiKey: '3cc590a735bc2e50d2a21e467cf62fee',
 
   gitRevision: process.env.GIT_REVISION,
 


### PR DESCRIPTION
Someone seems to be running a downloaded copy of Popcode in production mode, which generates a bunch of noisy errors in Bugsnag. So, update the notifier key to get rid of them.