### PR TITLE
Improvements to development preview script

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "lint": "eslint --ext .js,.jsx --plugin react src test *.js && stylelint src/**/*.css",
     "fixlint": "eslint --ext .js,.jsx --plugin react --fix src test *.js",
     "toc": "doctoc README.md --github --title '## Table of Contents'",
-    "preview": "rm -rvf dist && NODE_ENV=production gulp build && static -a 0.0.0.0 -p 3000 dist",
+    "preview": "rm -rvf dist/* && NODE_ENV=production gulp build && static -a 0.0.0.0 -p 3000 dist",
     "analyze-bundle": "gulp js --production && source-map-explorer ./dist/application.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "lint": "eslint --ext .js,.jsx --plugin react src test *.js && stylelint src/**/*.css",
     "fixlint": "eslint --ext .js,.jsx --plugin react --fix src test *.js",
     "toc": "doctoc README.md --github --title '## Table of Contents'",
-    "preview": "rm -rvf dist && NODE_ENV=production gulp build && static dist",
+    "preview": "rm -rvf dist && NODE_ENV=production gulp build && static -a 0.0.0.0 -p 3000 dist",
     "analyze-bundle": "gulp js --production && source-map-explorer ./dist/application.js"
   },
   "devDependencies": {


### PR DESCRIPTION
`yarn preview` will run a server hosting Popcode compiled in the same way it is for production. Particularly useful for testing changes to Webpack configurations etc.

A couple of improvements:

* Runs preview on port 3000, matching normal BrowserSync behavior
* Only removes the *contents* of `dist` before building (needed to work on Docker)