### PR TITLE
Add allow-popups-to-escape-sandbox token to PreviewFrame

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -13,6 +13,7 @@ import {CompiledProject as CompiledProjectRecord} from '../records';
 const sandboxOptions = [
   'allow-forms',
   'allow-popups',
+  'allow-popups-to-escape-sandbox',
   'allow-scripts',
   'allow-top-navigation',
 ].join(' ');


### PR DESCRIPTION
closes #1176

Adds `allow-popups-to-escape-sandbox` to the preview's iframe, so that links with `target="_blank"` will open correctly.