### PR TITLE
Always give imported snapshot new project key

### DIFF
--- a/src/actions/clients.js
+++ b/src/actions/clients.js
@@ -4,7 +4,10 @@ export const createSnapshot = createAction('CREATE_SNAPSHOT');
 export const snapshotCreated = createAction('SNAPSHOT_CREATED');
 export const snapshotExportError = createAction('SNAPSHOT_EXPORT_ERROR');
 export const snapshotNotFound = createAction('SNAPSHOT_NOT_FOUND');
-export const snapshotImported = createAction('SNAPSHOT_IMPORTED');
+export const snapshotImported = createAction(
+  'SNAPSHOT_IMPORTED',
+  (projectKey, project) => ({projectKey, project}),
+);
 export const snapshotImportError = createAction('SNAPSHOT_IMPORT_ERROR');
 export const projectRestoredFromLastSession =
   createAction('PROJECT_RESTORED_FROM_LAST_SESSION');

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -1,4 +1,5 @@
 import Immutable from 'immutable';
+import assign from 'lodash/assign';
 import isNil from 'lodash/isNil';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
@@ -124,7 +125,14 @@ export default function reduceProjects(stateIn, action) {
       return removePristineExcept(state, action.payload.projectKey);
 
     case 'SNAPSHOT_IMPORTED':
-      return addProject(state, action.payload);
+      return addProject(
+        state,
+        assign(
+          {},
+          action.payload.project,
+          {projectKey: action.payload.projectKey, updatedAt: null},
+        ),
+      );
 
     case 'GIST_IMPORTED':
       return importGist(

--- a/src/sagas/projects.js
+++ b/src/sagas/projects.js
@@ -58,7 +58,8 @@ export function* importSnapshot({payload: {snapshotKey}}) {
     if (isNull(snapshot)) {
       yield put(snapshotNotFound());
     } else {
-      yield put(snapshotImported(snapshot));
+      const projectKey = generateProjectKey();
+      yield put(snapshotImported(projectKey, snapshot));
     }
   } catch (error) {
     yield put(snapshotImportError(error));

--- a/test/unit/reducers/currentProject.js
+++ b/test/unit/reducers/currentProject.js
@@ -36,7 +36,7 @@ test('changeCurrentProject', reducerTest(
 test('snapshotImported', reducerTest(
   reducer,
   initialState,
-  partial(snapshotImported, {projectKey}),
+  partial(snapshotImported, projectKey, {}),
   Immutable.fromJS({projectKey}),
 ));
 

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -1,3 +1,4 @@
+import assign from 'lodash/assign';
 import test from 'tape';
 import reduce from 'lodash/reduce';
 import tap from 'lodash/tap';
@@ -90,20 +91,29 @@ test('changeCurrentProject', (t) => {
   ));
 });
 
-tap(project(), importedProject =>
+tap(project(), (importedProject) => {
+  const snapshotProjectKey = '123454321';
+
   test('snapshotImported', reducerTest(
     reducer,
     states.initial,
     partial(
       snapshotImported,
+      snapshotProjectKey,
       importedProject,
     ),
     states.initial.set(
-      importedProject.projectKey,
-      Project.fromJS(importedProject),
+      snapshotProjectKey,
+      Project.fromJS(
+        assign(
+          {},
+          importedProject,
+          {projectKey: snapshotProjectKey, updatedAt: null},
+        ),
+      ),
     ),
-  )),
-);
+  ));
+});
 
 tap(project(), rehydratedProject =>
   test('projectRestoredFromLastSession', reducerTest(


### PR DESCRIPTION
Previously the project key was retained through both project imports and exports, making it possible for a descendant of a project to overwrite the original (see fixed issue for details).

Instead, the `snapshotImported` action’s payload contains both a generated project key and the project data from the snapshot. The project key, which is generated in the saga, is always used when adding the project to the store (overwriting the original `projectKey` in the stored snapshot data).

Fixes #1341