### PR TITLE
Ignore messages from inactive preview frames

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -136,10 +136,14 @@ class PreviewFrame extends React.Component {
     });
 
     this._channel.bind('error', (_trans, params) => {
-      this._handleErrorMessage(params);
+      if (this.props.isActive) {
+        this._handleErrorMessage(params);
+      }
     });
     this._channel.bind('log', (_trans, params) => {
-      this._handleConsoleLog(params.args);
+      if (this.props.isActive) {
+        this._handleConsoleLog(params.args);
+      }
     });
   }
 


### PR DESCRIPTION
Preview frames can call `error` and `log` over JSChannel, which the `<PreviewFrame>` component listens for. However, these messages should be ignored unless the frame that sent them is the currently active preview frame. Fixes a bug where console log messages would appear duplicated after reloading the environment.

Fixes #1326