### PR TITLE
Don’t destructure DOM collections

### DIFF
--- a/src/util/compileProject.js
+++ b/src/util/compileProject.js
@@ -90,7 +90,8 @@ function attachJavascriptLibrary(doc, javascript) {
   const scriptTag = doc.createElement('script');
   const javascriptText = String(javascript);
   scriptTag.innerHTML = javascriptText.replace(/<\/script>/g, '<\\/script>');
-  const [firstScriptTag] = doc.scripts;
+  // eslint-disable-next-line prefer-destructuring
+  const firstScriptTag = doc.scripts[0];
   if (firstScriptTag) {
     firstScriptTag.parentNode.insertBefore(scriptTag, firstScriptTag);
   } else {
@@ -126,7 +127,8 @@ function addBase(doc) {
   const {head} = doc;
   const baseTag = doc.createElement('base');
   baseTag.target = '_top';
-  const [firstChild] = head.childNodes;
+  // eslint-disable-next-line prefer-destructuring
+  const firstChild = head.childNodes[0];
   if (firstChild) {
     head.insertBefore(baseTag, firstChild);
   } else {


### PR DESCRIPTION
In Chrome 38, DOM collections have particularly buggy behavior with respect to iteration—specifically, `Symbol.iterator in domCollection` evaluates to `true`, but `domCollection[Symbol.iterator]` is undefined!  This bug is [mentioned in a `core-js` issue from around that time](https://github.com/zloirock/core-js/issues/37#issuecomment-75811905).

Transpiled array destructuring uses iteration in its implementation, and thus breaks when attempting to destructure a DOM collection in the affected Chrome version(s). Because of the inconsistent feedback given by the runtime, `core-js` isn’t able to effectively polyfill iteration on this version.

So, just don’t destructure DOM collections—instead, do it the old fashioned way.

Fixes #1338