### PR TITLE
Gracefully handle compilation failures

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -41,7 +41,8 @@
     "snapshot-import-error": "Something went wrong trying to load that snapshot. Please try again.",
     "snapshot-not-found": "That snapshot doesn’t seem to exist. Check the link and try again.",
     "classroom-export-complete": "Your project is ready to share to Google Classroom",
-    "classroom-export-error": "Something went wrong trying to share to Google Classroom. Please try again."
+    "classroom-export-error": "Something went wrong trying to share to Google Classroom. Please try again.",
+    "project-compilation-failed": "Something went wrong trying to display a preview of your project. This is a bug in Popcode and we have been notified. Making another change to your code will likely fix this error."
   },
   "languages": {
     "html": "HTML",

--- a/src/actions/compiledProjects.js
+++ b/src/actions/compiledProjects.js
@@ -7,6 +7,10 @@ export const projectCompiled = createAction(
   (_source, timestamp = Date.now()) => ({timestamp}),
 );
 
+export const projectCompilationFailed = createAction(
+  'PROJECT_COMPILATION_FAILED',
+);
+
 export const refreshPreview = createAction(
   'REFRESH_PREVIEW',
   timestamp => ({timestamp}),

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -46,6 +46,7 @@ import {
 
 import {
   projectCompiled,
+  projectCompilationFailed,
   refreshPreview,
 } from './compiledProjects';
 
@@ -95,4 +96,5 @@ export {
   logOut,
   evaluateConsoleEntry,
   projectCompiled,
+  projectCompilationFailed,
 };

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -30,6 +30,13 @@ function addNotification(state, type, severity, payload = {}) {
   );
 }
 
+function dismissNotification(state, type) {
+  return state.update(
+    'notifications',
+    notifications => notifications.delete(type),
+  );
+}
+
 /* eslint-disable complexity */
 export default function ui(stateIn, action) {
   let state = stateIn;
@@ -117,10 +124,7 @@ export default function ui(stateIn, action) {
       );
 
     case 'USER_DISMISSED_NOTIFICATION':
-      return state.update(
-        'notifications',
-        notifications => notifications.delete(action.payload.type),
-      );
+      return dismissNotification(state, action.payload.type);
 
     case 'UPDATE_NOTIFICATION_METADATA':
       return state.setIn(
@@ -196,6 +200,16 @@ export default function ui(stateIn, action) {
         'error',
         action.payload,
       );
+
+    case 'PROJECT_COMPILATION_FAILED':
+      return addNotification(
+        state,
+        'project-compilation-failed',
+        'error',
+      );
+
+    case 'PROJECT_COMPILED':
+      return dismissNotification(state, 'project-compilation-failed');
 
     default:
       return state;

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -31,7 +31,11 @@ import {EmptyGistError} from '../../../src/clients/github';
 import {
   userLoggedOut,
 } from '../../../src/actions/user';
-import {applicationLoaded} from '../../../src/actions/';
+import {
+  applicationLoaded,
+  projectCompiled,
+  projectCompilationFailed,
+} from '../../../src/actions/';
 
 const initialState = Immutable.fromJS({
   editors: {
@@ -288,6 +292,20 @@ tap('123-456', snapshotKey =>
     withNotification('snapshot-created', 'notice', {snapshotKey}),
   )),
 );
+
+test('projectCompilationFailed', reducerTest(
+  reducer,
+  initialState,
+  partial(projectCompilationFailed, new Error()),
+  withNotification('project-compilation-failed', 'error'),
+));
+
+test('projectCompiled', reducerTest(
+  reducer,
+  withNotification('project-compilation-failed', 'error'),
+  partial(projectCompiled, new Error()),
+  initialState,
+));
 
 test('toggleTopBarMenu', (t) => {
   t.test('with no menu open', reducerTest(


### PR DESCRIPTION
In at least one known case, projects currently fail to compile because of a downstream error in `recast`. In general since it is possible for project compilation to throw an uncaught error, we want to catch those errors, display a useful error message, and report the error to Bugsnag. This does that.

Offers a partial fix for #1192 