### PR TITLE
Improved instructions editing buttons

### DIFF
--- a/src/components/InstructionsEditor.jsx
+++ b/src/components/InstructionsEditor.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {t} from 'i18next';
@@ -33,7 +34,9 @@ export default class InstructionsEditor extends React.Component {
       <div className="instructions-editor">
         <div className="instructions-editor__menu">
           <button
-            className="instructions-editor__menu-button instructions-editor__menu-button_secondary"
+            className={classnames('instructions-editor__menu-button',
+              'instructions-editor__menu-button_secondary',
+            )}
             onClick={this._handleCancelEditing}
           >
             {t('workspace.components.instructions.cancel')}

--- a/src/components/InstructionsEditor.jsx
+++ b/src/components/InstructionsEditor.jsx
@@ -48,7 +48,7 @@ export default class InstructionsEditor extends React.Component {
             {t('workspace.components.instructions.save')}
           </button>
         </div>
-        <div className="instructions-editor__input-container instructions-editor__menu-button_primary">
+        <div className="instructions-editor__input-container">
           <textarea
             className="instructions-editor__input"
             defaultValue={this.props.instructions}

--- a/src/components/InstructionsEditor.jsx
+++ b/src/components/InstructionsEditor.jsx
@@ -33,19 +33,19 @@ export default class InstructionsEditor extends React.Component {
       <div className="instructions-editor">
         <div className="instructions-editor__menu">
           <button
+            className="instructions-editor__menu-button instructions-editor__menu-button_secondary"
+            onClick={this._handleCancelEditing}
+          >
+            {t('workspace.components.instructions.cancel')}
+          </button>
+          <button
             className="instructions-editor__menu-button"
             onClick={this._handleSaveChanges}
           >
             {t('workspace.components.instructions.save')}
           </button>
-          <button
-            className="instructions-editor__menu-button"
-            onClick={this._handleCancelEditing}
-          >
-            {t('workspace.components.instructions.cancel')}
-          </button>
         </div>
-        <div className="instructions-editor__input-container">
+        <div className="instructions-editor__input-container instructions-editor__menu-button_primary">
           <textarea
             className="instructions-editor__input"
             defaultValue={this.props.instructions}

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -409,7 +409,34 @@ body {
 .instructions-editor__menu {
   padding: 0.5rem;
   text-align: right;
-  background-color: var(--color-light-gray);
+  font-size: var(--font-size-menu);
+}
+
+.instructions-editor__menu-button {
+  border-radius: var(--size-rounded-corners);
+  box-sizing: border-box;
+  cursor: pointer;
+  height: var(--size-top-bar-menu-button);
+  line-height: var(--size-top-bar-menu-button);
+  padding: 0 1em;
+  position: relative;
+  user-select: none;
+  vertical-align: middle;
+  margin-right: 0.5em;
+  white-space: nowrap;
+  width: 80px;
+}
+
+.instructions-editor__menu-button_secondary {
+  background-color: var(--color-low-contrast-gray);
+}
+
+.instructions-editor__menu-button:hover {
+  box-shadow: 0 0.1em 0.2em 0 rgba(0, 0, 0, 0.3);
+}
+
+.instructions-editor__menu-button:active {
+  box-shadow: inset 0 0.1em 0.2em 0 rgba(0, 0, 0, 0.3);
 }
 
 .instructions-editor__footer {


### PR DESCRIPTION
Resolves #1395 

New buttons:
<img width="366" alt="screen shot 2018-07-30 at 7 35 18 pm" src="https://user-images.githubusercontent.com/852079/43429291-a3e1b3f4-9430-11e8-970b-d03f007ba8a8.png">

These:
- Match top bar button stying
- Have a clear primary and secondary action
- Have equal widths (cancel was larger than save before)
