### PR TITLE
Syntax highlighting updates

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -545,27 +545,27 @@ body {
 }
 
 /* postcss-bem-linter: ignore */
-.ace-sqlserver .ace_keyword.ace_operator,
-.ace-sqlserver .ace_lparen,
-.ace-sqlserver .ace_rparen,
-.ace-sqlserver .ace_punctuation {
-  color: #4f4f4f !important;
+.editors__editor.ace-sqlserver .ace_keyword.ace_operator,
+.editors__editor.ace-sqlserver .ace_lparen,
+.editors__editor.ace-sqlserver .ace_rparen,
+.editors__editor.ace-sqlserver .ace_punctuation {
+  color: #4f4f4f;
 }
 
-.ace-sqlserver .ace_support.ace_function {
-  color: #9e21c4 !important;
+.editors__editor.ace-sqlserver .ace_support.ace_function {
+  color: #9e21c4;
 }
 
-.ace-sqlserver .ace_storage {
-  color: #1724fb !important;
+.editors__editor.ace-sqlserver .ace_storage {
+  color: #1724fb;
 }
 
-.ace-sqlserver .ace_string {
-  color: #c40b17 !important;
+.editors__editor.ace-sqlserver .ace_string {
+  color: #c40b17;
 }
 
-.ace-sqlserver .ace_numeric {
-  color: #17942e !important;
+.editors__editor.ace-sqlserver .ace_numeric {
+  color: #17942e;
 }
 
 /** @define output */

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -544,6 +544,30 @@ body {
   pointer-events: none;
 }
 
+/* postcss-bem-linter: ignore */
+.ace-sqlserver .ace_keyword.ace_operator,
+.ace-sqlserver .ace_lparen,
+.ace-sqlserver .ace_rparen,
+.ace-sqlserver .ace_punctuation {
+  color: #4f4f4f !important;
+}
+
+.ace-sqlserver .ace_support.ace_function {
+  color: #9e21c4 !important;
+}
+
+.ace-sqlserver .ace_storage {
+  color: #1724fb !important;
+}
+
+.ace-sqlserver .ace_string {
+  color: #c40b17 !important;
+}
+
+.ace-sqlserver .ace_numeric {
+  color: #17942e !important;
+}
+
 /** @define output */
 
 .output {

--- a/src/util/ace.js
+++ b/src/util/ace.js
@@ -1,4 +1,5 @@
 import ACE from 'brace';
+import 'brace/theme/sqlserver';
 
 function disableAutoClosing(editor) {
   editor.setBehavioursEnabled(false);
@@ -10,6 +11,7 @@ export function inheritFontStylesFromParentElement(editor) {
   editor.setOptions({
     fontFamily: computedStyle.getPropertyValue('font-family'),
     fontSize: computedStyle.getPropertyValue('font-size'),
+    theme: 'ace/theme/sqlserver',
   });
 }
 


### PR DESCRIPTION
In reference to #1359: 
This implements a new syntax highlighting with an eye towards it being more easily readable for colorblind users (and also me real talk I have a hard time with current syntax highlighting). 

### Before

![image](https://user-images.githubusercontent.com/14214/36976362-4b0fe4ca-204b-11e8-965c-ffea4723ebe1.png)

### After

![image](https://user-images.githubusercontent.com/14214/36976371-5aba504a-204b-11e8-98ce-25385a6fd663.png)

I'd like other folks to play around with this and see how you're feeling about color choices. To implement this, I started with a different theme (sqlserver - you can see the original [here](http://ajaxorg.github.io/ace-builds/kitchen-sink.html)), which I then adjusted so that the colors would be dark enough not to be color contrast failures, plus I added highlighting for numerics. 

When I was working on this I used 3 main tools: 
1) The [Spectrum Chrome extension](https://chrome.google.com/webstore/detail/spectrum/ofclemegkcmilinpcimpjkfhjfgmhieb?hl=en), which allows you to toggle through how the page would look for people with various types of colorblindness. There are a lot in the list but I focused on deuteranopia, protanopia, and tritanopia, as those were what I'd seen listed on other resources.
2) This website on [color palettes](http://mkweb.bcgsc.ca/colorblind/) for colorblindess, specifically the [12-color palette for colorblindness](http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.simple.png)
3) This [contrast ratio checker](http://leaverou.github.io/contrast-ratio/), which I used to ensure that the syntax highlighting was still readable (most colors pass AAA, all pass AA)

I know the linter isn't passing right now! I will come back and fix I'm just sleepy haha. 