### PR TITLE
Enforce newlines between import groups

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -190,7 +190,8 @@
           2
         ],
         "import/order": [
-          2
+          2,
+          {"newlines-between": "always-and-inside-groups"}
         ],
         "import/unambiguous": [
           2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+
 const gulp = require('gulp');
 const concat = require('gulp-concat');
 const sourcemaps = require('gulp-sourcemaps');
@@ -20,6 +21,7 @@ const cloudflare = require('cloudflare');
 const BrowserSync = require('browser-sync');
 const pify = require('pify');
 const isDocker = require('is-docker');
+
 const config = require('./src/config');
 const webpackConfiguration = require('./webpack.config');
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,7 @@
 /* eslint-disable import/no-commonjs */
 
 const isDocker = require('is-docker');
+
 const webpackConfiguration = require('./webpack.config.js');
 
 const isCi = Boolean(process.env.TRAVIS);

--- a/src/application.js
+++ b/src/application.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import installDevTools from 'immutable-devtools';
 import {install as installOfflinePlugin} from 'offline-plugin/runtime';
+
 import {bugsnagClient} from './util/bugsnag';
 import Application from './components/Application';
 import initI18n from './util/initI18n';

--- a/src/channels/loginState.js
+++ b/src/channels/loginState.js
@@ -1,4 +1,5 @@
 import {eventChannel} from 'redux-saga';
+
 import {onAuthStateChanged} from '../clients/firebase';
 
 export default eventChannel(

--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -5,6 +5,7 @@ import isNull from 'lodash-es/isNull';
 import omit from 'lodash-es/omit';
 import values from 'lodash-es/values';
 import uuid from 'uuid/v4';
+
 import {getGapiSync} from '../services/gapi';
 import {
   auth,

--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -1,6 +1,7 @@
 import get from 'lodash-es/get';
 import isEmpty from 'lodash-es/isEmpty';
 import trim from 'lodash-es/trim';
+
 import retryingFailedImports from '../util/retryingFailedImports';
 import performWithRetries from '../util/performWithRetries';
 import compileProject from '../util/compileProject';

--- a/src/clients/googleAnalytics.js
+++ b/src/clients/googleAnalytics.js
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga';
+
 import config from '../config';
 
 const cookieDomain =

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {Provider} from 'react-redux';
 import bowser from 'bowser';
+
 import createApplicationStore from '../createApplicationStore';
 import {ErrorBoundary, includeStoreInBugReports} from '../util/bugsnag';
 import supportedBrowsers from '../../config/browsers.json';
 import Workspace from '../containers/Workspace';
+
 import BrowserError from './BrowserError';
 import IEBrowserError from './IEBrowserError';
 

--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -3,6 +3,7 @@ import partial from 'lodash-es/partial';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import ConsoleEntry from './ConsoleEntry';
 import ConsoleInput from './ConsoleInput';
 

--- a/src/components/ConsoleEntry.jsx
+++ b/src/components/ConsoleEntry.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import {ConsoleEntry as ConsoleEntryRecord} from '../records';
+
 import ConsoleExpression from './ConsoleExpression';
 import ConsoleOutput from './ConsoleOutput';
 

--- a/src/components/ConsoleExpression.jsx
+++ b/src/components/ConsoleExpression.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import isNil from 'lodash-es/isNil';
+
 import {ConsoleEntry as ConsoleEntryRecord} from '../records';
 
 export default function ConsoleExpression({entry: {expression}, isActive}) {

--- a/src/components/ConsoleInput.jsx
+++ b/src/components/ConsoleInput.jsx
@@ -4,6 +4,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash-es/get';
 import preventClickthrough from 'react-prevent-clickthrough';
+
 import {
   createAceEditor,
   createAceSessionWithoutWorker,

--- a/src/components/ConsoleOutput.jsx
+++ b/src/components/ConsoleOutput.jsx
@@ -2,6 +2,7 @@ import isNil from 'lodash-es/isNil';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+
 import {ConsoleEntry} from '../records';
 
 export default function ConsoleOutput({entry, isActive}) {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -5,6 +5,7 @@ import constant from 'lodash-es/constant';
 import get from 'lodash-es/get';
 import throttle from 'lodash-es/throttle';
 import noop from 'lodash-es/noop';
+
 import {createAceEditor, createAceSessionWithoutWorker} from '../util/ace';
 
 import 'brace/ext/searchbox';

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -8,6 +8,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import includes from 'lodash-es/includes';
 import partial from 'lodash-es/partial';
 import partition from 'lodash-es/partition';
+
 import {getNodeHeights} from '../util/resize';
 
 import EditorContainer from './EditorContainer';

--- a/src/components/ErrorList.jsx
+++ b/src/components/ErrorList.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import map from 'lodash-es/map';
 import partial from 'lodash-es/partial';
 import {t} from 'i18next';
+
 import ErrorItem from './ErrorItem';
 
 function ErrorList({errors, onErrorClick, language}) {

--- a/src/components/ErrorReport.jsx
+++ b/src/components/ErrorReport.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import find from 'lodash-es/find';
+
 import ErrorList from './ErrorList';
 import PopThrobber from './PopThrobber';
 

--- a/src/components/Instructions.jsx
+++ b/src/components/Instructions.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isNull from 'lodash-es/isNull';
+
 import {toReact as markdownToReact} from '../util/markdown';
+
 import InstructionsEditor from './InstructionsEditor';
 
 export default function Instructions({

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import partial from 'lodash-es/partial';
+
 import NotificationContainer from './NotificationContainer';
 import {
   GenericNotification,

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import prefixAll from 'inline-style-prefixer/static';
+
 import ErrorReport from '../containers/ErrorReport';
 import Preview from '../containers/Preview';
 import Console from '../containers/Console';

--- a/src/components/Pop.jsx
+++ b/src/components/Pop.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import Neutral from '../static/images/pop/neutral.svg';
 import Thinking from '../static/images/pop/thinking.svg';
 import Horns from '../static/images/pop/horns.svg';

--- a/src/components/PopThrobber.jsx
+++ b/src/components/PopThrobber.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import Pop from './Pop';
 
 function PopThrobber(props) {

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -2,6 +2,7 @@ import get from 'lodash-es/get';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import React from 'react';
+
 import PreviewFrame from './PreviewFrame';
 
 export default function Preview({

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -6,6 +6,7 @@ import Bowser from 'bowser';
 import bindAll from 'lodash-es/bindAll';
 import constant from 'lodash-es/constant';
 import {t} from 'i18next';
+
 import normalizeError from '../util/normalizeError';
 import retryingFailedImports from '../util/retryingFailedImports';
 import {sourceDelimiter} from '../util/compileProject';

--- a/src/components/TopBar/CurrentUser.jsx
+++ b/src/components/TopBar/CurrentUser.jsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
+
 import CurrentUserMenu from './CurrentUserMenu';
 
 export default function CurrentUser({

--- a/src/components/TopBar/CurrentUserMenu.jsx
+++ b/src/components/TopBar/CurrentUserMenu.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {t} from 'i18next';
+
 import createMenu, {MenuItem} from './createMenu';
 import CurrentUserButton from './CurrentUserButton';
 

--- a/src/components/TopBar/ExportMenu.jsx
+++ b/src/components/TopBar/ExportMenu.jsx
@@ -2,6 +2,7 @@ import {t} from 'i18next';
 import tap from 'lodash-es/tap';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import createMenu, {MenuItem} from './createMenu';
 import ExportMenuButton from './ExportMenuButton';
 

--- a/src/components/TopBar/HamburgerMenu.jsx
+++ b/src/components/TopBar/HamburgerMenu.jsx
@@ -2,7 +2,9 @@ import {t} from 'i18next';
 import tap from 'lodash-es/tap';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import config from '../../config';
+
 import createMenu, {MenuItem} from './createMenu';
 import HamburgerMenuButton from './HamburgerMenuButton';
 

--- a/src/components/TopBar/LibraryPicker.jsx
+++ b/src/components/TopBar/LibraryPicker.jsx
@@ -3,7 +3,9 @@ import map from 'lodash-es/map';
 import partial from 'lodash-es/partial';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import libraries from '../../config/libraries';
+
 import createMenu, {MenuItem} from './createMenu';
 import LibraryPickerButton from './LibraryPickerButton';
 

--- a/src/components/TopBar/ProjectPicker.jsx
+++ b/src/components/TopBar/ProjectPicker.jsx
@@ -3,7 +3,9 @@ import map from 'lodash-es/map';
 import partial from 'lodash-es/partial';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import ProjectPreview from '../../containers/ProjectPreview';
+
 import ProjectPickerButton from './ProjectPickerButton';
 import createMenu, {MenuItem} from './createMenu';
 

--- a/src/components/TopBar/createMenu.jsx
+++ b/src/components/TopBar/createMenu.jsx
@@ -9,6 +9,7 @@ import preventClickthrough from 'react-prevent-clickthrough';
 import property from 'lodash-es/property';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import {closeTopBarMenu, toggleTopBarMenu} from '../../actions';
 import {getOpenTopBarMenu} from '../../selectors';
 

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import partial from 'lodash-es/partial';
+
 import Wordmark from '../../static/images/wordmark.svg';
 import Pop from '../Pop';
+
 import CurrentUser from './CurrentUser';
 import ExportMenu from './ExportMenu';
 import HamburgerMenu from './HamburgerMenu';

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -7,6 +7,7 @@ import get from 'lodash-es/get';
 import partial from 'lodash-es/partial';
 import {t} from 'i18next';
 import classnames from 'classnames';
+
 import {getNodeWidth, getNodeWidths} from '../util/resize';
 import {getQueryParameters, setQueryParameters} from '../util/queryParams';
 import {dehydrateProject, rehydrateProject} from '../clients/localStorage';
@@ -18,6 +19,7 @@ import Instructions from '../containers/Instructions';
 import NotificationList from '../containers/NotificationList';
 import EditorsColumn from '../containers/EditorsColumn';
 import Output from '../containers/Output';
+
 import PopThrobber from './PopThrobber';
 
 export default class Workspace extends React.Component {

--- a/src/components/notifications/ProjectExportNotification.jsx
+++ b/src/components/notifications/ProjectExportNotification.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
+
 import GenericNotificationWithURL from './GenericNotificationWithURL';
 
 export default function ProjectExportNotification({payload}) {

--- a/src/containers/Console.js
+++ b/src/containers/Console.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import Console from '../components/Console';
 import {
   getCurrentCompiledProjectKey,

--- a/src/containers/EditorsColumn.js
+++ b/src/containers/EditorsColumn.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import EditorsColumn from '../components/EditorsColumn';
 import {
   getCurrentProject,

--- a/src/containers/ErrorReport.js
+++ b/src/containers/ErrorReport.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import ErrorReport from '../components/ErrorReport';
 import {focusLine} from '../actions';
 import {

--- a/src/containers/Instructions.js
+++ b/src/containers/Instructions.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import Instructions from '../components/Instructions';
 import {
   getCurrentProjectInstructions,

--- a/src/containers/NotificationList.js
+++ b/src/containers/NotificationList.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import NotificationList from '../components/NotificationList';
 import {
   updateNotificationMetadata,

--- a/src/containers/Output.js
+++ b/src/containers/Output.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import Output from '../components/Output';
 import {
   isDraggingColumnDivider,

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import Preview from '../components/Preview';
 import {
   addRuntimeError,

--- a/src/containers/ProjectPreview.js
+++ b/src/containers/ProjectPreview.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import ProjectPreview from '../components/ProjectPreview';
 import {changeCurrentProject} from '../actions';
 import {

--- a/src/containers/TopBar.js
+++ b/src/containers/TopBar.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import TopBar from '../components/TopBar';
 import {
   getCurrentProjectExportedRepoName,

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+
 import Workspace from '../components/Workspace';
 import {getCurrentProject, isEditingInstructions} from '../selectors';
 import {

--- a/src/createApplicationStore.js
+++ b/src/createApplicationStore.js
@@ -5,6 +5,7 @@ import {
 } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import get from 'lodash-es/get';
+
 import reducers from './reducers';
 import rootSaga from './sagas';
 

--- a/src/records/ErrorReport.js
+++ b/src/records/ErrorReport.js
@@ -1,4 +1,5 @@
 import {Record} from 'immutable';
+
 import ErrorList from './ErrorList';
 
 const defaultErrorList = new ErrorList();

--- a/src/reducers/compiledProjects.js
+++ b/src/reducers/compiledProjects.js
@@ -1,4 +1,5 @@
 import {List} from 'immutable';
+
 import {CompiledProject} from '../records';
 
 const initialState = new List();

--- a/src/reducers/console.js
+++ b/src/reducers/console.js
@@ -1,4 +1,5 @@
 import {OrderedMap} from 'immutable';
+
 import {ConsoleEntry, ConsoleError} from '../records';
 
 const initialState = new OrderedMap();

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -1,5 +1,6 @@
 import {List} from 'immutable';
 import map from 'lodash-es/map';
+
 import {Error, ErrorList, ErrorReport} from '../records';
 
 const passedLanguageErrors = new ErrorList();

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,6 @@
 import {combineReducers} from 'redux-immutable';
 import reduceReducers from 'reduce-reducers';
+
 import user from './user';
 import projects, {reduceRoot as reduceRootForProjects} from './projects';
 import console from './console';

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -1,4 +1,5 @@
 import Immutable from 'immutable';
+
 import {
   updateEditorColumnFlex,
   updateWorkspaceRowFlex,

--- a/src/selectors/getCurrentProject.js
+++ b/src/selectors/getCurrentProject.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect';
+
 import getCurrentProjectKey from './getCurrentProjectKey';
 import getProjects from './getProjects';
 

--- a/src/selectors/getCurrentProjectExportedRepoName.js
+++ b/src/selectors/getCurrentProjectExportedRepoName.js
@@ -1,5 +1,6 @@
 import {createSelector} from 'reselect';
 import get from 'lodash-es/get';
+
 import getCurrentProject from './getCurrentProject';
 
 export default createSelector(

--- a/src/selectors/getCurrentProjectInstructions.js
+++ b/src/selectors/getCurrentProjectInstructions.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect';
+
 import getCurrentProjectKey from './getCurrentProjectKey';
 import getProjects from './getProjects';
 

--- a/src/selectors/getEnabledLibraries.js
+++ b/src/selectors/getEnabledLibraries.js
@@ -1,5 +1,6 @@
 import {createSelector} from 'reselect';
 import get from 'lodash-es/get';
+
 import getCurrentProject from './getCurrentProject';
 
 export default createSelector(

--- a/src/selectors/getHiddenUIComponents.js
+++ b/src/selectors/getHiddenUIComponents.js
@@ -1,5 +1,6 @@
 import get from 'lodash-es/get';
 import {createSelector} from 'reselect';
+
 import getCurrentProject from './getCurrentProject';
 
 export default createSelector(

--- a/src/selectors/makeGetProjectPreview.js
+++ b/src/selectors/makeGetProjectPreview.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect';
+
 import {generateTextPreview} from '../util/compileProject';
 
 export default function makeGetProjectPreview() {

--- a/src/services/appFirebase.js
+++ b/src/services/appFirebase.js
@@ -1,5 +1,6 @@
 import {firebase} from '@firebase/app';
 import once from 'lodash-es/once';
+
 import '@firebase/auth';
 import config from '../config';
 import retryingFailedImports from '../util/retryingFailedImports';

--- a/src/services/gapi.js
+++ b/src/services/gapi.js
@@ -1,6 +1,8 @@
 import $S from 'scriptjs';
 import once from 'lodash-es/once';
+
 import config from '../config';
+
 import {GOOGLE_SCOPES} from './appFirebase';
 
 const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/classroom/v1/rest'];

--- a/src/util/bugsnag.js
+++ b/src/util/bugsnag.js
@@ -1,6 +1,7 @@
 import bugsnag from 'bugsnag-js';
 import createPlugin from 'bugsnag-react';
 import React from 'react';
+
 import config from '../config';
 import {getCurrentProject} from '../selectors';
 

--- a/src/util/compileProject.js
+++ b/src/util/compileProject.js
@@ -5,7 +5,9 @@ import isEmpty from 'lodash-es/isEmpty';
 import map from 'lodash-es/map';
 import trim from 'lodash-es/trim';
 import uniq from 'lodash-es/uniq';
+
 import config from '../config';
+
 import retryingFailedImports from './retryingFailedImports';
 
 const downloadingScript = downloadScript();

--- a/src/util/initI18n.js
+++ b/src/util/initI18n.js
@@ -1,5 +1,7 @@
 import {init} from 'i18next';
+
 import resources from '../../locales';
+
 import applyCustomI18nFormatters from './i18nFormatting';
 
 export default function() {

--- a/src/util/projectUtils.js
+++ b/src/util/projectUtils.js
@@ -1,4 +1,5 @@
 import {Map} from 'immutable';
+
 import {saveProject} from '../clients/firebase';
 import {getCurrentProject, getCurrentUserId} from '../selectors';
 

--- a/src/validations/Validator.js
+++ b/src/validations/Validator.js
@@ -4,6 +4,7 @@ import map from 'lodash-es/map';
 import compact from 'lodash-es/compact';
 import remark from 'remark';
 import stripMarkdown from 'strip-markdown';
+
 import config from '../config';
 
 class Validator {

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -1,4 +1,5 @@
 import css from 'css';
+
 import Validator from '../Validator';
 
 const errorMap = {

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -1,6 +1,7 @@
 import prettyCSS from 'PrettyCSS';
 import trim from 'lodash-es/trim';
 import endsWith from 'lodash-es/endsWith';
+
 import Validator from '../Validator';
 
 const RADIAL_GRADIENT_EXPR =

--- a/src/validations/css/stylelint.js
+++ b/src/validations/css/stylelint.js
@@ -1,5 +1,6 @@
 import checkAgainstRule from 'stylelint/lib/utils/checkAgainstRule';
 import parse from 'postcss/lib/parse';
+
 import Validator from '../Validator';
 
 const errorMap = {

--- a/src/validations/html.js
+++ b/src/validations/html.js
@@ -1,4 +1,5 @@
 import trim from 'lodash-es/trim';
+
 import mergeValidations from './mergeValidations';
 import validateWithHtmlInspector from './html/htmlInspector';
 import validateWithHtmllint from './html/htmllint';

--- a/src/validations/html/htmlInspector.js
+++ b/src/validations/html/htmlInspector.js
@@ -2,6 +2,7 @@ import HTMLInspector from 'html-inspector';
 import last from 'lodash-es/last';
 import isNull from 'lodash-es/isNull';
 import trim from 'lodash-es/trim';
+
 import {localizedArrayToSentence} from '../../util/arrayToSentence';
 import Validator from '../Validator';
 

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -2,6 +2,7 @@ import clone from 'lodash-es/clone';
 import defaults from 'lodash-es/defaults';
 import {Linter, rules} from 'htmllint';
 import reduce from 'lodash-es/reduce';
+
 import Validator from '../Validator';
 
 const errorMap = {

--- a/src/validations/html/rules/MismatchedTag.js
+++ b/src/validations/html/rules/MismatchedTag.js
@@ -20,6 +20,7 @@
 // so yield UNOPENED_TAG.
 
 import findLastIndex from 'lodash-es/findLastIndex';
+
 import Code from './Code';
 
 export default class {

--- a/src/validations/html/rules/index.js
+++ b/src/validations/html/rules/index.js
@@ -1,5 +1,6 @@
 import Validator from '../../Validator';
 import runRules from '../runRules';
+
 import Code from './Code';
 import MismatchedTag from './MismatchedTag';
 

--- a/src/validations/javascript/esprima.js
+++ b/src/validations/javascript/esprima.js
@@ -1,6 +1,7 @@
 import {parse, tokenize} from 'esprima';
 import find from 'lodash-es/find';
 import inRange from 'lodash-es/inRange';
+
 import Validator from '../Validator';
 
 const UNEXPECTED_TOKEN_EXPR = /^Unexpected token (.+)$/;

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -6,6 +6,7 @@ import defaults from 'lodash-es/defaults';
 import find from 'lodash-es/find';
 import includes from 'lodash-es/includes';
 import {JSHINT as jshint} from 'jshint';
+
 import libraries from '../../config/libraries';
 import Validator from '../Validator';
 

--- a/test/helpers/Scenario.js
+++ b/test/helpers/Scenario.js
@@ -6,6 +6,7 @@ import {
   userAuthenticated,
 } from '../../src/actions/user';
 import Analyzer from '../../src/analyzers';
+
 import {userCredential} from './factory';
 
 export default class Scenario {

--- a/test/helpers/i18nFactory.js
+++ b/test/helpers/i18nFactory.js
@@ -1,4 +1,5 @@
 import {createInstance} from 'i18next';
+
 import applyCustomI18nFormatters from '../../src/util/i18nFormatting';
 
 const enTestResourceData = {

--- a/test/helpers/referenceStates.js
+++ b/test/helpers/referenceStates.js
@@ -1,4 +1,5 @@
 import {List, Map, fromJS} from 'immutable';
+
 import {Error, ErrorList, ErrorReport} from '../../src/records';
 
 const sampleError = new Error({reason: 'bad-code'});

--- a/test/helpers/testValidatorAcceptance.js
+++ b/test/helpers/testValidatorAcceptance.js
@@ -1,4 +1,5 @@
 import acceptance from '../data/acceptance.json';
+
 import validationTest from './validationTest';
 
 export default function testValidatorAcceptance(validator, language) {

--- a/test/unit/Analyzer.js
+++ b/test/unit/Analyzer.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import Analyzer from '../../src/analyzers';
 import {Project} from '../../src/records';
 

--- a/test/unit/localization/localization.js
+++ b/test/unit/localization/localization.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import getI18nInstance from '../../helpers/i18nFactory';
 import localizationTest from '../../helpers/localizationTest';
 

--- a/test/unit/reducers/clients.js
+++ b/test/unit/reducers/clients.js
@@ -1,6 +1,7 @@
 import test from 'tape';
 import Immutable from 'immutable';
 import partial from 'lodash-es/partial';
+
 import reducer from '../../../src/reducers/clients';
 import reducerTest from '../../helpers/reducerTest';
 import {

--- a/test/unit/reducers/console.js
+++ b/test/unit/reducers/console.js
@@ -1,6 +1,7 @@
 import {OrderedMap} from 'immutable';
 import partial from 'lodash-es/partial';
 import test from 'tape';
+
 import {ConsoleEntry, ConsoleError} from '../../../src/records';
 import {
   consoleErrorProduced,

--- a/test/unit/reducers/currentProject.js
+++ b/test/unit/reducers/currentProject.js
@@ -1,6 +1,7 @@
 import test from 'tape';
 import partial from 'lodash-es/partial';
 import Immutable from 'immutable';
+
 import reducerTest from '../../helpers/reducerTest';
 import reducer from '../../../src/reducers/currentProject';
 import {

--- a/test/unit/reducers/errors.js
+++ b/test/unit/reducers/errors.js
@@ -1,6 +1,7 @@
 import test from 'tape';
 import partial from 'lodash-es/partial';
 import {List} from 'immutable';
+
 import {Error, ErrorList} from '../../../src/records';
 import reducerTest from '../../helpers/reducerTest';
 import {errors as states} from '../../helpers/referenceStates';

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -4,6 +4,7 @@ import reduce from 'lodash-es/reduce';
 import tap from 'lodash-es/tap';
 import partial from 'lodash-es/partial';
 import Immutable from 'immutable';
+
 import reducerTest from '../../helpers/reducerTest';
 import {projects as states} from '../../helpers/referenceStates';
 import {gistData, project} from '../../helpers/factory';

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -2,6 +2,7 @@ import test from 'tape';
 import Immutable from 'immutable';
 import tap from 'lodash-es/tap';
 import partial from 'lodash-es/partial';
+
 import reducerTest from '../../helpers/reducerTest';
 import reducer, {DEFAULT_WORKSPACE} from '../../../src/reducers/ui';
 import {

--- a/test/unit/reducers/user.js
+++ b/test/unit/reducers/user.js
@@ -1,6 +1,7 @@
 import test from 'tape';
 import Immutable from 'immutable';
 import partial from 'lodash-es/partial';
+
 import reducerTest from '../../helpers/reducerTest';
 import {user as states} from '../../helpers/referenceStates';
 import {userCredential} from '../../helpers/factory';

--- a/test/unit/util/javascript.js
+++ b/test/unit/util/javascript.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import {hasExpressionStatement} from '../../../src/util/javascript';
 
 test('empty statement is not an expression statement', (assert) => {

--- a/test/unit/util/queryParams.js
+++ b/test/unit/util/queryParams.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import {getQueryParameters} from '../../../src/util/queryParams';
 
 

--- a/test/unit/validations/css.js
+++ b/test/unit/validations/css.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import css from '../../../src/validations/css';
 import validationTest from '../../helpers/validationTest';
 import testValidatorAcceptance from '../../helpers/testValidatorAcceptance';

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import html from '../../../src/validations/html';
 import validationTest from '../../helpers/validationTest';
 import testValidatorAcceptance from '../../helpers/testValidatorAcceptance';

--- a/test/unit/validations/html/rules.js
+++ b/test/unit/validations/html/rules.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import Code from '../../../../src/validations/html/rules/Code';
 import MismatchedTag
   from '../../../../src/validations/html/rules/MismatchedTag';

--- a/test/unit/validations/html/runRules.js
+++ b/test/unit/validations/html/runRules.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+
 import runRules from '../../../../src/validations/html/runRules';
 
 test('openTag row', async(t) => {

--- a/test/unit/validations/javascript.js
+++ b/test/unit/validations/javascript.js
@@ -1,5 +1,6 @@
 import test from 'tape';
 import partialRight from 'lodash-es/partialRight';
+
 import validationTest from '../../helpers/validationTest';
 import testValidatorAcceptance from '../../helpers/testValidatorAcceptance';
 import javascript from '../../../src/validations/javascript';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const OfflinePlugin = require('offline-plugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -15,6 +16,7 @@ const webpack = require('webpack');
 const escapeRegExp = require('lodash.escaperegexp');
 const git = require('git-rev-sync');
 const babel = require('babel-core');
+
 const babelLoaderVersion =
   require('./node_modules/babel-loader/package.json').version;
 


### PR DESCRIPTION
I think it makes it easier to tell where different imports are coming, and it’s easy to do now that there is an autofixer.