### PR TITLE
Console chevron and border

### DIFF
--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -67,7 +67,7 @@ export default function Console({
       >
         <div>
           Console
-          <span className="console__chevron u__icon">{chevron}</span>
+          <span className="u__icon">{chevron}</span>
         </div>
         <div
           className="console__button console__button_clear u__icon"

--- a/src/components/ConsoleEntry.jsx
+++ b/src/components/ConsoleEntry.jsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import {ConsoleEntry as ConsoleEntryRecord} from '../records';
+import ConsoleExpression from './ConsoleExpression';
 import ConsoleOutput from './ConsoleOutput';
 
 export default function ConsoleEntry({entry, isActive}) {
-  const {expression} = entry;
   return (
     <div className="console__entry">
-      <div
-        className={
-          classnames(
-            'console__expression',
-            {console__expression_inactive: !isActive},
-          )
-        }
-      >
-        {expression}
-      </div>
-      <ConsoleOutput
-        entry={entry}
-        isActive={isActive}
-      />
+      <ConsoleExpression entry={entry} isActive={isActive} />
+      <ConsoleOutput entry={entry} isActive={isActive} />
     </div>
   );
 }

--- a/src/components/ConsoleExpression.jsx
+++ b/src/components/ConsoleExpression.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import isNil from 'lodash/isNil';
+import {ConsoleEntry as ConsoleEntryRecord} from '../records';
+
+export default function ConsoleExpression({entry: {expression}, isActive}) {
+  if (isNil(expression)) {
+    return null;
+  }
+
+  return (
+    <div
+      className={
+        classnames(
+          'console__row',
+          'console__expression',
+          {console__expression_inactive: !isActive},
+        )
+      }
+    >
+      <div className="console__chevron">&#xf054;</div>
+      {expression}
+    </div>
+  );
+}
+
+ConsoleExpression.propTypes = {
+  entry: PropTypes.instanceOf(ConsoleEntryRecord).isRequired,
+  isActive: PropTypes.bool.isRequired,
+};
+
+ConsoleExpression.defaultProps = {
+  expression: null,
+};

--- a/src/components/ConsoleInput.jsx
+++ b/src/components/ConsoleInput.jsx
@@ -66,10 +66,12 @@ export default class ConsoleInput extends Component {
   render() {
     return (
       <div
-        className="console__input"
-        ref={this._ref}
+        className="console__row console__input"
         onClick={preventClickthrough}
-      />
+      >
+        <div className="console__chevron console__chevron_blue">&#xf054;</div>
+        <div className="console__editor" ref={this._ref} />
+      </div>
     );
   }
 }

--- a/src/components/ConsoleOutput.jsx
+++ b/src/components/ConsoleOutput.jsx
@@ -5,19 +5,24 @@ import classnames from 'classnames';
 import {ConsoleEntry} from '../records';
 
 export default function ConsoleOutput({entry, isActive}) {
-  const {value, error} = entry;
+  const {expression, value, error} = entry;
+  const chevron = expression ?
+    <div className="console__chevron console__chevron_outdent">&#xf053;</div> :
+    null;
 
   if (!isNil(value)) {
     return (
       <div
         className={
           classnames(
+            'console__row',
             'console__value',
             {console__value_inactive: !isActive},
           )
         }
       >
-        =&gt; {value}
+        {chevron}
+        {value}
       </div>
     );
   }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -509,10 +509,34 @@ body {
   font-size: 20px;
 }
 
+.console__row {
+  padding-left: 1em;
+  position: relative;
+}
+
+.console__chevron {
+  color: var(--color-light-gray);
+  font-family: 'FontAwesome';
+  left: 0;
+  position: absolute;
+  top: 0;
+  transform: scale(0.6);
+  transform-origin: left center;
+}
+
+.console__chevron_blue {
+  color: var(--color-blue);
+}
+
+.console__chevron_outdent {
+  text-indent: -0.1em;
+}
+
 .console__entry,
 .console__input {
-  margin-bottom: 0.5em;
   flex: none;
+  margin-top: 0.5em;
+  padding-bottom: 0.5em;
 }
 
 .console__input {
@@ -520,7 +544,11 @@ body {
 }
 
 .console__entry {
-  margin-left: 4px;
+  border-bottom: 1px solid var(--color-low-contrast-gray);
+}
+
+.console__editor {
+  margin-left: -4px;
 }
 
 .console__error {


### PR DESCRIPTION
* Adds chevrons to console input and output. Input row displays a blue right-facing chevron. Entered expression displays a gray right-facing chevron. Expression value displays a gray left-facing chevron. Values produced by `console.log()` have no chevron, but the same indentation.
* Adds a border and some padding between entries.

![image](https://user-images.githubusercontent.com/14214/34471281-100a1602-eefa-11e7-80b2-f585a98ffe4f.png)

Closes #1312 