### PR TITLE
Mark production as safe to use optional caches

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,6 +101,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
           main: [/(?:^|~)(?:main|preview)[-.~]/, ':externals:'],
           additional: [':rest:'],
         },
+        safeToUseOptionalCaches: isProduction,
         AppCache: {
           caches: ['main', 'additional', 'optional'],
         },


### PR DESCRIPTION
Optional caches require the assets be hashed and available permanently, which is the case in production.