### PR TITLE
Upgrade Firebase to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,8 +157,8 @@
   "dependencies": {
     "@firebase/app": "^0.3.3",
     "@firebase/app-types": "^0.3.2",
-    "@firebase/auth": "^0.5.3",
-    "@firebase/database": "^0.3.3",
+    "@firebase/auth": "^0.7.2",
+    "@firebase/database": "^0.3.4",
     "PrettyCSS": "^0.3.17",
     "array-to-sentence": "^2.0.0",
     "bowser": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,23 +204,23 @@
     tslib "1.9.0"
     xmlhttprequest "1.8.0"
 
-"@firebase/auth-types@0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.3.3.tgz#950a68bdae1e1e37ece054ff69ee0082c5ecabab"
+"@firebase/auth-types@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.3.4.tgz#253b1b2d9b520a0b945d4617c8418f0f19a4159f"
 
-"@firebase/auth@^0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.5.3.tgz#4f0d83cd5a7c173d3a7a06f904bb1084acd8a0c4"
+"@firebase/auth@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.7.2.tgz#6432f22f370d003f046bf6a395f6af1369c2ecc1"
   dependencies:
-    "@firebase/auth-types" "0.3.3"
+    "@firebase/auth-types" "0.3.4"
 
 "@firebase/database-types@0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.3.2.tgz#70611a64dd460e0e253c7427f860d56a1afd86fe"
 
-"@firebase/database@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.3.3.tgz#01123d4e0f8cb020e685ead27d795ef8794b2991"
+"@firebase/database@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.3.4.tgz#67fd48ed6d8fffc81c6c6f8e68bde70b99ba8ca9"
   dependencies:
     "@firebase/database-types" "0.3.2"
     "@firebase/logger" "0.1.1"


### PR DESCRIPTION
Upgrades Firebase packages from SDK version 5.0.4 to latest 5.3.1.

This is a shot-in-the-dark attempt to fix a bug where `auth/credential-already-in-use` errors do not include a credential in the payload, even though they are always supposed to.

Reviewing the changelog, there do not appear to be any breaking changes.