### PR TITLE
Links from instructions open in a new window

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "redux-saga": "^0.16.0",
     "redux-saga-debounce-effect": "^0.2.2",
     "remark": "^9.0.0",
+    "remark-external-links": "^1.0.1",
     "remark-react": "^4.0.0",
     "remark-react-lowlight": "^0.7.0",
     "reselect": "^3.0.1",

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -1,6 +1,7 @@
 import memoize from 'lodash/memoize';
 import remark from 'remark';
 import remarkReact from 'remark-react';
+import externalLinks from 'remark-external-links';
 import remarkLowlight from 'remark-react-lowlight';
 import css from 'highlight.js/lib/languages/css';
 import xml from 'highlight.js/lib/languages/xml';
@@ -17,12 +18,14 @@ const remarkWithHighlighting = memoize(() => {
     }),
   });
 
-  return remark().use(remarkReact, {
-    sanitize: schema,
-    remarkReactComponents: {
-      code: remarkLowlight({css, js, xml}),
-    },
-  });
+  return remark().
+    use(externalLinks).
+    use(remarkReact, {
+      sanitize: schema,
+      remarkReactComponents: {
+        code: remarkLowlight({css, js, xml}),
+      },
+    });
 });
 
 export function toReact(markdown) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,6 +2795,10 @@ css-select@~1.3.0-rc0:
     domutils "1.5.1"
     nth-check "^1.0.1"
 
+css-selector-parser@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.3.0.tgz#5f1ad43e2d8eefbfdc304fcd39a521664943e3eb"
+
 css-tree@1.0.0-alpha.27:
   version "1.0.0-alpha.27"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.27.tgz#f211526909c7dc940843d83b9376ed98ddb8de47"
@@ -8874,6 +8878,12 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-external-links@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/remark-external-links/-/remark-external-links-1.0.1.tgz#6140251948eb408bae596d96e3ec2f79678f177e"
+  dependencies:
+    unist-util-select "~1.5.0"
+
 remark-parse@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-1.1.0.tgz#c3ca10f9a8da04615c28f09aa4e304510526ec21"
@@ -10812,6 +10822,14 @@ unist-util-remove-position@^1.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
   dependencies:
     unist-util-visit "^1.1.0"
+
+unist-util-select@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-1.5.0.tgz#a93c2be8c0f653827803b81331adec2aa24cd933"
+  dependencies:
+    css-selector-parser "^1.1.0"
+    debug "^2.2.0"
+    nth-check "^1.0.1"
 
 unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Runs instructions markdown through `remark-external-links`, which by default adds a `target="_blank"` and `rel="noopener noreferrer"` to anchor tags.

At this point this is hard-coded into the `toReact` method used here, with no option to disable it—could always make it optional in the future, but it’s hard to imagine a situation in which we wouldn’t want links from processed Markdown to open in a new window.