### PR TITLE
Handle gapi load failure

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -50,7 +50,8 @@
     "classroom-export-error": "Something went wrong trying to share to Google Classroom. Please try again.",
     "project-compilation-failed": "Something went wrong trying to display a preview of your project. This is a bug in Popcode and we have been notified. Making another change to your code will likely fix this error.",
     "identity-linked": "Your GitHub account is now linked!",
-    "link-identity-failed": "There was a problem linking your GitHub account."
+    "link-identity-failed": "There was a problem linking your GitHub account.",
+    "gapi-client-unavailable": "It looks like you are having trouble with your internet connection. You can continue to work in Popcode but you won’t be able to log in or save your work. Proceed carefully!"
   },
   "languages": {
     "html": "HTML",

--- a/src/actions/clients.js
+++ b/src/actions/clients.js
@@ -37,3 +37,8 @@ export const projectExportNotDisplayed = createAction(
 );
 
 export const gapiClientReady = createAction('GAPI_CLIENT_READY');
+
+export const gapiClientUnavailable = createAction(
+  'GAPI_CLIENT_UNAVAILABLE',
+  error => ({error}),
+);

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -6,6 +6,7 @@ import {
   projectExportDisplayed,
   projectExportNotDisplayed,
   gapiClientReady,
+  gapiClientUnavailable,
 } from './clients';
 
 import {
@@ -111,6 +112,7 @@ export {
   projectCompiled,
   projectCompilationFailed,
   gapiClientReady,
+  gapiClientUnavailable,
   projectSuccessfullySaved,
   showSaveIndicator,
   hideSaveIndicator,

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -211,6 +211,9 @@ export default function ui(stateIn, action) {
     case 'LINK_IDENTITY_FAILED':
       return addNotification(state, 'link-identity-failed', 'error');
 
+    case 'GAPI_CLIENT_UNAVAILABLE':
+      return addNotification(state, 'gapi-client-unavailable', 'error');
+
     default:
       return state;
   }

--- a/src/sagas/clients.js
+++ b/src/sagas/clients.js
@@ -13,9 +13,11 @@ import {
   projectExported,
   projectExportError,
   gapiClientReady,
+  gapiClientUnavailable,
 } from '../actions/clients';
 import {getCurrentProject} from '../selectors';
 import {generateTextPreview} from '../util/compileProject';
+import {bugsnagClient} from '../util/bugsnag';
 import {loadAndConfigureGapi} from '../services/gapi';
 
 
@@ -65,8 +67,13 @@ export function* exportProject({payload: {exportType}}) {
 }
 
 export function* applicationLoaded() {
-  yield loadAndConfigureGapi();
-  yield put(gapiClientReady());
+  try {
+    yield loadAndConfigureGapi();
+    yield put(gapiClientReady());
+  } catch (error) {
+    yield call([bugsnagClient, 'notify'], error);
+    yield put(gapiClientUnavailable(error));
+  }
 }
 
 export default function* () {


### PR DESCRIPTION
If we fail to load `gapi`, for instance if there is no internet connection, Popcode should still be basically usable. Previously this situation would throw a promise rejection which was not handled, thus breaking out of the saga loop and causing the app to stop functioning properly. Now we handle the rejection and display a message to the user explaining the situation.