### PR TITLE
Upgrade esprima

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "css": "^2.2.1",
     "enumify": "^1.0.4",
     "es6-set": "^0.1.4",
-    "esprima": "^3.0.0",
+    "esprima": "^4.0.0",
     "github-api": "^3.0.0",
     "hast-util-sanitize": "^1.1.1",
     "highlight.js": "^9.12.0",

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -1,4 +1,4 @@
-import esprima from 'esprima';
+import {parse, tokenize} from 'esprima';
 import find from 'lodash/find';
 import inRange from 'lodash/inRange';
 import Validator from '../Validator';
@@ -80,10 +80,10 @@ class EsprimaValidator extends Validator {
 
   async _getRawErrors() {
     try {
-      esprima.parse(this._source);
+      parse(this._source);
     } catch (error) {
       try {
-        const tokens = esprima.tokenize(
+        const tokens = tokenize(
           this._source,
           {range: true, comment: true},
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,7 +3760,7 @@ espree@^3.5.2:
     acorn "^5.4.0"
     acorn-jsx "^3.0.0"
 
-esprima@3.x.x, esprima@^3.0.0, esprima@^3.1.3:
+esprima@3.x.x, esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 


### PR DESCRIPTION
Upgrades esprima to 4.0.0. This required switching from a default import to named imports, which somehow stymied me for months, but I’m pretty sure was all we needed to do the whole time.