### PR TITLE
Work around Chrome sandbox error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+  chrome: stable
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.2
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -77,6 +77,14 @@ module.exports = function(config) {
       reporters: ['dots', 'BrowserStack'],
     });
   } else if (isCi) {
-    config.set({browsers: ['ChromeHeadless']});
+    config.set({
+      browsers: ['ChromeHeadlessNoSandbox'],
+      customLaunchers: {
+        ChromeHeadlessNoSandbox: {
+          base: 'ChromeHeadless',
+          flags: ['--no-sandbox'],
+        },
+      },
+    });
   }
 };


### PR DESCRIPTION
In response to the Spectre/Meltdown vulnerabilities, Chrome made a change which [caused a regression on Travis preventing Chrome from running in container-based infrastructure](https://github.com/travis-ci/travis-ci/issues/8836).  This [can be worked around in a couple of ways](https://docs.travis-ci.com/user/chrome), including adding a `sudo: true` configuration to Travis, which switches the project back to the older infrastructure in which each build spins up its own VM.

That older infrastructure takes longer to build (because you have to spin up a full VM), so we prefer to stick with the container-based architecture. Accordingly, for CI builds we will run Chrome with the `--no-sandbox` flag, which allows it to run without `sudo`.