### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "slowparse": "^1.1.4",
     "strip-markdown": "^3.0.0",
     "stylelint": "^8.0.0",
-    "sweetalert": "^2.0.8",
+    "sweetalert2": "^7.8.6",
     "uuid": "^3.1.0",
     "void-elements": "^3.1.0",
     "whatwg-fetch": "^2.0.3"

--- a/src/previewSupport/overrideAlert.js
+++ b/src/previewSupport/overrideAlert.js
@@ -1,4 +1,4 @@
-import swal from 'sweetalert';
+import swal from 'sweetalert2';
 
 export default function overrideAlert() {
   Object.defineProperties(window, { // eslint-disable-line prefer-reflect

--- a/yarn.lock
+++ b/yarn.lock
@@ -3253,10 +3253,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-object-assign@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-
 es6-set@^0.1.4, es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -9309,12 +9305,9 @@ svgo@^1.0.1:
     unquote "^1.1.0"
     util.promisify "~1.0.0"
 
-sweetalert@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/sweetalert/-/sweetalert-2.0.8.tgz#b3ee2adc4dad548d4ae998994f5ac802dc753b86"
-  dependencies:
-    es6-object-assign "^1.1.0"
-    promise-polyfill "^6.0.2"
+sweetalert2@^7.8.6:
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-7.8.6.tgz#85326eb68d6965f9ebc41ad4dfdd0945734d02ec"
 
 symbol-observable@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
  