### PR TITLE
Add email and profile scopes to GitHub

### DIFF
--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -17,7 +17,7 @@ import config from '../config';
 import retryingFailedImports from '../util/retryingFailedImports';
 import {getGapiSync, SCOPES as GOOGLE_SCOPES} from '../services/gapi';
 
-const GITHUB_SCOPES = ['gist', 'public_repo'];
+const GITHUB_SCOPES = ['gist', 'public_repo', 'read:user', 'user:email'];
 const VALID_SESSION_UID_COOKIE = 'firebaseAuth.validSessionUid';
 const SESSION_TTL_MS = 5 * 60 * 1000;
 const githubAuthProvider = new firebase.auth.GithubAuthProvider();

--- a/src/sagas/user.js
+++ b/src/sagas/user.js
@@ -1,5 +1,4 @@
 import {bugsnagClient} from '../util/bugsnag';
-import cloneDeepWith from 'lodash-es/cloneDeepWith';
 import isEmpty from 'lodash-es/isEmpty';
 import isError from 'lodash-es/isError';
 import isString from 'lodash-es/isString';
@@ -132,25 +131,6 @@ export function* linkGithubIdentity() {
           yield put(linkIdentityFailed(e));
           return;
         }
-
-        if (isNil(e.credential)) {
-          const clonedError = cloneDeepWith(e, val => Object.assign({}, val));
-          const errorToJson = e.toJSON();
-          yield call(
-            [bugsnagClient, 'notify'],
-            e,
-            {
-              metaData: {
-                errorObject: e,
-                clonedError,
-                errorToJson,
-              },
-            },
-          );
-          yield put(linkIdentityFailed(e));
-          return;
-        }
-
         const {data: githubProfile} = yield call(
           getProfileForAuthenticatedUser,
           e.credential.accessToken,


### PR DESCRIPTION
Because of what I believe is a bug in the Firebase SDK, we don’t get a credential back with the auth error unless the response from GitHub includes an email address. I will file a bug with the SDK, but in the meantime, requesting `read:user` and `user:email` is a viable workaround.

Also removes the detailed error logging since I found the root cause of the error.