### PR TITLE
Remove redundant null-check from Instructions.jsx

### DIFF
--- a/src/components/Instructions.jsx
+++ b/src/components/Instructions.jsx
@@ -12,7 +12,7 @@ export default function Instructions({instructions, isOpen}) {
       className="layout__instructions"
     >
       <div className="instructions">
-        {instructions ? markdownToReact(instructions) : null}
+        {markdownToReact(instructions)}
       </div>
     </div>
   );


### PR DESCRIPTION
We already return 'null' if 'instructions' is falsey, so no need to
do it in JSX too.