### PR TITLE
Print undefined for certain entries; fixes #1333

### DIFF
--- a/src/previewSupport/prettyPrint.js
+++ b/src/previewSupport/prettyPrint.js
@@ -1,9 +1,5 @@
 import inspect from 'object-inspect';
-import isUndefined from 'lodash/isUndefined';
 
 export default function prettyPrint(value) {
-  if (isUndefined(value)) {
-    return value;
-  }
   return inspect(value, {quoteStyle: 'double'});
 }

--- a/src/util/javascript.js
+++ b/src/util/javascript.js
@@ -1,0 +1,16 @@
+import {parse} from 'esprima';
+import find from 'lodash/find';
+
+function tryParse(javascript) {
+  try {
+    return parse(javascript);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function hasExpressionStatement(javascript) {
+  const maybeParsed = tryParse(javascript);
+  return Boolean(maybeParsed && find(maybeParsed.body,
+    ({type}) => type === 'ExpressionStatement'));
+}

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -22,7 +22,7 @@ class CssValidator extends Validator {
 
   async _getRawErrors() {
     const css = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       'css',
     ));
     return css.parse(this._source, {silent: true}).stylesheet.parsingErrors;

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -134,7 +134,7 @@ class PrettyCssValidator extends Validator {
 
   async _getRawErrors() {
     const prettyCSS = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       'PrettyCSS',
     ));
     try {

--- a/src/validations/css/stylelint.js
+++ b/src/validations/css/stylelint.js
@@ -22,7 +22,7 @@ class StyleLintValidator extends Validator {
 
   async _getRawErrors() {
     const {'default': stylelint} = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       '../../util/minimalStylelint',
     ));
     let result;

--- a/src/validations/html/htmlInspector.js
+++ b/src/validations/html/htmlInspector.js
@@ -94,7 +94,7 @@ class HtmlInspectorValidator extends Validator {
     }
 
     const HTMLInspector = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       'html-inspector',
     ));
 

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -143,7 +143,7 @@ class HtmllintValidator extends Validator {
   async _getRawErrors() {
     const {Linter, rules} = await retryingFailedImports(
       () => import(
-        /* webpackChunkName: 'linters' */
+        /* webpackChunkName: 'mainAsync' */
         'htmllint',
       ),
     );

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -126,7 +126,7 @@ class SlowparseValidator extends Validator {
 
   async _getRawErrors() {
     const {'default': Slowparse} = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       '../../util/slowparse',
     ));
     let error;

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -80,7 +80,7 @@ class EsprimaValidator extends Validator {
 
   async _getRawErrors() {
     const esprima = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       'esprima',
     ));
     try {

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -172,7 +172,7 @@ class JsHintValidator extends Validator {
 
   async _getRawErrors() {
     const {JSHINT: jshint} = await retryingFailedImports(() => import(
-      /* webpackChunkName: 'linters' */
+      /* webpackChunkName: 'mainAsync' */
       'jshint',
     ));
     try {

--- a/test/unit/util/javascript.js
+++ b/test/unit/util/javascript.js
@@ -1,0 +1,36 @@
+import test from 'tape';
+import {hasExpressionStatement} from '../../../src/util/javascript';
+
+test('empty statement is not an expression statement', (assert) => {
+  assert.isEqual(hasExpressionStatement(';'), false);
+  assert.end();
+});
+
+test('variable definition is not an expression statement',
+  (assert) => {
+    assert.isEqual(hasExpressionStatement('let i = 1'), false);
+    assert.end();
+  });
+
+test('loop is not an expression statement', (assert) => {
+  assert.isEqual(
+    hasExpressionStatement('for (let i = 0; i < 10; ++i) console.log(i);'),
+    false);
+  assert.end();
+});
+
+test('malformed expression does not contain an expression statement',
+  (assert) => {
+    assert.isEqual(hasExpressionStatement('1 + 2 +'), false);
+    assert.end();
+  });
+
+test('valid expression contains an expression statement', (assert) => {
+  assert.isEqual(hasExpressionStatement('window.nothingHere'), true);
+  assert.end();
+});
+
+test('multiple statements contain an expression statement', (assert) => {
+  assert.isEqual(hasExpressionStatement('let i = 1; 2; let j = 3'), true);
+  assert.end();
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = (env = 'development') => {
     new OfflinePlugin({
       caches: {
         main: [':rest:'],
-        additional: ['linters*.js', 'previewLibraries*.js'],
+        additional: ['mainAsync*.js', 'previewLibraries*.js'],
       },
       safeToUseOptionalCaches: true,
       publicPath: '/',


### PR DESCRIPTION
Specifically, whitelists expression statements whose expression is assignment, an identifier, a literal (i.e. `undefined`), or a member expression (e.g. `obj.foo`, `arr[0]`).

Testing caveats: for some reason, the console answers never appear when I run via `yarn dev`. The answers appear from `yarn preview`, but I have to open the server in incognito mode for the `preview.js` to refresh. For `preview.js` to refresh in my normal browser session, I had to `rm -rf dist static/compiled bower_components node_modules`; not sure which directories actually cleaned up my browser session's `preview.js`.

Therefore, this PR may be incomplete; let me know how to improve testability!