### PR TITLE
add highlight to starting bracket

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -121,23 +121,27 @@ class Editor extends React.Component {
     }
   }
 
+  _addMarkerToOpeningBracket() {
+    const {row, column} = this._editor.getCursorPosition();
+    const token = this._editor.session.getTokenAt(row, column);
+    this._editor.session.removeMarker(this._editor.session.$highlightMarker);
+    if (token && includes(BRACKETTYPES, token.type)) {
+      this._editor.session.$highlightMarker =
+        this._editor.session.addMarker(
+          new Range(row, token.start, row, token.start + token.value.length),
+          'ace_bracket',
+          'text',
+        );
+    }
+  }
+
   _startNewSession(source) {
     const session = createAceSessionWithoutWorker(this.props.language, source);
     session.on('change', () => {
       this.props.onInput(this._editor.getValue());
     });
     session.selection.on('changeCursor', () => {
-      const {row, column} = this._editor.getCursorPosition();
-      const token = this._editor.session.getTokenAt(row, column);
-      this._editor.session.removeMarker(this._editor.session.$highlightMarker);
-      if (token && includes(BRACKETTYPES, token.type)) {
-        this._editor.session.$highlightMarker =
-          this._editor.session.addMarker(
-            new Range(row, token.start, row, token.start + token.value.length),
-            'ace_bracket',
-            'text',
-          );
-      }
+      this._addMarkerToOpeningBracket();
     });
     session.setAnnotations(this.props.errors);
     this._editor.setSession(session);

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -4,6 +4,8 @@ import bindAll from 'lodash/bindAll';
 import get from 'lodash/get';
 import throttle from 'lodash/throttle';
 import noop from 'lodash/noop';
+import includes from 'lodash/includes';
+import ace from 'brace';
 import {createAceEditor, createAceSessionWithoutWorker} from '../util/ace';
 
 import 'brace/ext/searchbox';
@@ -15,6 +17,13 @@ import 'brace/theme/monokai';
 const RESIZE_THROTTLE = 250;
 const NORMAL_FONTSIZE = 14;
 const LARGE_FONTSIZE = 20;
+const {Range} = ace.acequire('ace/range');
+const BRACKETTYPES = [
+  'meta.tag.tag-name.xml',
+  'paren.lparen',
+  'paren.rparen',
+];
+
 
 class Editor extends React.Component {
   constructor() {
@@ -116,6 +125,19 @@ class Editor extends React.Component {
     const session = createAceSessionWithoutWorker(this.props.language, source);
     session.on('change', () => {
       this.props.onInput(this._editor.getValue());
+    });
+    session.selection.on('changeCursor', () => {
+      const {row, column} = this._editor.getCursorPosition();
+      const token = this._editor.session.getTokenAt(row, column);
+      this._editor.session.removeMarker(this._editor.session.$highlightMarker);
+      if (token && includes(BRACKETTYPES, token.type)) {
+        this._editor.session.$highlightMarker =
+          this._editor.session.addMarker(
+            new Range(row, token.start, row, token.start + token.value.length),
+            'ace_bracket',
+            'text',
+          );
+      }
     });
     session.setAnnotations(this.props.errors);
     this._editor.setSession(session);

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -452,10 +452,6 @@ body {
   pointer-events: none;
 }
 
-div.ace_bracket.ace_start.ace_br15 {
-  border: 1px solid #00ff85;
-}
-
 /** @define output */
 
 .output {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -452,6 +452,10 @@ body {
   pointer-events: none;
 }
 
+div.ace_bracket.ace_start.ace_br15 {
+  border: 1px solid #00ff85;
+}
+
 /** @define output */
 
 .output {

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -452,6 +452,11 @@ body {
   pointer-events: none;
 }
 
+/* postcss-bem-linter: ignore */
+div.ace_bracket.ace_start.ace_br15 {
+  border: 1px solid #68685b;
+}
+
 /** @define output */
 
 .output {


### PR DESCRIPTION
@outoftime Thought I'd play around with this. I updated the highlight color to make it more visible and made it so the initial tag with the cursor is highlighted in addition to the matching tag. This works for any html element, } and ).

I used the ace editor functionality using the token and bypassed the redux store storing the maker id in the editor session. Not sure if this is the best implementation. 

I thought this type of feature aligns with the mission of popcode but love to hear your thoughts 

![screen shot 2018-02-24 at 11 09 34 pm](https://user-images.githubusercontent.com/9774128/36638085-b2ae08a8-19b8-11e8-85a3-3d7f00656346.png)
![screen shot 2018-02-24 at 11 11 46 pm](https://user-images.githubusercontent.com/9774128/36638086-b72d9f10-19b8-11e8-8ced-0884244f6d62.png)
![screen shot 2018-02-24 at 11 11 32 pm](https://user-images.githubusercontent.com/9774128/36638087-b8bbd69e-19b8-11e8-81d8-eec839f99e00.png)
