### PR TITLE
switch primary login to google and add login with github button

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -15,7 +15,8 @@
     "session": {
       "link-github": "Link GitHub",
       "log-in-prompt": "Log in to save",
-      "log-out-prompt": "Log out"
+      "log-out-prompt": "Log out",
+      "log-in-github": "Log in with GitHub"
     }
   },
   "editors": {

--- a/src/components/TopBar/HamburgerMenu.jsx
+++ b/src/components/TopBar/HamburgerMenu.jsx
@@ -15,7 +15,9 @@ const HamburgerMenu = createMenu({
   renderItems({
     hasInstructions,
     isEditingInstructions,
+    isUserAuthenticated,
     onStartEditingInstructions,
+    onStartGithubLogIn,
   }) {
     return tap([], (items) => {
       items.push(
@@ -31,6 +33,18 @@ const HamburgerMenu = createMenu({
           }
         </MenuItem>,
       );
+
+      if (!isUserAuthenticated) {
+        items.push(
+          <MenuItem
+            onClick={onStartGithubLogIn}
+          >
+            {
+              t('top-bar.session.log-in-github')
+            }
+          </MenuItem>,
+        );
+      }
 
       items.push(
         <a
@@ -77,7 +91,9 @@ const HamburgerMenu = createMenu({
 HamburgerMenu.propTypes = {
   hasInstructions: PropTypes.bool.isRequired,
   isEditingInstructions: PropTypes.bool.isRequired,
+  isUserAuthenticated: PropTypes.bool.isRequired,
   onStartEditingInstructions: PropTypes.func.isRequired,
+  onStartGithubLogIn: PropTypes.func.isRequired,
 };
 
 export default HamburgerMenu;

--- a/src/components/TopBar/index.jsx
+++ b/src/components/TopBar/index.jsx
@@ -36,7 +36,6 @@ export default function TopBar({
   hasInstructions,
   hasExportedRepo,
   isEditingInstructions,
-  isExperimental,
   isGapiReady,
   isGistExportInProgress,
   isRepoExportInProgress,
@@ -112,7 +111,7 @@ export default function TopBar({
         onChangeCurrentProject={onChangeCurrentProject}
       />
       <CurrentUser
-        isLoginAvailable={!isExperimental || isGapiReady}
+        isLoginAvailable={isGapiReady}
         isOpen={openMenu === 'currentUser'}
         isUserAnonymous={isUserAnonymous}
         isUserAuthenticated={isUserAuthenticated}
@@ -122,15 +121,17 @@ export default function TopBar({
         onClose={partial(onCloseMenu, 'currentUser')}
         onLinkGitHub={onLinkGitHub}
         onLogOut={onLogOut}
-        onStartLogIn={isExperimental ? onStartGoogleLogIn : onStartGithubLogIn}
+        onStartLogIn={onStartGoogleLogIn}
       />
       <HamburgerMenu
         hasInstructions={hasInstructions}
         isEditingInstructions={isEditingInstructions}
         isOpen={openMenu === 'hamburger'}
+        isUserAuthenticated={isUserAuthenticated}
         onClick={partial(onClickMenu, 'hamburger')}
         onStartEditingInstructions={
           partial(onStartEditingInstructions, currentProjectKey)}
+        onStartGithubLogIn={onStartGithubLogIn}
       />
     </header>
   );
@@ -144,7 +145,6 @@ TopBar.propTypes = {
   hasInstructions: PropTypes.bool.isRequired,
   isClassroomExportInProgress: PropTypes.bool.isRequired,
   isEditingInstructions: PropTypes.bool.isRequired,
-  isExperimental: PropTypes.bool,
   isGapiReady: PropTypes.bool.isRequired,
   isGistExportInProgress: PropTypes.bool.isRequired,
   isRepoExportInProgress: PropTypes.bool.isRequired,
@@ -179,6 +179,5 @@ TopBar.propTypes = {
 TopBar.defaultProps = {
   currentProjectKey: null,
   currentUser: null,
-  isExperimental: false,
   openMenu: null,
 };


### PR DESCRIPTION
Takes primary google auth out of experimental mode and adds a login to GitHub button to the hamburger menu. @outoftime 