### PR TITLE
Use a fragment rather than an array for hamburger menu items

### DIFF
--- a/src/components/TopBar/HamburgerMenu.jsx
+++ b/src/components/TopBar/HamburgerMenu.jsx
@@ -1,7 +1,8 @@
+/* eslint-disable react/prop-types */
+
 import {t} from 'i18next';
-import tap from 'lodash-es/tap';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {Fragment} from 'react';
 
 import config from '../../config';
 
@@ -19,11 +20,10 @@ const HamburgerMenu = createMenu({
     onStartEditingInstructions,
     onStartGithubLogIn,
   }) {
-    return tap([], (items) => {
-      items.push(
+    return (
+      <Fragment>
         <MenuItem
           isDisabled={isEditingInstructions}
-          key="addOrEditInstructions"
           onClick={onStartEditingInstructions}
         >
           {
@@ -31,38 +31,26 @@ const HamburgerMenu = createMenu({
               t('top-bar.edit-instructions') :
               t('top-bar.add-instructions')
           }
-        </MenuItem>,
-      );
+        </MenuItem>
 
-      if (!isUserAuthenticated) {
-        items.push(
-          <MenuItem
-            onClick={onStartGithubLogIn}
-          >
-            {
-              t('top-bar.session.log-in-github')
-            }
-          </MenuItem>,
-        );
-      }
+        {
+          !isUserAuthenticated && (
+            <MenuItem onClick={onStartGithubLogIn}>
+              {t('top-bar.session.log-in-github')}
+            </MenuItem>
+          )
+        }
 
-      items.push(
         <a
           className="top-bar__menu-item"
           href={config.feedbackUrl}
-          key="feedback"
           rel="noopener noreferrer"
           target="blank"
         >
           {t('top-bar.send-feedback')}
-        </a>,
-      );
+        </a>
 
-      items.push(
-        <div
-          className="top-bar__menu-item top-bar__menu-item_icons"
-          key="social"
-        >
+        <div className="top-bar__menu-item top-bar__menu-item_icons">
           <a
             className="u__icon top-bar__menu-item-icon"
             href="https://github.com/popcodeorg/popcode"
@@ -81,9 +69,9 @@ const HamburgerMenu = createMenu({
             rel="noopener noreferrer"
             target="_blank"
           >&#xf198;</a>
-        </div>,
-      );
-    });
+        </div>
+      </Fragment>
+    );
   },
 })(HamburgerMenuButton);
 


### PR DESCRIPTION
Proximate motivation is fixing a missing `key` prop for the GitHub login item, but ultimately using an array in this situation (where there is actually a specific set of items we want to return) is no longer the preferred approach. Instead, use a `<Fragment>`.