### PR TITLE
Remove anonymous gist export

### DIFF
--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -5,7 +5,6 @@ import trim from 'lodash/trim';
 import performWithRetries from '../util/performWithRetries';
 import compileProject from '../util/compileProject';
 
-const anonymousGithub = new GitHub({});
 const COMMIT_MESSAGE = 'Created using Popcode: https://popcode.org';
 const MASTER = 'master';
 const GH_PAGES = 'gh-pages';
@@ -70,11 +69,7 @@ export async function createGistFromProject(project, user) {
   const response =
     await performWithRetryNetworkErrors(() => github.getGist().create(gist));
 
-  const gistData = response.data;
-  if (canUpdateGist(user)) {
-    return updateGistWithImportUrl(github, gistData);
-  }
-  return gistData;
+  return updateGistWithImportUrl(github, response.data);
 }
 
 export async function loadGistFromId(gistId, user) {
@@ -253,19 +248,7 @@ function githubWithAccessToken(token) {
   return new GitHub({auth: 'oauth', token});
 }
 
-function getGithubToken(user) {
-  return get(user, ['accessTokens', 'github.com']);
-}
-
 function clientForUser(user) {
-  const githubToken = getGithubToken(user);
-  if (githubToken) {
-    return githubWithAccessToken(githubToken);
-  }
-
-  return anonymousGithub;
-}
-
-function canUpdateGist(user) {
-  return Boolean(getGithubToken(user));
+  const githubToken = get(user, ['accessTokens', 'github.com']);
+  return githubWithAccessToken(githubToken);
 }

--- a/src/components/TopBar/HamburgerMenu.jsx
+++ b/src/components/TopBar/HamburgerMenu.jsx
@@ -24,12 +24,6 @@ const HamburgerMenu = createMenu({
     return tap([], (items) => {
       items.push(
         <MenuItem
-          key="exportGist"
-          onClick={isGistExportInProgress ? noop : onExportGist}
-        >
-          {t('top-bar.export-gist')}
-        </MenuItem>,
-        <MenuItem
           key="exportToClassroom"
           onClick={isClassroomExportInProgress ? noop : onExportToClassroom}
         >
@@ -37,15 +31,26 @@ const HamburgerMenu = createMenu({
         </MenuItem>,
       );
 
-      if (isUserAuthenticated && isExperimental) {
+      if (isUserAuthenticated) {
         items.push(
           <MenuItem
-            key="exportRepo"
-            onClick={isRepoExportInProgress ? noop : onExportRepo}
+            key="exportGist"
+            onClick={isGistExportInProgress ? noop : onExportGist}
           >
-            {t('top-bar.export-repo')}
+            {t('top-bar.export-gist')}
           </MenuItem>,
         );
+
+        if (isExperimental) {
+          items.push(
+            <MenuItem
+              key="exportRepo"
+              onClick={isRepoExportInProgress ? noop : onExportRepo}
+            >
+              {t('top-bar.export-repo')}
+            </MenuItem>,
+          );
+        }
       }
 
       items.push(


### PR DESCRIPTION
GitHub will shortly be [removing the ability to do anonymous gist export via their API](https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/).  So, only show the **Export Gist** button if you’re logged in. The GitHub client now assumes you’re authenticated when doing a gist export, which allows us to trim some no-longer-needed code.

Fixes #1363