### PR TITLE
Fixes for older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "promise-retry": "^1.1.1",
     "prop-types": "^15.6.2",
     "qs": "^6.1.0",
+    "raf": "^3.4.0",
     "react": "^16.4.2",
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "^16.4.2",

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import prefixAll from 'inline-style-prefixer/static';
 import {t} from 'i18next';
+import classnames from 'classnames';
+import clone from 'lodash-es/clone';
 import isEmpty from 'lodash-es/isEmpty';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
@@ -122,7 +124,7 @@ export default function EditorsColumn({
     <div
       className="environment__column"
       ref={onRef}
-      style={prefixAll(style)}
+      style={prefixAll(clone(style))}
     >
       <div className="environment__column-contents editors">
         {children}

--- a/src/components/EditorsColumn.jsx
+++ b/src/components/EditorsColumn.jsx
@@ -22,6 +22,7 @@ export default function EditorsColumn({
   errors,
   resizableFlexGrow,
   resizableFlexRefs,
+  isFlexResizingSupported,
   isTextSizeLarge,
   requestedFocusedLine,
   onComponentHide,
@@ -82,7 +83,12 @@ export default function EditorsColumn({
           key={`divider:${language}`}
           onDrag={partial(onResizableFlexDividerDrag, index)}
         >
-          <div className="editors__row-divider" />
+          <div
+            className={classnames(
+              'editors__row-divider',
+              {'editors__row-divider_draggable': isFlexResizingSupported},
+            )}
+          />
         </DraggableCore>,
       );
     }
@@ -128,6 +134,7 @@ export default function EditorsColumn({
 EditorsColumn.propTypes = {
   currentProject: PropTypes.object.isRequired,
   errors: PropTypes.object.isRequired,
+  isFlexResizingSupported: PropTypes.bool.isRequired,
   isTextSizeLarge: PropTypes.bool.isRequired,
   requestedFocusedLine: PropTypes.instanceOf(EditorLocation),
   resizableFlexGrow: ImmutablePropTypes.list.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -135,6 +135,7 @@ export default class Workspace extends React.Component {
   _renderEnvironment() {
     const {
       currentProject,
+      isFlexResizingSupported,
       resizableFlexGrow,
       resizableFlexRefs,
       onResizableFlexDividerDrag,
@@ -159,7 +160,10 @@ export default class Workspace extends React.Component {
           onStop={onStopDragColumnDivider}
         >
           <div
-            className="editors__column-divider"
+            className={classnames(
+              'editors__column-divider',
+              {'editors__column-divider_draggable': isFlexResizingSupported},
+            )}
           />
         </DraggableCore>
         <Output
@@ -191,6 +195,7 @@ export default class Workspace extends React.Component {
 Workspace.propTypes = {
   currentProject: PropTypes.object,
   isEditingInstructions: PropTypes.bool.isRequired,
+  isFlexResizingSupported: PropTypes.bool.isRequired,
   resizableFlexGrow: ImmutablePropTypes.list.isRequired,
   resizableFlexRefs: PropTypes.array.isRequired,
   onApplicationLoaded: PropTypes.func.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -175,13 +175,13 @@ export default class Workspace extends React.Component {
       <div className="layout">
         <TopBar />
         <NotificationList />
-        <main className="layout__columns">
+        <div className="layout__columns">
           <Instructions />
           {this._renderInstructionsBar()}
           <div className="workspace layout__main">
             {this._renderEnvironment()}
           </div>
-        </main>
+        </div>
         <AccountMigration />
       </div>
     );

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -505,14 +505,20 @@ body {
 
 .editors__column-divider {
   background-color: var(--color-light-gray);
-  cursor: ew-resize;
   width: 0.5vh;
+}
+
+.editors__column-divider_draggable {
+  cursor: ew-resize;
 }
 
 .editors__row-divider {
   background-color: var(--color-light-gray);
-  cursor: ns-resize;
   height: 0.5vh;
+}
+
+.editors__row-divider_draggable {
+  cursor: ns-resize;
 }
 
 .editors__help-text {

--- a/src/higherOrderComponents/resizableFlex/index.js
+++ b/src/higherOrderComponents/resizableFlex/index.js
@@ -13,10 +13,16 @@ import {updateResizableFlex} from '../../actions';
 
 import calculateFlexGrowAfterDrag from './calculateFlexGrowAfterDrag';
 import directionAdapterFor from './directionAdapterFor';
+import isFlexResizingSupported from './isFlexResizingSupported';
+import shamResizableFlex from './sham';
 
 let nextInstanceId = 1;
 
 export default function resizableFlex(size) {
+  if (!isFlexResizingSupported()) {
+    return shamResizableFlex(size);
+  }
+
   const instanceId = (nextInstanceId++).toString();
   const getResizableFlexGrow = makeGetResizableFlexGrow(instanceId);
 
@@ -26,6 +32,8 @@ export default function resizableFlex(size) {
       const initialMainSizes = times(size, () => null);
 
       const stateIndependentFunctions = {
+        isFlexResizingSupported: true,
+
         onResizableFlexDividerDrag(beforeIndex, event, payload) {
           const afterIndex = findIndex(regions, 'current', beforeIndex + 1);
           const [{current: before}, {current: after}] =

--- a/src/higherOrderComponents/resizableFlex/isFlexResizingSupported.js
+++ b/src/higherOrderComponents/resizableFlex/isFlexResizingSupported.js
@@ -1,0 +1,5 @@
+import once from 'lodash-es/once';
+
+export default once(
+  () => 'flex-grow' in getComputedStyle(document.documentElement),
+);

--- a/src/higherOrderComponents/resizableFlex/sham.js
+++ b/src/higherOrderComponents/resizableFlex/sham.js
@@ -1,0 +1,22 @@
+import {List} from 'immutable';
+import React from 'react';
+import times from 'lodash-es/times';
+import noop from 'lodash-es/noop';
+
+export default function resizableFlex(size) {
+  const props = {
+    isFlexResizingSupported: false,
+    resizableFlexGrow: new List(times(size, () => null)),
+    resizableFlexRefs: times(size, () => noop),
+    onResizableFlexDividerDrag: noop,
+  };
+
+  return (Component) => {
+    function WrappedComponent(ownProps) {
+      return <Component {...props} {...ownProps} />;
+    }
+    WrappedComponent.displayName =
+      `ResizableFlex.sham(${Component.displayName || Component.name}`;
+    return WrappedComponent;
+  };
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,6 +157,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
         'babel-polyfill',
         'es6-set/implement',
         'whatwg-fetch',
+        'raf/polyfill',
         './src/init/DOMParserShim',
         './src/application.js',
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8490,6 +8490,12 @@ quote-stream@~0.0.0:
     minimist "0.0.8"
     through2 "~0.4.1"
 
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 ramda@0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"


### PR DESCRIPTION
Was testing for regressions after upgrading a library and realized that old browsers are totally broken. Had to do several fixes for Chrome 23 and one more for Safari 7.1:

* Remove the `<main>` tag (React requires that all tags used in JSX are recognized by the browser; old Chrome does not know about the `<main>` tag)
* Polyfill `requestAnimationFrame`
* Only do flex resizing on browsers that implement the modern flexbox standard; sham out the functionality on older browsers
* Clone the `style` object received as a prop by `EditorsContainer`