### PR TITLE
Report uncaught errors in sagas to Bugsnag

### DIFF
--- a/src/createApplicationStore.js
+++ b/src/createApplicationStore.js
@@ -8,6 +8,7 @@ import get from 'lodash-es/get';
 
 import reducers from './reducers';
 import rootSaga from './sagas';
+import {bugsnagClient} from './util/bugsnag';
 
 const compose = get(
   window,
@@ -16,7 +17,11 @@ const compose = get(
 );
 
 export default function createApplicationStore() {
-  const sagaMiddleware = createSagaMiddleware();
+  const sagaMiddleware = createSagaMiddleware({
+    onError(error) {
+      bugsnagClient.notify(error);
+    },
+  });
   const store = createStore(
     reducers,
     compose(applyMiddleware(sagaMiddleware)),


### PR DESCRIPTION
Realized we have a huge hole in our error monitoring—uncaught errors that happen inside `redux-saga` call paths are caught by `redux-saga` itself, meaning they’re not captured as uncaught exceptions or unhandled promise rejections. So, we need to explicitly send them to Bugsnag.  Fortunately, `redux-saga` does provide an `onError` callback when creating the middleware that actually runs sagas, which is intended for just this use case. Add that callback and report errors to Bugsnag.