### PR TITLE
Dismiss Snapshot Notification after Project is Updated

### DIFF
--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -38,7 +38,9 @@ export default function ui(stateIn, action) {
       return state.set('isEditingInstructions', false);
 
     case 'UPDATE_PROJECT_SOURCE':
-      return state.set('isTyping', true);
+      return state.
+        set('isTyping', true).
+        deleteIn(['notifications', 'snapshot-created']);
 
     case 'USER_DONE_TYPING':
       return state.set('isTyping', false);

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -93,9 +93,15 @@ test('gistImportError', reducerTest(
 
 test('updateProjectSource', reducerTest(
   reducer,
-  initialState,
+  initialState.setIn(['notifications', 'snapshot-created'], {
+    metadata: {snapshotKey: 'f941ba40-b111-42c5-882d-c21c99afb29d'},
+    severity: 'notice',
+    type: 'snapshot-created',
+  }),
   updateProjectSource,
-  initialState.set('isTyping', true),
+  initialState.
+    set('isTyping', true).
+    deleteIn(['notifications', 'snapshot-created']),
 ));
 
 test('userDoneTyping', reducerTest(


### PR DESCRIPTION
### Description

Deletes notification from Redux store in the `UPDATE_PROJECT_SOURCE` reducer.

### Screenshots

![popcode-dismiss-notification](https://user-images.githubusercontent.com/11700385/47391747-a5f73b00-d6e8-11e8-91a9-cab9d76bd298.gif)


Fixes #1048