### PR TITLE
Upgrade parse5 to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "moment": "^2.14.1",
     "object-inspect": "^1.5.0",
     "offline-plugin": "^4.8.1",
-    "parse5": "^3.0.2",
+    "parse5": "^4.0.0",
     "pify": "^3.0.0",
     "promise-retry": "^1.1.1",
     "prop-types": "^15.5.10",

--- a/src/validations/html/runRules.js
+++ b/src/validations/html/runRules.js
@@ -1,4 +1,4 @@
-import {SAXParser} from 'parse5';
+import SAXParser from 'parse5/lib/sax';
 import voidElements from 'void-elements';
 
 // Runs `rules` on `source` and promises an iterable of all errors.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7710,11 +7710,9 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
-parse5@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
+parse5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
 parseqs@0.0.5:
   version "0.0.5"


### PR DESCRIPTION
Requires explicitly importing the `sax` module, which is otherwise loaded lazily and marked as only being available in Node (despite working fine in the browser).