### PR TITLE
Upgrade React to 16.4

### DIFF
--- a/src/components/ConsoleInput.jsx
+++ b/src/components/ConsoleInput.jsx
@@ -16,12 +16,15 @@ export default class ConsoleInput extends Component {
     bindAll(this, '_ref');
   }
 
-  componentWillReceiveProps({isTextSizeLarge, requestedFocusedLine}) {
-    if (isTextSizeLarge !== this.props.isTextSizeLarge) {
+  componentDidUpdate({isTextSizeLarge: prevIsTextSizeLarge}) {
+    const {isTextSizeLarge, requestedFocusedLine} = this.props;
+
+    if (isTextSizeLarge !== prevIsTextSizeLarge) {
       requestAnimationFrame(() => {
         inheritFontStylesFromParentElement(this._editor);
       });
     }
+
     this._focusRequestedLine(requestedFocusedLine);
   }
 

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import bindAll from 'lodash-es/bindAll';
+import constant from 'lodash-es/constant';
 import get from 'lodash-es/get';
 import throttle from 'lodash-es/throttle';
 import noop from 'lodash-es/noop';
@@ -27,6 +28,10 @@ class Editor extends React.Component {
     }, RESIZE_THROTTLE);
 
     bindAll(this, '_handleWindowResize', '_resizeEditor', '_setupEditor');
+
+    this.render = constant(
+      <div className="editors__editor" ref={this._setupEditor} />,
+    );
   }
 
   componentDidMount() {
@@ -35,26 +40,34 @@ class Editor extends React.Component {
     window.addEventListener('resize', this._handleWindowResize);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.projectKey !== this.props.projectKey) {
-      this._startNewSession(nextProps.source);
-    } else if (nextProps.source !== this.props.source &&
-        nextProps.source !== this._editor.getValue()) {
-      this._editor.setValue(nextProps.source);
+  componentDidUpdate({
+    percentageOfHeight: prevPercentageOfHeight,
+    projectKey: prevProjectKey,
+    source: prevSource,
+  }) {
+    const {
+      errors,
+      percentageOfHeight,
+      projectKey,
+      requestedFocusedLine,
+      source,
+      textSizeIsLarge,
+    } = this.props;
+
+    if (projectKey !== prevProjectKey) {
+      this._startNewSession(source);
+    } else if (source !== prevSource && source !== this._editor.getValue()) {
+      this._editor.setValue(source);
     }
 
-    this._focusRequestedLine(nextProps.requestedFocusedLine);
-    this._applyFontSize(nextProps.textSizeIsLarge);
+    this._focusRequestedLine(requestedFocusedLine);
+    this._applyFontSize(textSizeIsLarge);
 
-    if (nextProps.percentageOfHeight !== this.props.percentageOfHeight) {
+    if (percentageOfHeight !== prevPercentageOfHeight) {
       requestAnimationFrame(this._resizeEditor);
     }
 
-    this._editor.getSession().setAnnotations(nextProps.errors);
-  }
-
-  shouldComponentUpdate() {
-    return false;
+    this._editor.getSession().setAnnotations(errors);
   }
 
   componentWillUnmount() {
@@ -121,15 +134,6 @@ class Editor extends React.Component {
     this._editor.setSession(session);
     this._editor.moveCursorTo(0, 0);
     this._resizeEditor();
-  }
-
-  render() {
-    return (
-      <div
-        className="editors__editor"
-        ref={this._setupEditor}
-      />
-    );
   }
 }
 

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -34,7 +34,7 @@ export default class Workspace extends React.Component {
     this.columnRefs = [null, null];
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const {onApplicationLoaded} = this.props;
     const {
       gistId,
@@ -42,16 +42,16 @@ export default class Workspace extends React.Component {
       isExperimental,
     } = getQueryParameters(location.search);
     const rehydratedProject = rehydrateProject();
+
     setQueryParameters({isExperimental});
+
     onApplicationLoaded({
       snapshotKey,
       gistId,
       isExperimental,
       rehydratedProject,
     });
-  }
 
-  componentDidMount() {
     addEventListener('beforeunload', this._handleUnload);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3450,9 +3450,19 @@ error-stack-parser@^2.0.1:
   dependencies:
     stackframe "^1.0.3"
 
-es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
+es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.6.1:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-abstract@^1.7.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -3622,8 +3632,8 @@ eslint-plugin-promise@^3.4.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz#f4bde5c2c77cdd69557a8f69a24d1ad3cfc9e67e"
 
 eslint-plugin-react@^7.0.1:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"
   dependencies:
     doctrine "^2.0.2"
     has "^1.0.1"
@@ -4789,11 +4799,17 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.0, has@^1.0.1, has@~1.0.1:
+has@^1.0.0, has@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+has@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.2.tgz#1a64bfe4b52e67fb87b9822503d97c019fb6ba42"
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,17 +2474,17 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@*, colors@>=0.6.0, colors@^1.1.0, colors@^1.1.2:
+colors@*, colors@>=0.6.0, colors@^1.1.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.4.tgz#e0cb41d3e4b20806b3bfc27f4559f01b94bc2f7c"
-
-colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 colors@^1.1.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+
+colors@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 combine-lists@^1.0.0:
   version "1.0.1"
@@ -6771,8 +6771,8 @@ node-dir@0.1.8:
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.8.tgz#55fb8deb699070707fb67f91a460f0448294c77d"
 
 node-fetch@^1.0.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -8325,8 +8325,8 @@ react-dom@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.14.9.tgz#05064a3dcf0fb1880a3b2bfc9d58c55d8d9f6293"
 
 react-dom@^16.0.0:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -8384,9 +8384,18 @@ react@^0.14.0:
     envify "^3.0.0"
     fbjs "^0.6.1"
 
-"react@^15.6.2 || ^16.0", react@^16.3.2:
+"react@^15.6.2 || ^16.0":
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.3.2:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Upgrades `react` and `react-dom` from 16.3 to 16.4. Also upgrades `eslint-plugin-react` to 7.8.2.

The React changelog does not list anything relevant, but according to the latest `eslint-plugin-react`, the `componentWillReceiveProps` and `componentWillMount` lifecycle methods have been deprecated since React 16.3. I don’t think this is actually correct—the React team has simply indicated that they will be deprecated in the future—but since the linter was failing on the presence of those methods, no time like the present. So, migrated the components that used the to-be-deprecated lifecycle methods to use non-deprecated ones.

https://github.com/facebook/react/blob/master/CHANGELOG.md#1640-may-23-2018
https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#780---2018-05-11

Fixes #1402 