### PR TITLE
Preserve experimental flag (and only experimental) after refresh

### DIFF
--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -10,9 +10,9 @@ import get from 'lodash/get';
 import partial from 'lodash/partial';
 import map from 'lodash/map';
 import {t} from 'i18next';
-import qs from 'qs';
 import classnames from 'classnames';
 import {getNodeWidth, getNodeWidths} from '../util/resize';
+import {getQueryParameters, setQueryParameters} from '../util/queryParams';
 import {dehydrateProject, rehydrateProject} from '../clients/localStorage';
 
 import {
@@ -76,21 +76,13 @@ class Workspace extends React.Component {
   }
 
   componentWillMount() {
-    let gistId = null;
-    let snapshotKey = null;
-    let isExperimental = false;
-    if (location.search) {
-      const query = qs.parse(location.search.slice(1));
-      if (query.gist) {
-        gistId = query.gist;
-      }
-      if (query.snapshot) {
-        snapshotKey = query.snapshot;
-      }
-      isExperimental = Object.keys(query).includes('experimental');
-    }
+    const {
+      gistId,
+      snapshotKey,
+      isExperimental,
+    } = getQueryParameters(location.search);
     const rehydratedProject = rehydrateProject();
-    history.replaceState({}, '', location.pathname);
+    setQueryParameters({isExperimental});
     this.props.dispatch(applicationLoaded({
       snapshotKey,
       gistId,

--- a/src/util/queryParams.js
+++ b/src/util/queryParams.js
@@ -1,0 +1,30 @@
+import qs from 'qs';
+
+export function getQueryParameters(queryString) {
+  let gistId = null;
+  let snapshotKey = null;
+  let isExperimental = false;
+  if (queryString) {
+    const query = qs.parse(queryString.slice(1));
+    if (query.gist) {
+      gistId = query.gist;
+    }
+    if (query.snapshot) {
+      snapshotKey = query.snapshot;
+    }
+    isExperimental = Object.keys(query).includes('experimental');
+  }
+  return {
+    gistId,
+    snapshotKey,
+    isExperimental,
+  };
+}
+
+export function setQueryParameters(params) {
+  if (params.isExperimental) {
+    history.replaceState({}, '', '?experimental');
+  } else {
+    history.replaceState({}, '', location.pathname);
+  }
+}

--- a/test/unit/util/queryParams.js
+++ b/test/unit/util/queryParams.js
@@ -1,0 +1,48 @@
+import test from 'tape';
+import {getQueryParameters} from '../../../src/util/queryParams';
+
+
+test('empty querystring', (assert) => {
+  const {gistId, snapshotKey, isExperimental} = getQueryParameters('');
+  assert.isEqual(gistId, null);
+  assert.isEqual(snapshotKey, null);
+  assert.isEqual(isExperimental, false);
+  assert.end();
+});
+
+test('snapshot url', (assert) => {
+  const {
+    gistId,
+    snapshotKey,
+    isExperimental,
+  } = getQueryParameters('?snapshot=90283083-5951-4af8-bc12-2fe889ea5e4a');
+  assert.isEqual(gistId, null);
+  assert.isEqual(snapshotKey, '90283083-5951-4af8-bc12-2fe889ea5e4a');
+  assert.isEqual(isExperimental, false);
+  assert.end();
+});
+
+
+test('experimental url', (assert) => {
+  const {
+    gistId,
+    snapshotKey,
+    isExperimental,
+  } = getQueryParameters('?experimental');
+  assert.isEqual(gistId, null);
+  assert.isEqual(snapshotKey, null);
+  assert.isEqual(isExperimental, true);
+  assert.end();
+});
+
+test('gist url', (assert) => {
+  const {
+    gistId,
+    snapshotKey,
+    isExperimental,
+  } = getQueryParameters('?gist=223f7869fa7dea6089dffd72a38c3286');
+  assert.isEqual(gistId, '223f7869fa7dea6089dffd72a38c3286');
+  assert.isEqual(snapshotKey, null);
+  assert.isEqual(isExperimental, false);
+  assert.end();
+});


### PR DESCRIPTION
Factor our functions dealing with the url query parameters to a
helper module

Fixes: #1358