### PR TITLE
Linting for unused or undefined private properties

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -595,6 +595,12 @@
         "prefer-template": [
           2
         ],
+        "private-props/no-unused-or-undeclared": [
+          2
+        ],
+        "private-props/no-use-outside": [
+          2
+        ],
         "promise/no-callback-in-promise": [
           2
         ],
@@ -854,7 +860,8 @@
     "plugins": [
       "import",
       "react",
-      "promise"
+      "promise",
+      "private-props"
     ],
     "settings": {
       "import/resolver": "webpack"

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "eslint-import-resolver-webpack": "^0.9.0",
     "eslint-loader": "^2.0.0",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-private-props": "^0.3.0",
     "eslint-plugin-promise": "^3.4.2",
     "eslint-plugin-react": "^7.0.1",
     "eslint_d": "^5.1.0",

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -135,8 +135,6 @@ class PreviewFrame extends React.Component {
   }
 
   _attachToFrame(frame) {
-    this._frame = frame;
-
     if (!frame) {
       if (this._channel) {
         this._channel.destroy();

--- a/src/validations/Validator.js
+++ b/src/validations/Validator.js
@@ -7,31 +7,30 @@ import stripMarkdown from 'strip-markdown';
 import config from '../config';
 
 class Validator {
-  constructor(source, language, errorMap, analyzer) {
-    this._source = source;
+  constructor(source, language, errorMap) {
+    this.source = source;
     this._language = language;
     this._errorMap = errorMap;
-    this._analyzer = analyzer;
   }
 
   async getAnnotations() {
-    const errors = await this._getRawErrors();
+    const errors = await this.getRawErrors();
     return compact(map(
       errors,
       this._convertErrorToAnnotation.bind(this),
     ));
   }
 
-  _mapError(rawError) {
-    const key = this._keyForError(rawError);
+  mapError(rawError) {
+    const key = this.keyForError(rawError);
     if (this._errorMap.hasOwnProperty(key)) {
-      return this._errorMap[key](rawError, this._source);
+      return this._errorMap[key](rawError, this.source);
     }
     return null;
   }
 
   _convertErrorToAnnotation(rawError) {
-    const error = this._mapError(rawError);
+    const error = this.mapError(rawError);
     if (!error) {
       if (config.warnOnDroppedErrors) {
         // eslint-disable-next-line no-console
@@ -46,7 +45,7 @@ class Validator {
       error.payload,
     );
 
-    const location = this._locationForError(rawError);
+    const location = this.locationForError(rawError);
 
     return assign({}, location, error, {
       text: remark().use(stripMarkdown).processSync(message).toString(),
@@ -55,20 +54,20 @@ class Validator {
     });
   }
 
-  _keyForError() {
-    throw new Error('Subclasses must define _keyForError()');
+  keyForError() {
+    throw new Error('Subclasses must define keyForError()');
   }
 
-  _getRawErrors() {
-    throw new Error('Subclasses must define _getRawErrors()');
+  getRawErrors() {
+    throw new Error('Subclasses must define getRawErrors()');
   }
 
-  _rowForError() {
-    throw new Error('Subclasses must define _rowForError()');
+  rowForError() {
+    throw new Error('Subclasses must define rowForError()');
   }
 
-  _columnForError() {
-    throw new Error('Subclasses must define _columnForError()');
+  columnForError() {
+    throw new Error('Subclasses must define columnForError()');
   }
 }
 

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -20,15 +20,15 @@ class CssValidator extends Validator {
     super(source, 'css', errorMap);
   }
 
-  async _getRawErrors() {
-    return css.parse(this._source, {silent: true}).stylesheet.parsingErrors;
+  async getRawErrors() {
+    return css.parse(this.source, {silent: true}).stylesheet.parsingErrors;
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.reason;
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     const row = error.line - 1;
     const column = error.column - 1;
     return {row, column};

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -132,20 +132,20 @@ class PrettyCssValidator extends Validator {
     super(source, 'css', errorMap);
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     try {
-      const result = prettyCSS.parse(this._source);
+      const result = prettyCSS.parse(this.source);
       return result.getProblems();
     } catch (_e) {
       return [];
     }
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.code.split(':')[0];
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     if (!error.token) {
       return {row: 0, column: 0};
     }

--- a/src/validations/css/stylelint.js
+++ b/src/validations/css/stylelint.js
@@ -21,14 +21,14 @@ class StyleLintValidator extends Validator {
     super(source, 'css', errorMap);
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     try {
       const warnings = [];
       checkAgainstRule(
         {
           ruleName: 'declaration-block-trailing-semicolon',
           ruleSettings: ['always'],
-          root: parse(this._source),
+          root: parse(this.source),
         },
         warning => warnings.push(warning),
       );
@@ -38,7 +38,7 @@ class StyleLintValidator extends Validator {
     }
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     if (isSyntaxError(error)) {
       return `syntaxError/${error.reason}`;
     }
@@ -46,7 +46,7 @@ class StyleLintValidator extends Validator {
     return `lintRule/${error.rule}`;
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     return {row: error.line - 1, column: error.column};
   }
 }

--- a/src/validations/html/htmlInspector.js
+++ b/src/validations/html/htmlInspector.js
@@ -90,10 +90,10 @@ HTMLInspector.rules.add(
 class HtmlInspectorValidator extends Validator {
   constructor(source) {
     super(source, 'html', errorMap);
-    this._doc = new DOMParser().parseFromString(this._source, 'text/html');
+    this._doc = new DOMParser().parseFromString(this.source, 'text/html');
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     if (isNull(this._doc.documentElement)) {
       return Promise.resolve([]);
     }
@@ -107,17 +107,17 @@ class HtmlInspectorValidator extends Validator {
     });
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.rule;
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     const range = this._doc.createRange();
     range.setEndBefore(error.context);
     const lines = range.toString().split('\n');
 
     const droppedNewlines =
-      this._source.split('\n').length -
+      this.source.split('\n').length -
       this._doc.documentElement.outerHTML.split('\n').length;
 
     return {

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -147,20 +147,20 @@ class HtmllintValidator extends Validator {
     super(source, 'html', errorMap);
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     try {
-      const results = await linter.lint(this._source, options);
+      const results = await linter.lint(this.source, options);
       return results;
     } catch (e) {
       return [];
     }
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.code;
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     const row = error.line - 1;
     const column = error.column - 1;
     return {row, column};

--- a/src/validations/html/rules/index.js
+++ b/src/validations/html/rules/index.js
@@ -27,15 +27,15 @@ class RuleValidator extends Validator {
     super(source, 'html', errorMap);
   }
 
-  _keyForError({code}) {
+  keyForError({code}) {
     return code;
   }
 
-  async _getRawErrors() {
-    return Array.from(await runRules([new MismatchedTag()], this._source));
+  async getRawErrors() {
+    return Array.from(await runRules([new MismatchedTag()], this.source));
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     switch (error.code) {
       case Code.MISPLACED_CLOSE_TAG:
         return error.match;

--- a/src/validations/html/slowparse.js
+++ b/src/validations/html/slowparse.js
@@ -124,10 +124,10 @@ class SlowparseValidator extends Validator {
     super(source, 'html', errorMap);
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     let error;
     try {
-      ({error} = Slowparse.HTML(document, this._source, {errorDetectors}));
+      ({error} = Slowparse.HTML(document, this.source, {errorDetectors}));
     } catch (e) {
       error = null;
     }
@@ -139,12 +139,12 @@ class SlowparseValidator extends Validator {
     return [];
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.type;
   }
 
-  _locationForError(error) {
-    const lines = this._source.slice(0, error.cursor).split('\n');
+  locationForError(error) {
+    const lines = this.source.slice(0, error.cursor).split('\n');
     const row = lines.length - 1;
     const column = lines[row].length - 1;
     return {row, column};

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -78,13 +78,13 @@ class EsprimaValidator extends Validator {
     super(source, 'javascript', errorMap);
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     try {
-      parse(this._source);
+      parse(this.source);
     } catch (error) {
       try {
         const tokens = tokenize(
-          this._source,
+          this.source,
           {range: true, comment: true},
         );
         const token = findTokenForError(error, tokens);
@@ -96,17 +96,17 @@ class EsprimaValidator extends Validator {
     return [];
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.error.description;
   }
 
-  _mapError(error) {
-    const mappedError = super._mapError(error);
+  mapError(error) {
+    const mappedError = super.mapError(error);
     if (mappedError) {
       return mappedError;
     }
 
-    const match = UNEXPECTED_TOKEN_EXPR.exec(this._keyForError(error));
+    const match = UNEXPECTED_TOKEN_EXPR.exec(this.keyForError(error));
     if (match) {
       return {
         reason: 'unexpected-token',
@@ -118,7 +118,7 @@ class EsprimaValidator extends Validator {
     return {reason: 'tokenize-error'};
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     const row = error.error.lineNumber - 1;
     const column = error.error.column - 1;
     return {row, column};

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -140,7 +140,7 @@ const errorMap = {
 
 class JsHintValidator extends Validator {
   constructor(source, analyzer) {
-    super(source, 'javascript', errorMap, analyzer);
+    super(source, 'javascript', errorMap);
     this._jshintOptions = this._getConfig(
       analyzer.containsExternalScript,
       analyzer.enabledLibraries,
@@ -170,9 +170,9 @@ class JsHintValidator extends Validator {
     return options;
   }
 
-  async _getRawErrors() {
+  async getRawErrors() {
     try {
-      jshint(this._source, this._jshintOptions);
+      jshint(this.source, this._jshintOptions);
     } catch (e) {
       return [];
     }
@@ -181,11 +181,11 @@ class JsHintValidator extends Validator {
     return compact(castArray(data.errors));
   }
 
-  _keyForError(error) {
+  keyForError(error) {
     return error.code;
   }
 
-  _locationForError(error) {
+  locationForError(error) {
     const row = error.line - 1;
     const column = error.character - 1;
     return {row, column};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,6 +3631,13 @@ eslint-plugin-import@^2.2.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
+eslint-plugin-private-props@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-private-props/-/eslint-plugin-private-props-0.3.0.tgz#aeff3521ec9aad93b4f0e835aa8beff74c24fc70"
+  dependencies:
+    lodash "^4.0.0"
+    requireindex "~1.1.0"
+
 eslint-plugin-promise@^3.4.2:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz#65ebf27a845e3c1e9d6f6a5622ddd3801694b621"
@@ -8937,6 +8944,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 requires-port@1.x.x:
   version "1.0.0"


### PR DESCRIPTION
Adds the `eslint-plugin-private-props` plugin, which enforces that private properties in classes are both defined and used within the same class. Had to change the code in a couple of places:

* Remove unused private property in the `<PreviewFrame>` component
* Rename instance properties and methods in the `Validator` base class that are used by subclasses—these “protected” (in the Java sense) members should not use the naming convention for private members