### PR TITLE
Send detailed information about error missing credential

### DIFF
--- a/test/unit/sagas/user.js
+++ b/test/unit/sagas/user.js
@@ -228,7 +228,8 @@ test('linkGithubIdentity', (t) => {
 
     testSaga(linkGithubIdentitySaga, linkGithubIdentity()).
       next().call(linkGithub).
-      throw(error).put(linkIdentityFailed(error)).
+      throw(error).call([bugsnagClient, 'notify'], error).
+      next().put(linkIdentityFailed(error)).
       next().isDone();
 
     assert.end();


### PR DESCRIPTION
When we get an `auth/credential-already-in-use` with no credential, send both a cloned copy of the error and the result of calling `error.toJSON()`, which for some reason returns an object with a different shape.