### PR TITLE
Hide console when errors visible rather than removing it

### DIFF
--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -12,22 +12,26 @@ export default function Console({
   onConsoleClicked,
   history,
   isEnabled,
+  isHidden,
   isOpen,
   isTextSizeLarge,
-  showingErrors,
   onClearConsoleEntries,
   onInput,
   onToggleVisible,
   onRequestedLineFocused,
   requestedFocusedLine,
 }) {
-  if (showingErrors || !isEnabled) {
+  if (!isEnabled) {
     return null;
   }
 
   const console = (
     <div
-      className="console__scroll-container output__item"
+      className={classnames(
+        'console__scroll-container',
+        'output__item',
+        {u__hidden: isHidden},
+      )}
       onClick={onConsoleClicked}
     >
       <div
@@ -45,7 +49,7 @@ export default function Console({
           const isActive =
             currentCompiledProjectKey === entry.evaluatedByCompiledProjectKey;
           return (
-          // eslint-disable-next-line react/no-array-index-key
+            // eslint-disable-next-line react/no-array-index-key
             <ConsoleEntry entry={entry} isActive={isActive} key={key} />
           );
         }).valueSeq().reverse()}
@@ -85,10 +89,10 @@ Console.propTypes = {
   currentProjectKey: PropTypes.string.isRequired,
   history: ImmutablePropTypes.iterable.isRequired,
   isEnabled: PropTypes.bool.isRequired,
+  isHidden: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   isTextSizeLarge: PropTypes.bool,
   requestedFocusedLine: PropTypes.object,
-  showingErrors: PropTypes.bool.isRequired,
   onClearConsoleEntries: PropTypes.func.isRequired,
   onConsoleClicked: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,

--- a/src/containers/Console.js
+++ b/src/containers/Console.js
@@ -27,7 +27,7 @@ function mapStateToProps(state) {
     isOpen: !getHiddenUIComponents(state).includes('console'),
     isTextSizeLarge: isTextSizeLarge(state),
     requestedFocusedLine: getRequestedFocusedLine(state),
-    showingErrors: !isCurrentProjectSyntacticallyValid(state),
+    isHidden: !isCurrentProjectSyntacticallyValid(state),
   };
 }
 


### PR DESCRIPTION
If we completely remove the console component any time the project is not in a known valid state, the console will be unmounted and remounted every time the user types a keystroke in an editor (since this puts it in a `validating` state for at least a split second). This is undesirable for several reasons, including that the console input is focused on mount (meaning it steals focus when the user is typing in a code editor); and that setting up and tearing down an ACE editor on each keystroke is a huge waste of runtime resources.

Fixed by just `display: none`ing the console component when it should not be visible.

Fixes #1325