### PR TITLE
Hide console during error state

### DIFF
--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -22,11 +22,7 @@ export default function Console({
 }) {
   const console = (
     <div
-      className={classnames(
-        'console__scroll-container',
-        'output__item',
-        {u__hidden: isHidden},
-      )}
+      className="console__scroll-container output__item"
       onClick={onConsoleClicked}
     >
       <div
@@ -55,7 +51,12 @@ export default function Console({
   const chevron = isOpen ? ' \uf078' : ' \uf077';
 
   return (
-    <div className="console">
+    <div
+      className={classnames(
+        'console',
+        {u__hidden: isHidden},
+      )}
+    >
       <div
         className="label console__label"
         onClick={partial(onToggleVisible, currentProjectKey)}


### PR DESCRIPTION
closes #1348

The console was not being hidden during the error state, because the `u__hidden` class was applied to the wrong element.