### PR TITLE
Add default props where needed

### DIFF
--- a/src/components/Instructions.jsx
+++ b/src/components/Instructions.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import isNull from 'lodash-es/isNull';
 import {toReact as markdownToReact} from '../util/markdown';
 import InstructionsEditor from './InstructionsEditor';
 
@@ -11,7 +12,7 @@ export default function Instructions({
   onCancelEditing,
   onSaveChanges,
 }) {
-  if (!isEditing && !instructions || !isOpen) {
+  if (isNull(projectKey) || !isEditing && !instructions || !isOpen) {
     return null;
   }
 
@@ -39,7 +40,11 @@ Instructions.propTypes = {
   instructions: PropTypes.string.isRequired,
   isEditing: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  projectKey: PropTypes.string.isRequired,
+  projectKey: PropTypes.string,
   onCancelEditing: PropTypes.func.isRequired,
   onSaveChanges: PropTypes.func.isRequired,
+};
+
+Instructions.defaultProps = {
+  projectKey: null,
 };

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -136,7 +136,7 @@ TopBar.propTypes = {
   hasInstructions: PropTypes.bool.isRequired,
   isClassroomExportInProgress: PropTypes.bool.isRequired,
   isEditingInstructions: PropTypes.bool.isRequired,
-  isExperimental: PropTypes.bool.isRequired,
+  isExperimental: PropTypes.bool,
   isGapiReady: PropTypes.bool.isRequired,
   isGistExportInProgress: PropTypes.bool.isRequired,
   isRepoExportInProgress: PropTypes.bool.isRequired,
@@ -167,5 +167,6 @@ TopBar.propTypes = {
 
 TopBar.defaultProps = {
   currentProjectKey: null,
+  isExperimental: false,
   openMenu: null,
 };


### PR DESCRIPTION
Moving the bootstrap action to `componentDidUpdate()` in `<Workspace>` did end up causing a brief moment where certain props are not present.  Did not break anything, but does cause prop type validations. So, mark them as not required and add defaults.