### PR TITLE
Use Immutable records for UI state

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -26,7 +26,7 @@ export const popOutProject = createAction(
 
 export const notificationTriggered = createAction(
   'NOTIFICATION_TRIGGERED',
-  (type, severity = 'error', payload = {}) => ({type, severity, payload}),
+  (type, severity = 'error', metadata = {}) => ({type, severity, metadata}),
 );
 
 export const userDismissedNotification = createAction(

--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
+import {EditorLocation} from '../records';
+
 import ConsoleEntry from './ConsoleEntry';
 import ConsoleInput from './ConsoleInput';
 
@@ -88,7 +90,7 @@ Console.propTypes = {
   isHidden: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   isTextSizeLarge: PropTypes.bool,
-  requestedFocusedLine: PropTypes.object,
+  requestedFocusedLine: PropTypes.instanceOf(EditorLocation),
   onClearConsoleEntries: PropTypes.func.isRequired,
   onConsoleClicked: PropTypes.func.isRequired,
   onInput: PropTypes.func.isRequired,

--- a/src/components/ConsoleInput.jsx
+++ b/src/components/ConsoleInput.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import get from 'lodash-es/get';
 import preventClickthrough from 'react-prevent-clickthrough';
 
+import {EditorLocation} from '../records';
 import {
   createAceEditor,
   createAceSessionWithoutWorker,
@@ -82,7 +83,7 @@ export default class ConsoleInput extends Component {
 
 ConsoleInput.propTypes = {
   isTextSizeLarge: PropTypes.bool,
-  requestedFocusedLine: PropTypes.object,
+  requestedFocusedLine: PropTypes.instanceOf(EditorLocation),
   onInput: PropTypes.func.isRequired,
   onRequestedLineFocused: PropTypes.func.isRequired,
 };

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -7,6 +7,7 @@ import throttle from 'lodash-es/throttle';
 import noop from 'lodash-es/noop';
 
 import {createAceEditor, createAceSessionWithoutWorker} from '../util/ace';
+import {EditorLocation} from '../records';
 
 import 'brace/ext/searchbox';
 import 'brace/mode/html';
@@ -143,7 +144,7 @@ Editor.propTypes = {
   language: PropTypes.string.isRequired,
   percentageOfHeight: PropTypes.number.isRequired,
   projectKey: PropTypes.string.isRequired,
-  requestedFocusedLine: PropTypes.object,
+  requestedFocusedLine: PropTypes.instanceOf(EditorLocation),
   source: PropTypes.string.isRequired,
   textSizeIsLarge: PropTypes.bool.isRequired,
   onInput: PropTypes.func.isRequired,

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -10,6 +10,8 @@ import map from 'lodash-es/map';
 import partial from 'lodash-es/partial';
 import partition from 'lodash-es/partition';
 
+import {EditorLocation} from '../records';
+
 import EditorContainer from './EditorContainer';
 import Editor from './Editor';
 
@@ -125,7 +127,7 @@ EditorsColumn.propTypes = {
   currentProject: PropTypes.object.isRequired,
   errors: PropTypes.object.isRequired,
   isTextSizeLarge: PropTypes.bool.isRequired,
-  requestedFocusedLine: PropTypes.object,
+  requestedFocusedLine: PropTypes.instanceOf(EditorLocation),
   resizableFlexGrow: ImmutablePropTypes.list.isRequired,
   resizableFlexRefs: PropTypes.array.isRequired,
   style: PropTypes.object.isRequired,

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -1,6 +1,9 @@
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import React from 'react';
 import PropTypes from 'prop-types';
 import partial from 'lodash-es/partial';
+
+import {Notification as NotificationRecord} from '../records';
 
 import NotificationContainer from './NotificationContainer';
 import {
@@ -28,40 +31,39 @@ export default function NotificationList({
   onNotificationDismissed,
   onUpdateNotificationMetadata,
 }) {
-  if (!notifications.length) {
+  if (notifications.isEmpty()) {
     return null;
   }
 
-  const notificationList = notifications.map((notification) => {
-    const Notification = chooseNotificationComponent(notification);
-
-    return (
-      <NotificationContainer
-        key={notification.type}
-        severity={notification.severity}
-        onDismissed={
-          partial(onNotificationDismissed, notification)
-        }
-      >
-        <Notification
-          metadata={notification.metadata}
-          payload={notification.payload}
-          type={notification.type}
-          onUpdateMetadata={
-            partial(onUpdateNotificationMetadata, notification)
-          }
-        />
-      </NotificationContainer>
-    );
-  });
-
   return (
-    <div className="notification-list">{notificationList}</div>
+    <div className="notification-list">{
+      notifications.map((notification) => {
+        const Notification = chooseNotificationComponent(notification);
+
+        return (
+          <NotificationContainer
+            key={notification.type}
+            severity={notification.severity}
+            onDismissed={
+              partial(onNotificationDismissed, notification)
+            }
+          >
+            <Notification
+              metadata={notification.metadata}
+              type={notification.type}
+              onUpdateMetadata={
+                partial(onUpdateNotificationMetadata, notification)
+              }
+            />
+          </NotificationContainer>
+        );
+      })
+    }</div>
   );
 }
 
 NotificationList.propTypes = {
-  notifications: PropTypes.array.isRequired,
+  notifications: ImmutablePropTypes.iterableOf(NotificationRecord).isRequired,
   onNotificationDismissed: PropTypes.func.isRequired,
   onUpdateNotificationMetadata: PropTypes.func.isRequired,
 };

--- a/src/components/notifications/GenericNotification.jsx
+++ b/src/components/notifications/GenericNotification.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import {t} from 'i18next';
 
 export default function GenericNotification(props) {
   return (
-    <span>{t(`notifications.${props.type}`, props.payload)}</span>
+    <span>{t(`notifications.${props.type}`, props.metadata.toObject())}</span>
   );
 }
 
 GenericNotification.propTypes = {
-  payload: PropTypes.object.isRequired,
+  metadata: ImmutablePropTypes.map.isRequired,
   type: PropTypes.string.isRequired,
 };

--- a/src/components/notifications/GistImportError.jsx
+++ b/src/components/notifications/GistImportError.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import {t} from 'i18next';
 
 function gistUrlFromId(gistId) {
   return `https://gist.github.com/${gistId}`;
 }
 
-export default function GistImportError({payload: {gistId}}) {
+export default function GistImportError({metadata}) {
   return (
     <span>
       {t('notifications.gist-import-error')}{' '}
       <a
-        href={gistUrlFromId(gistId)}
+        href={gistUrlFromId(metadata.get('gistId'))}
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -22,5 +23,7 @@ export default function GistImportError({payload: {gistId}}) {
 }
 
 GistImportError.propTypes = {
-  payload: PropTypes.object.isRequired,
+  metadata: ImmutablePropTypes.contains({
+    gistId: PropTypes.string,
+  }).isRequired,
 };

--- a/src/components/notifications/ProjectExportNotification.jsx
+++ b/src/components/notifications/ProjectExportNotification.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
 
 import GenericNotificationWithURL from './GenericNotificationWithURL';
 
-export default function ProjectExportNotification({payload}) {
-  const {url, exportType} = payload;
+export default function ProjectExportNotification({metadata}) {
+  const url = metadata.get('url');
+  const exportType = metadata.get('exportType');
   const linkText = t('notifications.project-export-link');
   const text = t(`notifications.${exportType}-export-complete`);
 
@@ -19,5 +21,8 @@ export default function ProjectExportNotification({payload}) {
 }
 
 ProjectExportNotification.propTypes = {
-  payload: PropTypes.object.isRequired,
+  metadata: ImmutablePropTypes.contains({
+    url: PropTypes.string.isRequired,
+    exportType: PropTypes.string.isRequired,
+  }).isRequired,
 };

--- a/src/components/notifications/SnapshotNotification.jsx
+++ b/src/components/notifications/SnapshotNotification.jsx
@@ -2,19 +2,19 @@ import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import partial from 'lodash-es/partial';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import {t} from 'i18next';
 
 export default function SnapshotNotification({
-  metadata: {isCopied},
-  payload: {snapshotKey},
+  metadata,
   onUpdateMetadata,
 }) {
   const uri = document.createElement('a');
   uri.setAttribute('href', '/');
-  uri.search = `snapshot=${snapshotKey}`;
+  uri.search = `snapshot=${metadata.get('snapshotKey')}`;
 
   let checkmark;
-  if (isCopied) {
+  if (metadata.get('isCopied')) {
     checkmark = [
       ' ',
       <span className="u__icon" key="icon">&#xf058;</span>,
@@ -40,7 +40,9 @@ export default function SnapshotNotification({
 }
 
 SnapshotNotification.propTypes = {
-  metadata: PropTypes.object.isRequired,
-  payload: PropTypes.object.isRequired,
+  metadata: ImmutablePropTypes.contains({
+    snapshotKey: PropTypes.string.isRequired,
+    isCopied: PropTypes.bool,
+  }).isRequired,
   onUpdateMetadata: PropTypes.func.isRequired,
 };

--- a/src/records/EditorLocation.js
+++ b/src/records/EditorLocation.js
@@ -1,0 +1,7 @@
+import {Record} from 'immutable';
+
+export default Record({
+  component: null,
+  line: 0,
+  column: 0,
+}, 'EditorLocation');

--- a/src/records/Notification.js
+++ b/src/records/Notification.js
@@ -1,0 +1,7 @@
+import {Map, Record} from 'immutable';
+
+export default Record({
+  type: null,
+  severity: 'notice',
+  metadata: new Map(),
+}, 'Notification');

--- a/src/records/UiState.js
+++ b/src/records/UiState.js
@@ -1,0 +1,12 @@
+import {Record, Map} from 'immutable';
+
+export default Record({
+  isDraggingColumnDivider: false,
+  isEditingInstructions: false,
+  isExperimental: false,
+  isTextSizeLarge: false,
+  isTyping: false,
+  notifications: new Map(),
+  openTopBarMenu: null,
+  requestedFocusedLine: null,
+}, 'UiState');

--- a/src/records/UiState.js
+++ b/src/records/UiState.js
@@ -9,4 +9,5 @@ export default Record({
   notifications: new Map(),
   openTopBarMenu: null,
   requestedFocusedLine: null,
+  saveIndicatorShown: false,
 }, 'UiState');

--- a/src/records/index.js
+++ b/src/records/index.js
@@ -5,6 +5,7 @@ import Error from './Error';
 import ErrorList from './ErrorList';
 import ErrorReport from './ErrorReport';
 import Project from './Project';
+import UiState from './UiState';
 import User from './User';
 import UserAccount from './UserAccount';
 
@@ -18,4 +19,5 @@ export {
   Project,
   User,
   UserAccount,
+  UiState,
 };

--- a/src/records/index.js
+++ b/src/records/index.js
@@ -1,6 +1,7 @@
 import CompiledProject from './CompiledProject';
 import ConsoleEntry from './ConsoleEntry';
 import ConsoleError from './ConsoleError';
+import EditorLocation from './EditorLocation';
 import Error from './Error';
 import ErrorList from './ErrorList';
 import ErrorReport from './ErrorReport';
@@ -14,6 +15,7 @@ export {
   CompiledProject,
   ConsoleEntry,
   ConsoleError,
+  EditorLocation,
   Error,
   ErrorList,
   ErrorReport,

--- a/src/records/index.js
+++ b/src/records/index.js
@@ -4,6 +4,7 @@ import ConsoleError from './ConsoleError';
 import Error from './Error';
 import ErrorList from './ErrorList';
 import ErrorReport from './ErrorReport';
+import Notification from './Notification';
 import Project from './Project';
 import UiState from './UiState';
 import User from './User';
@@ -16,6 +17,7 @@ export {
   Error,
   ErrorList,
   ErrorReport,
+  Notification,
   Project,
   User,
   UserAccount,

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -1,13 +1,13 @@
-import Immutable from 'immutable';
+import Immutable, {Map} from 'immutable';
 
-import {UiState} from '../records';
+import {Notification, UiState} from '../records';
 
 const defaultState = new UiState();
 
-function addNotification(state, type, severity, payload = {}) {
+function addNotification(state, type, severity, metadata = {}) {
   return state.setIn(
     ['notifications', type],
-    Immutable.fromJS({type, severity, payload, metadata: {}}),
+    new Notification({type, severity, metadata: new Map(metadata)}),
   );
 }
 
@@ -93,16 +93,16 @@ export default function ui(stateIn, action) {
         state,
         action.payload.type,
         action.payload.severity,
-        action.payload.payload,
+        action.payload.metadata,
       );
 
     case 'USER_DISMISSED_NOTIFICATION':
       return dismissNotification(state, action.payload.type);
 
     case 'UPDATE_NOTIFICATION_METADATA':
-      return state.setIn(
+      return state.updateIn(
         ['notifications', action.payload.type, 'metadata'],
-        Immutable.fromJS(action.payload.metadata),
+        metadata => metadata.merge(action.payload.metadata),
       );
 
     case 'USER_LOGGED_OUT':

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -1,6 +1,6 @@
-import Immutable, {Map} from 'immutable';
+import {Map} from 'immutable';
 
-import {Notification, UiState} from '../records';
+import {EditorLocation, Notification, UiState} from '../records';
 
 const defaultState = new UiState();
 
@@ -46,7 +46,7 @@ export default function ui(stateIn, action) {
     case 'FOCUS_LINE':
       return state.set(
         'requestedFocusedLine',
-        new Immutable.Map({
+        new EditorLocation({
           component: action.payload.component,
           line: action.payload.line,
           column: action.payload.column,
@@ -56,7 +56,7 @@ export default function ui(stateIn, action) {
     case 'CLEAR_CONSOLE_ENTRIES':
       return state.set(
         'requestedFocusedLine',
-        new Immutable.Map({
+        new EditorLocation({
           component: 'console',
           line: 0,
           column: 0,

--- a/src/selectors/getNotifications.js
+++ b/src/selectors/getNotifications.js
@@ -2,5 +2,5 @@ import {createSelector} from 'reselect';
 
 export default createSelector(
   state => state.getIn(['ui', 'notifications']),
-  notifications => notifications.valueSeq().toJS(),
+  notifications => notifications.valueSeq(),
 );

--- a/src/selectors/getOpenTopBarMenu.js
+++ b/src/selectors/getOpenTopBarMenu.js
@@ -1,3 +1,3 @@
 export default function getOpenTopBarMenu(state) {
-  return state.getIn(['ui', 'topBar', 'openMenu']);
+  return state.getIn(['ui', 'openTopBarMenu']);
 }

--- a/src/selectors/getRequestedFocusedLine.js
+++ b/src/selectors/getRequestedFocusedLine.js
@@ -1,8 +1,3 @@
 export default function getRequestedFocusedLine(state) {
-  const requestedFocusedLine =
-    state.getIn(['ui', 'requestedFocusedLine']);
-  if (requestedFocusedLine) {
-    return requestedFocusedLine.toJS();
-  }
-  return null;
+  return state.getIn(['ui', 'requestedFocusedLine']);
 }

--- a/src/selectors/getRequestedFocusedLine.js
+++ b/src/selectors/getRequestedFocusedLine.js
@@ -1,6 +1,6 @@
 export default function getRequestedFocusedLine(state) {
   const requestedFocusedLine =
-    state.getIn(['ui', 'editors', 'requestedFocusedLine']);
+    state.getIn(['ui', 'requestedFocusedLine']);
   if (requestedFocusedLine) {
     return requestedFocusedLine.toJS();
   }

--- a/src/selectors/isDraggingColumnDivider.js
+++ b/src/selectors/isDraggingColumnDivider.js
@@ -1,3 +1,3 @@
 export default function isDraggingColumnDivider(state) {
-  return state.getIn(['ui', 'workspace', 'isDraggingColumnDivider']);
+  return state.getIn(['ui', 'isDraggingColumnDivider']);
 }

--- a/src/selectors/isEditingInstructions.js
+++ b/src/selectors/isEditingInstructions.js
@@ -1,3 +1,3 @@
 export default function isEditingInstructions(state) {
-  return state.getIn(['ui', 'workspace', 'isEditingInstructions']);
+  return state.getIn(['ui', 'isEditingInstructions']);
 }

--- a/src/selectors/isExperimental.js
+++ b/src/selectors/isExperimental.js
@@ -1,3 +1,3 @@
 export default function isExperimental(state) {
-  return state.getIn(['ui', 'experimental']);
+  return state.getIn(['ui', 'isExperimental']);
 }

--- a/src/selectors/isTextSizeLarge.js
+++ b/src/selectors/isTextSizeLarge.js
@@ -1,3 +1,3 @@
 export default function(state) {
-  return state.getIn(['ui', 'editors', 'textSizeIsLarge']);
+  return state.getIn(['ui', 'isTextSizeLarge']);
 }

--- a/src/selectors/isUserTyping.js
+++ b/src/selectors/isUserTyping.js
@@ -1,3 +1,3 @@
 export default function isUserTyping(state) {
-  return state.getIn(['ui', 'editors', 'typing']);
+  return state.getIn(['ui', 'isTyping']);
 }

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -1,10 +1,11 @@
 import test from 'tape';
-import Immutable from 'immutable';
 import tap from 'lodash-es/tap';
 import partial from 'lodash-es/partial';
+import {Map} from 'immutable';
 
 import reducerTest from '../../helpers/reducerTest';
-import reducer, {DEFAULT_WORKSPACE} from '../../../src/reducers/ui';
+import reducer from '../../../src/reducers/ui';
+import {EditorLocation, Notification, UiState} from '../../../src/records';
 import {
   gistNotFound,
   gistImportError,
@@ -44,20 +45,12 @@ import {
   projectCompilationFailed,
 } from '../../../src/actions';
 
-const initialState = Immutable.fromJS({
-  editors: {
-    typing: false,
-    requestedFocusedLine: null,
-  },
-  workspace: DEFAULT_WORKSPACE,
-  notifications: new Immutable.Map(),
-  topBar: {openMenu: null},
-});
+const initialState = new UiState();
 
-function withNotification(type, severity, payload = {}) {
+function withNotification(type, severity, metadata = {}) {
   return initialState.setIn(
     ['notifications', type],
-    Immutable.fromJS({type, severity, payload, metadata: {}}),
+    new Notification({type, severity, metadata: new Map(metadata)}),
   );
 }
 
@@ -67,19 +60,19 @@ test('startEditingInstructions', reducerTest(
   reducer,
   initialState,
   startEditingInstructions,
-  initialState.setIn(['workspace', 'isEditingInstructions'], true),
+  initialState.set('isEditingInstructions', true),
 ));
 
 test('startEditingInstructions', reducerTest(
   reducer,
-  initialState.setIn(['workspace', 'isEditingInstructions'], true),
+  initialState.set('isEditingInstructions', true),
   cancelEditingInstructions,
   initialState,
 ));
 
 test('updateProjectInstructions', reducerTest(
   reducer,
-  initialState.setIn(['workspace', 'isEditingInstructions'], true),
+  initialState.set('isEditingInstructions', true),
   updateProjectInstructions,
   initialState,
 ));
@@ -102,12 +95,12 @@ test('updateProjectSource', reducerTest(
   reducer,
   initialState,
   updateProjectSource,
-  initialState.setIn(['editors', 'typing'], true),
+  initialState.set('isTyping', true),
 ));
 
 test('userDoneTyping', reducerTest(
   reducer,
-  initialState.setIn(['editors', 'typing'], true),
+  initialState.set('isTyping', true),
   userDoneTyping,
   initialState,
 ));
@@ -136,16 +129,16 @@ test('userLoggedOut', (t) => {
 
   t.test('with currentUser menu open', reducerTest(
     reducer,
-    initialState.setIn(['topBar', 'openMenu'], 'currentUser'),
+    initialState.set('openTopBarMenu', 'currentUser'),
     userLoggedOut,
     initialState,
   ));
 
   t.test('with different menu open', reducerTest(
     reducer,
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
     userLoggedOut,
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
   ));
 });
 
@@ -159,16 +152,16 @@ test('linkGithubIdentity', (t) => {
 
   t.test('with currentUser menu open', reducerTest(
     reducer,
-    initialState.setIn(['topBar', 'openMenu'], 'currentUser'),
+    initialState.set('openTopBarMenu', 'currentUser'),
     linkGithubIdentity,
     initialState,
   ));
 
   t.test('with different menu open', reducerTest(
     reducer,
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
     linkGithubIdentity,
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
   ));
 });
 
@@ -240,17 +233,17 @@ test('focusLine', reducerTest(
   reducer,
   initialState,
   partial(focusLine, 'editor.javascript', 4, 2),
-  initialState.setIn(
-    ['editors', 'requestedFocusedLine'],
-    new Immutable.Map({component: 'editor.javascript', line: 4, column: 2}),
+  initialState.set(
+    'requestedFocusedLine',
+    new EditorLocation({component: 'editor.javascript', line: 4, column: 2}),
   ),
 ));
 
 test('editorFocusedRequestedLine', reducerTest(
   reducer,
-  initialState.setIn(
-    ['editors', 'requestedFocusedLine'],
-    new Immutable.Map({component: 'editor.javascript', line: 4, column: 2}),
+  initialState.set(
+    'requestedFocusedLine',
+    new EditorLocation({component: 'editor.javascript', line: 4, column: 2}),
   ),
   editorFocusedRequestedLine,
   initialState,
@@ -284,14 +277,14 @@ test('applicationLoaded', (t) => {
     reducer,
     initialState,
     partial(applicationLoaded, {gistId: null, isExperimental: true}),
-    initialState.set('experimental', true),
+    initialState.set('isExperimental', true),
   ));
 
   t.test('isExperimental = false', reducerTest(
     reducer,
     initialState,
     partial(applicationLoaded, {gistId: null, isExperimental: false}),
-    initialState.set('experimental', false),
+    initialState.set('isExperimental', false),
   ));
 });
 
@@ -323,20 +316,20 @@ test('toggleTopBarMenu', (t) => {
     reducer,
     initialState,
     partial(toggleTopBarMenu, 'silly'),
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
   ));
 
   t.test('with specified menu open', reducerTest(
     reducer,
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
     partial(toggleTopBarMenu, 'silly'),
     initialState,
   ));
 
   t.test('with different menu open', reducerTest(
     reducer,
-    initialState.setIn(['topBar', 'openMenu'], 'goofy'),
+    initialState.set('openTopBarMenu', 'goofy'),
     partial(toggleTopBarMenu, 'silly'),
-    initialState.setIn(['topBar', 'openMenu'], 'silly'),
+    initialState.set('openTopBarMenu', 'silly'),
   ));
 });


### PR DESCRIPTION
Introduces three new `Record` types:

* `UiState`, containing top-level UI state
* `Notification`, which is what it sounds like
* `EditorLocation`, which identifies a specific line/column in a particular editor in the UI

Both `UiState` and `Notification` have simplified schemata from their previous `Map` representations:

* `UiState` is now flattened; the nesting didn’t really add clarity
* `Notification` no longer has a `payload` property; this has been merged into the existing `metadata` property