### PR TITLE
Fix GitHub client access token lookup

### DIFF
--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -294,6 +294,6 @@ async function githubWithAccessToken(token) {
 }
 
 async function clientForUser(user) {
-  const githubToken = get(user, ['accessTokens', 'github.com']);
+  const githubToken = get(user, ['account', 'accessTokens', 'github.com']);
   return githubWithAccessToken(githubToken);
 }


### PR DESCRIPTION
Missed a spot when moving the user profile information  to nested under `account`. Fixes gist/repo export, etc.