### PR TITLE
Upgrade remark-external-links

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "redux-saga": "^0.16.0",
     "redux-saga-debounce-effect": "^0.2.2",
     "remark": "^9.0.0",
-    "remark-external-links": "^1.0.1",
+    "remark-external-links": "^2.0.0",
     "remark-react": "^4.0.0",
     "remark-react-lowlight": "^0.7.0",
     "reselect": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8792,9 +8792,9 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
-remark-external-links@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/remark-external-links/-/remark-external-links-1.0.1.tgz#6140251948eb408bae596d96e3ec2f79678f177e"
+remark-external-links@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/remark-external-links/-/remark-external-links-2.0.0.tgz#fe00455719d92408a7b453ef04f7f481d163b1f8"
   dependencies:
     unist-util-select "~1.5.0"
 


### PR DESCRIPTION
Upgrades to 2.0.0, for compatibility with the Remark version we’re already using.