### PR TITLE
Prefetch async chunks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,10 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
       }),
       new ScriptExtHtmlWebpackPlugin({
         defaultAttribute: 'defer',
+        prefetch: {
+          chunks: 'async',
+          test: /\.js$/,
+        },
         custom: [
           {
             test: /^(?!(|.*~)main[.~-])/,


### PR DESCRIPTION
Automatically generates `<link rel="prefetch">` resource hints for async JavaScript chunks. Inspired by the recent updates to Webpack supporting this as built-in functionality, but actually uses the `script-ext-html-webpack-plugin`, which uses the native browser feature rather than reimplementing it in JavaScript. The native functionality should be more efficient since the browser can start doing work before the main JS is loaded.

Unfortunately this does mean that Safari won’t benefit from the prefetching at all, since it doesn’t support prefetch resource hints, but it’s just a performance optimization so not the end of the world.