### PR TITLE
Store exported repos by username 

### DIFF
--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -25,8 +25,12 @@ function normalizeTitle(title) {
   return titleWithoutPunctuationAndWhitespace;
 }
 
+function getRepoNameForUser(project, user) {
+  return project.externalLocations.githubRepos[user.githubUsername];
+}
+
 export async function createOrUpdateRepoFromProject(project, user) {
-  const repoAlreadyExists = Boolean(project.externalLocations.githubRepoName);
+  const repoAlreadyExists = Boolean(getRepoNameForUser(project, user));
   if (repoAlreadyExists) {
     return updateRepoFromProject(project, user);
   }
@@ -65,7 +69,7 @@ async function createRepoFromProject(project, user) {
 
 export async function updateRepoFromProject(project, user) {
   const github = await clientForUser(user);
-  const repoName = project.externalLocations.githubRepoName;
+  const repoName = getRepoNameForUser(project, user);
 
   const {data: userData} = await performWithRetryNetworkErrors(
     () => github.getUser().getProfile(),

--- a/src/records/Project.js
+++ b/src/records/Project.js
@@ -1,4 +1,4 @@
-import {Record, Set} from 'immutable';
+import {Map, Record, Set} from 'immutable';
 
 import HTML_TEMPLATE from '../../templates/new.html';
 
@@ -9,7 +9,7 @@ const Sources = Record({
 });
 
 const ExternalLocations = Record({
-  githubRepoName: null,
+  githubRepos: new Map(),
 });
 
 export default class Project extends Record({

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -211,10 +211,17 @@ export default function reduceProjects(stateIn, action) {
 
     case 'PROJECT_EXPORTED':
       if (action.payload.exportType === 'repo' &&
-        action.payload.exportData.name) {
-        return state.setIn(
-          [action.payload.projectKey, 'externalLocations', 'githubRepoName'],
-          action.payload.exportData.name,
+        action.payload.exportData.repoName) {
+        return state.mergeIn(
+          [
+            action.payload.projectKey,
+            'externalLocations',
+            'githubRepos',
+          ],
+          Immutable.fromJS({
+            [action.payload.exportData.username]:
+              action.payload.exportData.repoName,
+          }),
         ).setIn(
           [action.payload.projectKey, 'updatedAt'],
           action.meta.timestamp,

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -11,19 +11,18 @@ function user(stateIn, action) {
       const {user: userData, credential, additionalUserInfo} = action.payload;
 
       const profileData = get(userData, ['providerData', 0], userData);
+      const githubUsername = get(additionalUserInfo, 'username');
 
       return state.merge({
         authenticated: true,
         id: userData.uid,
-        displayName: profileData.displayName || get(
-          additionalUserInfo,
-          'username',
-        ),
+        displayName: profileData.displayName || githubUsername,
         avatarUrl: profileData.photoURL,
         accessTokens: new Immutable.Map().set(
           credential.providerId,
           credential.accessToken,
         ),
+        githubUsername,
       });
     }
 

--- a/src/sagas/clients.js
+++ b/src/sagas/clients.js
@@ -39,7 +39,10 @@ export function* exportProject({payload: {exportType}}) {
     } else if (exportType === 'repo') {
       ({url, name} = yield call(createOrUpdateRepoFromProject, project, user));
       if (name) {
-        exportData = {name};
+        exportData = {
+          repoName: name,
+          username: user.githubUsername,
+        };
       }
     } else if (exportType === 'classroom') {
       const snapshotKey = yield call(createProjectSnapshot, project);

--- a/src/selectors/getCurrentProjectExportedRepoName.js
+++ b/src/selectors/getCurrentProjectExportedRepoName.js
@@ -1,12 +1,13 @@
 import {createSelector} from 'reselect';
 import get from 'lodash/get';
 import getCurrentProject from './getCurrentProject';
+import getCurrentUser from './getCurrentUser';
 
 export default createSelector(
-  [getCurrentProject],
-  currentProject =>
+  [getCurrentProject, getCurrentUser],
+  (currentProject, currentUser) =>
     currentProject ? get(currentProject,
-      ['externalLocations', 'githubRepoName'],
+      ['externalLocations', 'githubRepos', currentUser.githubUsername],
       null,
     ) : null,
 );

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -327,11 +327,11 @@ tap(initProjects({1: true}), (projects) => {
       'https://github.com/usernmaer/Page-Title-abc123',
       'repo',
       '1',
-      {name: repoName},
+      {repoName, username: 'popcoder'},
       timestamp,
     ),
     projects.setIn(['1', 'updatedAt'], timestamp).
-      setIn(['1', 'externalLocations', 'githubRepoName'], repoName),
+      setIn(['1', 'externalLocations', 'githubRepos', 'popcoder'], repoName),
     'stores the repo name',
   ));
 });

--- a/test/unit/reducers/user.js
+++ b/test/unit/reducers/user.js
@@ -3,11 +3,15 @@ import Immutable from 'immutable';
 import partial from 'lodash-es/partial';
 import reducerTest from '../../helpers/reducerTest';
 import {user as states} from '../../helpers/referenceStates';
-import {userCredential} from '../../helpers/factory';
+import {
+  additionalUserInfo,
+  userCredential,
+} from '../../helpers/factory';
 import reducer from '../../../src/reducers/user';
 import {userAuthenticated, userLoggedOut} from '../../../src/actions/user';
 
 const userCredentialIn = userCredential();
+const additionalUserInfoIn = additionalUserInfo();
 
 const loggedInState = Immutable.fromJS({
   authenticated: true,
@@ -17,6 +21,7 @@ const loggedInState = Immutable.fromJS({
   accessTokens: {
     'github.com': userCredentialIn.credential.accessToken,
   },
+  githubUsername: additionalUserInfoIn.username,
 });
 
 test('userAuthenticated', (t) => {
@@ -34,7 +39,7 @@ test('userAuthenticated', (t) => {
       userAuthenticated,
       userCredential({user: {providerData: [{displayName: null}]}}),
     ),
-    loggedInState.set('displayName', 'popcoder'),
+    loggedInState.set('displayName', additionalUserInfoIn.username),
   ));
 });
 

--- a/test/unit/sagas/clients.js
+++ b/test/unit/sagas/clients.js
@@ -119,7 +119,7 @@ test('export repo', (t) => {
         url,
         exportType,
         scenario.project.projectKey,
-        {name},
+        {repoName: name, username: undefined},
         Date.now(),
       )).
       next().isDone();


### PR DESCRIPTION
Instead of storing a single string for the reponame, store strings keyed by github username to allow multiple people to export the same project (importing snapshot workflows, for example).

One high level comment: this is backwards incompatible - any repos exported since release will be orphaned (update repo will appear as export repo). This does not seem like a big deal to me but I felt it should be called out.


Line-level comments below
