### PR TITLE
Local override for Docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 bower_components
 yarn-error.log
+docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "3000:3000"
     volumes:
       - .:/app:cached
-      - ./node_modules:/app/node_modules:delegated
       - npm_cache:/root/.npm
       - yarn_cache:/usr/local/share/.cache/yarn
     tmpfs:
@@ -21,6 +20,5 @@ services:
       - .:/repo:cached
       - ~/.travis:/travis
 volumes:
-  node_modules:
   npm_cache:
   yarn_cache:


### PR DESCRIPTION
Adds `docker-compose.override.yml` to `.gitignore` so that people can easily override local `docker-compose` configurations to their liking. I used this to set up NFS mount of the project directory. Also removes the explicit bind mount for `node_modules`, which was a very minor optimization but makes overriding the mount much more annoying.