### PR TITLE
Upgrade i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "highlight.js": "^9.12.0",
     "html-inspector": "^0.8.2",
     "htmllint": "^0.7.0",
-    "i18next": "^10.0.1",
+    "i18next": "^11.2.3",
     "immutable": "^3.7.5",
     "inline-style-prefixer": "^4.0.0",
     "js-cookie": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4824,9 +4824,9 @@ i18next-resource-store-loader@^0.1.1:
     loader-utils "^0.2.11"
     lodash "^4.6.1"
 
-i18next@^10.0.1:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-10.6.0.tgz#90ffd9f9bc617f34b9a12e037260f524445f7684"
+i18next@^11.2.3:
+  version "11.2.3"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-11.2.3.tgz#cc29400460ede53ecc0a3a399e3497e82a1d830e"
 
 iconv-lite@0.4.15:
   version "0.4.15"


### PR DESCRIPTION
[Breaking changes](https://github.com/i18next/i18next/blob/master/CHANGELOG.md#1100---1111-fixing-version-mismatch-cdnjs---npm) look pretty clearly not relevant to us