### PR TITLE
Basic pretty printing for console

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "lodash": "^4.15.0",
     "loop-breaker": "^0.1.0-alpha.7",
     "moment": "^2.14.1",
+    "object-inspect": "^1.5.0",
     "offline-plugin": "^4.8.1",
     "parse5": "^3.0.2",
     "pify": "^3.0.0",

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -46,10 +46,10 @@ class PreviewFrame extends React.Component {
     this._channel.call({
       method: 'evaluateExpression',
       params: expression,
-      success: (result) => {
+      success: (printedResult) => {
         this.props.onConsoleValue(
           key,
-          JSON.stringify(result),
+          printedResult,
           this.props.compiledProject.compiledProjectKey,
         );
       },
@@ -110,10 +110,9 @@ class PreviewFrame extends React.Component {
     });
   }
 
-  _handleConsoleLog(consoleArgs) {
-    const output = consoleArgs.map(arg => JSON.stringify(arg)).join(' ');
+  _handleConsoleLog(printedValue) {
     const {compiledProjectKey} = this.props.compiledProject;
-    this.props.onConsoleLog(output, compiledProjectKey);
+    this.props.onConsoleLog(printedValue, compiledProjectKey);
   }
 
   _attachToFrame(frame) {
@@ -142,7 +141,7 @@ class PreviewFrame extends React.Component {
     });
     this._channel.bind('log', (_trans, params) => {
       if (this.props.isActive) {
-        this._handleConsoleLog(params.args);
+        this._handleConsoleLog(params);
       }
     });
   }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -551,6 +551,10 @@ body {
   margin-left: -4px;
 }
 
+.console__value {
+  white-space: pre-wrap;
+}
+
 .console__error {
   color: var(--color-red);
 }

--- a/src/previewSupport/handleConsoleExpressions.js
+++ b/src/previewSupport/handleConsoleExpressions.js
@@ -1,5 +1,6 @@
 import channel from './channel';
 import createScopedEvaluationChain from './createScopedEvaluationChain';
+import prettyPrint from './prettyPrint';
 
 let evalNext = createScopedEvaluationChain((next) => {
   evalNext = next;
@@ -8,6 +9,6 @@ let evalNext = createScopedEvaluationChain((next) => {
 export default function handleConsoleExpressions() {
   channel.bind(
     'evaluateExpression',
-    (_trans, expression) => evalNext(expression),
+    (_trans, expression) => prettyPrint(evalNext(expression)),
   );
 }

--- a/src/previewSupport/handleConsoleLogs.js
+++ b/src/previewSupport/handleConsoleLogs.js
@@ -1,4 +1,5 @@
 import channel from './channel';
+import prettyPrint from './prettyPrint';
 
 const consoleFunctions = ['log', 'info', 'warn', 'error', 'debug'];
 
@@ -6,7 +7,7 @@ function notifyChannel(args) {
   if (args.length > 0) {
     channel.notify({
       method: 'log',
-      params: {args},
+      params: args.map(prettyPrint).join(' '),
     });
   }
 }

--- a/src/previewSupport/prettyPrint.js
+++ b/src/previewSupport/prettyPrint.js
@@ -1,0 +1,9 @@
+import inspect from 'object-inspect';
+import isUndefined from 'lodash/isUndefined';
+
+export default function prettyPrint(value) {
+  if (isUndefined(value)) {
+    return value;
+  }
+  return inspect(value, {quoteStyle: 'double'});
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6594,6 +6594,10 @@ object-hash@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.8.tgz#28a659cf987d96a4dabe7860289f3b5326c4a03c"
 
+object-inspect@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+
 object-inspect@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-0.4.0.tgz#f5157c116c1455b243b06ee97703392c5ad89fec"


### PR DESCRIPTION
Gets us marginally nicer pretty printing behavior for console output, using `object-inspect`. This is an improvement over JSX in that:

* Objects are formatted with some helpful whitespace
* Object keys are not quoted
* Functions are printed meaningfully (just shows e.g. `[Function f]` but much better than `JSON.stringify` which does nothing at all!)
* DOM nodes are printed quite nicely

Quick first pass at #1252 