### PR TITLE
Explicitly set test NODE_ENV for running tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 - sh -e /etc/init.d/xvfb start
 script:
 - yarn check
-- yarn test
+- NODE_ENV=test yarn test
 - gulp build
 - eslint --no-eslintrc --env es5 dist
 - bundlesize


### PR DESCRIPTION
Based on exceptions that Bugsnag is reporting, it seems like the tests on Travis are being run with a `NODE_ENV` of production, even though the Karma configuration should be propagating `test` through the Webpack env plugin. Anyway, it’s probably more sensible to just explicitly set the environment variable when running tests.

We do keep the env variable set to `production` for the rest of the Travis run since that’s the correct value for building the production bundle that’s going to get deployed.