### PR TITLE
Share node_modules between Docker and host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/app:cached
-      - node_modules:/app/node_modules
+      - ./node_modules:/app/node_modules:delegated
       - npm_cache:/root/.npm
       - yarn_cache:/usr/local/share/.cache/yarn
     tmpfs:


### PR DESCRIPTION
There’s not much reason to have node_modules in a volume unless you’re trying to run Popcode both in a Docker container and on the host (in which case natively compiled modules could cause a problem). So, just share `node_modules` between the container and host machine. In particular this allows us to straightforwardly use `eslint` and friends in editor integrations.