### PR TITLE
Workspace and EditorsColumn containers

### DIFF
--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -4,7 +4,7 @@ import bowser from 'bowser';
 import createApplicationStore from '../createApplicationStore';
 import {ErrorBoundary, includeStoreInBugReports} from '../util/bugsnag';
 import supportedBrowsers from '../../config/browsers.json';
-import Workspace from './Workspace';
+import Workspace from '../containers/Workspace';
 import BrowserError from './BrowserError';
 import IEBrowserError from './IEBrowserError';
 

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -50,12 +50,13 @@ export default class EditorsColumn extends React.Component {
       currentProject,
       editorsFlex,
       errors,
+      isTextSizeLarge,
+      requestedFocusedLine,
       onComponentHide,
       onEditorInput,
       onRef,
       onRequestedLineFocused,
       style,
-      ui,
     } = this.props;
 
     const children = [];
@@ -73,7 +74,11 @@ export default class EditorsColumn extends React.Component {
           language={language}
           source={currentProject.sources[language]}
           style={{flex: editorsFlex[index]}}
-          onHide={partial(onComponentHide, `editor.${language}`)}
+          onHide={partial(
+            onComponentHide,
+            currentProject.projectKey,
+            `editor.${language}`,
+          )}
           onRef={partial(this._storeEditorRef, index)}
         >
           <Editor
@@ -81,10 +86,14 @@ export default class EditorsColumn extends React.Component {
             language={language}
             percentageOfHeight={1 / visibleLanguages.length}
             projectKey={currentProject.projectKey}
-            requestedFocusedLine={ui.editors.requestedFocusedLine}
+            requestedFocusedLine={requestedFocusedLine}
             source={currentProject.sources[language]}
-            textSizeIsLarge={ui.editors.textSizeIsLarge}
-            onInput={partial(onEditorInput, language)}
+            textSizeIsLarge={isTextSizeLarge}
+            onInput={partial(
+              onEditorInput,
+              currentProject.projectKey,
+              language,
+            )}
             onRequestedLineFocused={onRequestedLineFocused}
           />
         </EditorContainer>,
@@ -111,6 +120,7 @@ export default class EditorsColumn extends React.Component {
           key={language}
           onClick={partial(
             this.props.onComponentUnhide,
+            currentProject.projectKey,
             `editor.${language}`,
           )}
         >
@@ -143,14 +153,17 @@ EditorsColumn.propTypes = {
   currentProject: PropTypes.object.isRequired,
   editorsFlex: PropTypes.array.isRequired,
   errors: PropTypes.object.isRequired,
+  isTextSizeLarge: PropTypes.bool.isRequired,
+  requestedFocusedLine: PropTypes.object,
   style: PropTypes.object.isRequired,
-  ui: PropTypes.shape({
-    editors: PropTypes.object.isRequired,
-  }).isRequired,
   onComponentHide: PropTypes.func.isRequired,
   onComponentUnhide: PropTypes.func.isRequired,
   onDividerDrag: PropTypes.func.isRequired,
   onEditorInput: PropTypes.func.isRequired,
   onRef: PropTypes.func.isRequired,
   onRequestedLineFocused: PropTypes.func.isRequired,
+};
+
+EditorsColumn.defaultProps = {
+  requestedFocusedLine: null,
 };

--- a/src/containers/EditorsColumn.js
+++ b/src/containers/EditorsColumn.js
@@ -1,0 +1,55 @@
+import {connect} from 'react-redux';
+import EditorsColumn from '../components/EditorsColumn';
+import {
+  getCurrentProject,
+  getEditorsFlex,
+  getErrors,
+  getRequestedFocusedLine,
+  isTextSizeLarge,
+} from '../selectors';
+import {
+  dragRowDivider,
+  editorFocusedRequestedLine,
+  hideComponent,
+  updateProjectSource,
+  unhideComponent,
+} from '../actions';
+
+function mapStateToProps(state) {
+  return {
+    currentProject: getCurrentProject(state),
+    editorsFlex: getEditorsFlex(state),
+    errors: getErrors(state),
+    isTextSizeLarge: isTextSizeLarge(state),
+    requestedFocusedLine: getRequestedFocusedLine(state),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onComponentHide(projectKey, componentName) {
+      dispatch(hideComponent(projectKey, componentName));
+    },
+
+    onComponentUnhide(projectKey, componentName) {
+      dispatch(unhideComponent(projectKey, componentName));
+    },
+
+    onDividerDrag(data) {
+      dispatch(dragRowDivider(data));
+    },
+
+    onEditorInput(projectKey, language, source) {
+      dispatch(updateProjectSource(projectKey, language, source));
+    },
+
+    onRequestedLineFocused() {
+      dispatch(editorFocusedRequestedLine());
+    },
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditorsColumn);

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -1,0 +1,50 @@
+import {connect} from 'react-redux';
+import Workspace from '../components/Workspace';
+import {getCurrentProject, isEditingInstructions} from '../selectors';
+import {
+  dragColumnDivider,
+  startDragColumnDivider,
+  stopDragColumnDivider,
+  toggleComponent,
+  applicationLoaded,
+} from '../actions';
+
+function mapStateToProps(state) {
+  return {
+    currentProject: getCurrentProject(state),
+    isDraggingColumnDivider: state.getIn(
+      ['ui', 'workspace', 'isDraggingColumnDivider'],
+    ),
+    isEditingInstructions: isEditingInstructions(state),
+    rowsFlex: state.getIn(['ui', 'workspace', 'rowFlex']).toJS(),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onApplicationLoaded(payload) {
+      dispatch(applicationLoaded(payload));
+    },
+
+    onComponentToggle(projectKey, componentName) {
+      dispatch(toggleComponent(projectKey, componentName));
+    },
+
+    onDragColumnDivider(payload) {
+      dispatch(dragColumnDivider(payload));
+    },
+
+    onStartDragColumnDivider() {
+      dispatch(startDragColumnDivider());
+    },
+
+    onStopDragColumnDivider() {
+      dispatch(stopDragColumnDivider());
+    },
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Workspace);

--- a/src/selectors/getEditorsFlex.js
+++ b/src/selectors/getEditorsFlex.js
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+
+export default createSelector(
+  [state => state.getIn(['ui', 'workspace', 'columnFlex'])],
+  flex => flex.toJS(),
+);

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -9,6 +9,7 @@ import getCurrentProjectKey from './getCurrentProjectKey';
 import getCurrentUser from './getCurrentUser';
 import getCurrentUserId from './getCurrentUserId';
 import getCurrentValidationState from './getCurrentValidationState';
+import getEditorsFlex from './getEditorsFlex';
 import getEnabledLibraries from './getEnabledLibraries';
 import getErrors from './getErrors';
 import getHiddenUIComponents from './getHiddenUIComponents';
@@ -42,6 +43,7 @@ export {
   getCurrentUser,
   getCurrentUserId,
   getCurrentValidationState,
+  getEditorsFlex,
   getEnabledLibraries,
   getErrors,
   getHiddenUIComponents,


### PR DESCRIPTION
Finishes the long-stalled refactor which puts all major structural components inside containers. The `<Workspace>` and `<EditorsColumn>` components are now paired with containers for connection to Redux.

The `<Workspace>` component in particular needs more cleanup, but the further work needed is outside the scope of this PR.