### PR TITLE
Upgrade array-to-sentence library to 2.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -120,7 +120,8 @@
           "always",
           {
             "js": "never",
-            "jsx": "never"
+            "jsx": "never",
+            "mjs": "never"
           }
         ],
         "import/first": [

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "license": "MIT",
   "dependencies": {
     "PrettyCSS": "fidian/PrettyCSS#3516dfa69",
-    "array-to-sentence": "^1.1.0",
+    "array-to-sentence": "^2.0.0",
     "bowser": "^1.4.5",
     "brace": "^0.11.0",
     "bugsnag-js": "^4.0.3",

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,9 @@
 
 import '../src/init';
 import '../src/validations/linters';
+import initI18n from '../src/util/initI18n';
+
+initI18n();
 
 const testsContext = require.context('./unit');
 testsContext.keys().forEach(testsContext);

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -177,7 +177,7 @@ test('li not inside ul', validationTest(
   {
     reason: 'invalid-tag-parent',
     row: htmlWithBody.offset,
-    payload: {tag: 'li', parent: '<ul>, <ol> and <menu> tags'},
+    payload: {tag: 'li', parent: '<ul>, <ol> or <menu> tags'},
   },
 ));
 
@@ -187,7 +187,7 @@ test('li inside div', validationTest(
   {
     reason: 'invalid-tag-parent',
     row: htmlWithBody.offset,
-    payload: {tag: 'li', parent: '<ul>, <ol> and <menu> tags'},
+    payload: {tag: 'li', parent: '<ul>, <ol> or <menu> tags'},
   },
 ));
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -348,7 +348,7 @@ module.exports = (env = 'development') => {
         'github-api': 'github-api/dist/components',
         'html-inspector$': 'html-inspector/html-inspector.js',
       },
-      extensions: ['.js', '.jsx', '.json'],
+      extensions: ['.mjs', '.js', '.jsx', '.json'],
     },
     devtool: isTest ? 'inline-source-map' : 'source-map',
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,9 +517,9 @@ array-slice@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-1.1.0.tgz#e368ea15f89bc7069f7ffb89aec3a6c7d4ac22d4"
 
-array-to-sentence@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/array-to-sentence/-/array-to-sentence-1.1.0.tgz#c804956dafa53232495b205a9452753a258d39fc"
+array-to-sentence@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/array-to-sentence/-/array-to-sentence-2.0.0.tgz#1e57691fdc18ba24a47e3ebabda9324baac960b4"
 
 array-union@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Also adds support for implicitly loading `.mjs` modules.