### PR TITLE
Pass access token directly to GitHub client rather than entire user

### DIFF
--- a/src/sagas/clients.js
+++ b/src/sagas/clients.js
@@ -37,10 +37,14 @@ export function* exportProject({payload: {exportType}}) {
   let url, name;
 
   try {
+    const accessToken = user.account.accessTokens['github.com'];
+
     if (exportType === 'gist') {
-      ({html_url: url} = yield call(createGistFromProject, project, user));
+      ({html_url: url} =
+        yield call(createGistFromProject, project, accessToken));
     } else if (exportType === 'repo') {
-      ({url, name} = yield call(createOrUpdateRepoFromProject, project, user));
+      ({url, name} =
+        yield call(createOrUpdateRepoFromProject, project, accessToken));
       if (name) {
         exportData = {name};
       }

--- a/src/sagas/projects.js
+++ b/src/sagas/projects.js
@@ -72,7 +72,7 @@ export function* importSnapshot({payload: {snapshotKey}}) {
 export function* importGist({payload: {gistId}}) {
   try {
     const gistData =
-      yield call(loadGistFromId, gistId, {authenticated: false});
+      yield call(loadGistFromId, gistId);
     yield put(gistImported(generateProjectKey(), gistData));
   } catch (error) {
     if (get(error, 'response.status') === 404) {

--- a/test/helpers/Scenario.js
+++ b/test/helpers/Scenario.js
@@ -1,5 +1,3 @@
-import partial from 'lodash-es/partial';
-
 import reduce from '../../src/reducers';
 import {
   projectCreated,
@@ -18,9 +16,8 @@ export default class Scenario {
   }
 
   logIn() {
-    const {user, credentials} = this.userWithCredentials =
-      userWithCredentials();
-    this._reduce(partial(userAuthenticated, user, credentials));
+    const {user, credentials} = userWithCredentials();
+    this._reduce(userAuthenticated(user, credentials));
     return this;
   }
 

--- a/test/unit/sagas/clients.js
+++ b/test/unit/sagas/clients.js
@@ -63,7 +63,7 @@ test('export gist', (t) => {
       next(scenario.state).call(
         createGistFromProject,
         scenario.project.toJS(),
-        scenario.user.toJS(),
+        scenario.user.account.accessTokens.get('github.com'),
       );
   }
 
@@ -107,7 +107,7 @@ test('export repo', (t) => {
       next(scenario.state).call(
         createOrUpdateRepoFromProject,
         scenario.project.toJS(),
-        scenario.user.toJS(),
+        scenario.user.account.accessTokens.get('github.com'),
       );
   }
 
@@ -150,7 +150,7 @@ test('update repo', (t) => {
       next(scenario.state).call(
         createOrUpdateRepoFromProject,
         scenario.project.toJS(),
-        scenario.user.toJS(),
+        scenario.user.account.accessTokens.get('github.com'),
       );
   }
 

--- a/test/unit/sagas/projects.js
+++ b/test/unit/sagas/projects.js
@@ -178,7 +178,7 @@ test('importGist()', (t) => {
   t.test('with successful import', (assert) => {
     const saga = testSaga(importGistSaga, applicationLoaded({gistId}));
 
-    saga.next().call(loadGistFromId, gistId, {authenticated: false});
+    saga.next().call(loadGistFromId, gistId);
 
     const gist = gistData({html: '<!doctype html>test'});
     saga.next(gist).inspect((effect) => {
@@ -206,7 +206,7 @@ test('importGist()', (t) => {
 
   t.test('with not found error', (assert) => {
     testSaga(importGistSaga, applicationLoaded({gistId})).
-      next().call(loadGistFromId, gistId, {authenticated: false}).
+      next().call(loadGistFromId, gistId).
       throw(
         Object.create(new Error(), {response: {value: {status: 404}}}),
       ).put(gistNotFound(gistId)).
@@ -216,7 +216,7 @@ test('importGist()', (t) => {
 
   t.test('with other error', (assert) => {
     testSaga(importGistSaga, applicationLoaded({gistId})).
-      next().call(loadGistFromId, gistId, {authenticated: false}).
+      next().call(loadGistFromId, gistId).
       throw(new Error()).put(gistImportError()).
       next().isDone();
     assert.end();
@@ -229,7 +229,7 @@ test('userAuthenticated', (assert) => {
   testSaga(userAuthenticatedSaga, userAuthenticated(userWithCredentials())).
     next().inspect(effect => assert.ok(effect.SELECT)).
     next(scenario.state).fork(saveCurrentProject).
-    next(scenario.state).call(loadAllProjects, scenario.user.get('id')).
+    next(scenario.state).call(loadAllProjects, scenario.user.account.id).
     next(projects).put(projectsLoaded(projects)).
     next().isDone();
   assert.end();


### PR DESCRIPTION
Passing the entire user unnecessarily couples the GitHub client to the data structure we use to store the logged in user information. Changing it to just take the access token enables a new use case during account migrate/merge, but I’m extracting this out into a separate pull request to make the incremental change.