### PR TITLE
containerize output

### DIFF
--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -6,10 +6,14 @@ import Preview from '../containers/Preview';
 import Console from '../containers/Console';
 
 export default function Output({
-  ignorePointerEvents,
+  isAnyTopBarMenuOpen,
+  isDraggingColumnDivider,
   style,
   onRef,
 }) {
+  const ignorePointerEvents =
+    isDraggingColumnDivider || isAnyTopBarMenuOpen;
+
   return (
     <div
       className="environment__column"
@@ -28,7 +32,8 @@ export default function Output({
 }
 
 Output.propTypes = {
-  ignorePointerEvents: PropTypes.bool.isRequired,
+  isAnyTopBarMenuOpen: PropTypes.bool.isRequired,
+  isDraggingColumnDivider: PropTypes.bool.isRequired,
   style: PropTypes.object.isRequired,
   onRef: PropTypes.func.isRequired,
 };

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -17,7 +17,7 @@ import TopBar from '../containers/TopBar';
 import Instructions from '../containers/Instructions';
 import NotificationList from '../containers/NotificationList';
 import EditorsColumn from '../containers/EditorsColumn';
-import Output from './Output';
+import Output from '../containers/Output';
 import PopThrobber from './PopThrobber';
 
 export default class Workspace extends React.Component {
@@ -64,20 +64,6 @@ export default class Workspace extends React.Component {
     if (!isNull(currentProject) && !isPristineProject(currentProject)) {
       dehydrateProject(currentProject);
     }
-  }
-
-  _renderOutput() {
-    const {isDraggingColumnDivider, rowsFlex} = this.props;
-    return (
-      <Output
-        ignorePointerEvents={
-          isDraggingColumnDivider ||
-            Boolean(get(this, 'props.ui.topBar.openMenu'))
-        }
-        style={{flex: rowsFlex[1]}}
-        onRef={partial(this._storeColumnRef, 1)}
-      />
-    );
   }
 
   _handleClickInstructionsBar() {
@@ -162,7 +148,10 @@ export default class Workspace extends React.Component {
             ref={this._storeDividerRef}
           />
         </DraggableCore>
-        {this._renderOutput()}
+        <Output
+          style={{flex: rowsFlex[1]}}
+          onRef={partial(this._storeColumnRef, 1)}
+        />
       </div>
     );
   }
@@ -186,7 +175,6 @@ export default class Workspace extends React.Component {
 
 Workspace.propTypes = {
   currentProject: PropTypes.object,
-  isDraggingColumnDivider: PropTypes.bool.isRequired,
   isEditingInstructions: PropTypes.bool.isRequired,
   rowsFlex: PropTypes.array.isRequired,
   onApplicationLoaded: PropTypes.func.isRequired,

--- a/src/containers/Output.js
+++ b/src/containers/Output.js
@@ -1,0 +1,17 @@
+import {connect} from 'react-redux';
+import Output from '../components/Output';
+import {
+  isDraggingColumnDivider,
+  getOpenTopBarMenu,
+} from '../selectors';
+
+function mapStateToProps(state) {
+  return {
+    isDraggingColumnDivider: isDraggingColumnDivider(state),
+    isAnyTopBarMenuOpen: Boolean(getOpenTopBarMenu(state)),
+  };
+}
+
+export default connect(
+  mapStateToProps,
+)(Output);

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -12,9 +12,6 @@ import {
 function mapStateToProps(state) {
   return {
     currentProject: getCurrentProject(state),
-    isDraggingColumnDivider: state.getIn(
-      ['ui', 'workspace', 'isDraggingColumnDivider'],
-    ),
     isEditingInstructions: isEditingInstructions(state),
     rowsFlex: state.getIn(['ui', 'workspace', 'rowFlex']).toJS(),
   };

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -22,6 +22,7 @@ import getRequestedFocusedLine from './getRequestedFocusedLine';
 import isCurrentlyValidating from './isCurrentlyValidating';
 import isCurrentProjectSyntacticallyValid
   from './isCurrentProjectSyntacticallyValid';
+import isDraggingColumnDivider from './isDraggingColumnDivider';
 import isEditingInstructions from './isEditingInstructions';
 import isExperimental from './isExperimental';
 import isGistExportInProgress from './isGistExportInProgress';
@@ -56,6 +57,7 @@ export {
   getRequestedFocusedLine,
   isCurrentlyValidating,
   isCurrentProjectSyntacticallyValid,
+  isDraggingColumnDivider,
   isEditingInstructions,
   isExperimental,
   isGistExportInProgress,

--- a/src/selectors/isDraggingColumnDivider.js
+++ b/src/selectors/isDraggingColumnDivider.js
@@ -1,0 +1,3 @@
+export default function isDraggingColumnDivider(state) {
+  return state.getIn(['ui', 'workspace', 'isDraggingColumnDivider']);
+}


### PR DESCRIPTION
This PR containerizes the Output.

@outoftime I think the draggable console PR was getting a bit unruly. I thought it would be better to chunk it out into some separate PRs. Doesn't do much as a stand alone but should make it easier to implement the console divider drag later on. 

