### PR TITLE
Travis uses Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,15 @@ deploy:
   on:
     repo: popcodeorg/popcode
     branch: master
+- provider: script
+  script: >
+    echo "$DOCKER_PASSWORD" |
+    docker login -u "$DOCKER_USERNAME" --password-stdin &&
+    docker push popcodeorg/popcode
+  on:
+    repo: popcodeorg/popcode
+    branch: master
+
 after_deploy:
 - >
   docker run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,29 @@
-language: node_js
-node_js:
-- 8.12.0
-env:
-  global:
-  - NODE_ENV=production
-  - CXX=g++-4.8
-  - LOG_REDUX_ACTIONS=false
-  - FIREBASE_APP=popcode
-  - FIREBASE_API_KEY=AIzaSyAga2AZz56-dAjl1fsswFfvs3HRBbfKZJg
-  - BROWSER_STACK_USERNAME=matthewbrown17
-  - CLOUDFLARE_ZONE=d3f68763e9e100672fc0e1800282ddbe
-  - GOOGLE_ANALYTICS_TRACKING_ID=UA-90316486-1
-  - HOSTNAME=popcode.org
-  - secure: oNSex8CSxFztUhsuIVREJmJTH2H3D+zW1Q8tckp717HyJQQ3j1cVd1FUPJpLYu8sYAxMbf1HrxGPYfXUfXAXPKcXK6eCoWVUfJ9sCjTPgI+IKNYWshOsZxgkpZDELqK02iXfiX2N9IBX9Ucf/QLrtcmVCx4uSOIwU0zlKTnZZKOIaVhZMh9WJl0zetMdnh4zwRwJ0JqN/NDbEq43gKC87BZsk09/j/2kq3soyIqLoTe4kzkOxpnQUYBlQaL0XgrjODnMxiL+7tvmNJXzMgYH5VgfjU8mSrA78JnmrakbQIMtTn53rCXNM+LD67RbvSWwiUwTT6Ve7hYNyriovfXqk3UKL5KoawThn6/SF4zFc8lma395OMbE2NVTU0VaOGZ5wiiQvVeZftg272RRFeAHRSRjERjO5+mAi65nKLEcO7uIIMVG/hVcKVUplo9yfQpLOJyPaVke3iLP74D5s0PLxROM11qwYhrEHk7uE5nhPhc8GADtUbEjIh/HbOeLDpsK0unjwbiQzqQ1P5kxx0Z33ISjraM4aIpMch6bL8kPLKXPxF3i/7J16NkTnbNic6W+O8IOCuHgHgt+7NVdt+NNgQyZJockS4FVdGg3yktgXCFlKwcBcQNMkud3pDhUnivGlK6XV5cZRb3G6Kx/DwpjWqW405lCIFLtyicqKZ/13FI=
-  - secure: SfrceTUdcPMC9Jk7T9eIFVxDGdoOC9sUUg6nQX+3GerJ+vefoVFjspx/StYPr5Jci7NWqFCGns/8Ctu7eOK7p9lFnHeleuNGxKhotsmV2dfF3DjzkusuTisVhFMNKclVCxSSuQYswBZJ8ZUCdxMYq3XIyl5kfxD7t8Tb09cdeYWPw1SUkSdjMYbVUkL+Q+tidb4FudhIH5hZQ+gAAtRYidxG1esNj0cB1ITyN5eM3UkGM59/TFqvIGfolJEBJFW7gyeqedKlgiavdXVaEOvBk4kqu+2q7waMTYbCMPLBFNBBH7bEdPt4OA5hU5qlVuCMH7y3CKHOikSDiIBzLEIcx1cy1xmHzvxuDya340vW0IK8PnvSV2jp/3uy4XWc0SXq+zWAZTfHwYFObx32byo0pBTnx8CVkxdhwNZYwfCU7KIPHJ++WVpxTyx/BrJT5BkqmTbnccsJrpr75DNfm/lrthWjz66Es2sdZVb5Knn/ezfHyKP92hcl1jNhddkX4YWH1rZt5UYA1paQrsMgolKnt9oRBsaN5/2A5X+2hHzwDRSV20XP7d7ZLwDtUCsUQf7aMo5B4P6p3ElRGpLyA04YRm/x/aegQujVMrgdIKxZ/u/TtM0gPkkoeFcbDSrQq3PVEiOGMiDxKPrKMEE4f0nYqs6mpeyoBn6lSyCXDWhXcAo=
-cache:
-  apt: true
-  npm: true
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-  chrome: stable
+language: minimal
+services:
+- docker
 install:
-- npm ci --production=false
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
+- docker build -t popcode
 script:
-- npm ls > /dev/null
-- NODE_ENV=test npm test
-- npx gulp build
-- npx eslint --no-eslintrc --env es5 dist
+- docker run popcode bash -c 'npm ls > /dev/null'
+- docker run --env NODE_ENV=test popcode npm test
+- >-
+  docker run
+  --env NODE_ENV=production
+  --env FIREBASE_APP
+  --env FIREBASE_API_KEY
+  --env FIREBASE_CLIENT_ID
+  --env GIT_REVISION="$TRAVIS_COMMIT"
+  --env GOOGLE_ANALYTICS_TRACKING_ID
+  --volume="$TRAVIS_BUILD_DIR/dist:/app/dist"
+  popcode
+  npx gulp build
+- >-
+  docker run
+  --volume=$TRAVIS_BUILD_DIR/dist:/app/dist
+  popcode
+  npx eslint --no-eslintrc --env es5 dist
 before_deploy:
-- npx gulp syncFirebase
+- docker run --env FIREBASE_SECRET npx gulp syncFirebase
 deploy:
 - provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,14 @@ deploy:
     repo: popcodeorg/popcode
     branch: master
 after_deploy:
-- gulp purgeCache
+- >
+  docker run
+  --env CLOUDFLARE_EMAIL
+  --env CLOUDFLARE_KEY
+  --env CLOUDFLARE_ZONE
+  --env HOSTNAME
+  popcode
+  gulp purgeCache
 notifications:
   slack:
     secure: IJ0LSnahbfPFMFFgEK+wwSYEUWjJ2AFZz89oSmzSuKqEchM7AA2tpkCAPvN37cUksPE4YozVXxx++SQ4j+fk1lmhhddEUYO9ueB/UqD3iu0xCFR/CJ30ka7QDkfzkatKkn0H8MVU3FwEJ6ZbHJR2zJVUALPFw7AQ08EE4GpTC2TfWSiYuv1AnuVUC8ZkvGBjwFN1lQrAnHFS62sreNmYtBR0FHHo9DEE+NanYdtLnFYyGeDauWx7I1ERT1vnv4G+0vx5Guu7TGwC1uzHCTlciqSGPeaifaC+uXR/8VaTabZS4G1PsR8ROYt3S/RFtCEAfuhBvlcWdNnfLH7/xLhET4W35H/hhHmSaMYJCy/gnQW/bXfLCxtO5/luwM5nOM4NeQcRybqreBL/q4K78giw6ttpTo5EumBxXrYKo4PRWfOWkOhePotQ/IRzpsoMqFHxzlJxv9HPSnFb+11OTe3BsxfWpsHs233eIBpKYOcjpzXPP4GSq7FH2V7jL2lg6Cc81XUK2v8upJpPoWRRfM52LxemNi+uEMBrgLro6VA2O5qRDN/+mhr8wYS4dLms5uk6Hq87UA9xhlIUl0P9d6kfN0vHi+QzxLMLvA1ateFncaG7MKTgMNjsckziKlR2B8FZ1c3lT55RB/zfojGzrDs0l7TCKB+WKP5uPJEWw5/UC2A=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 services:
 - docker
 install:
-- docker build -t popcode
+- docker build -t popcode .
 script:
 - docker run popcode bash -c 'npm ls > /dev/null'
 - docker run --env NODE_ENV=test popcode npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update && apt-get install -y google-chrome-stable
 
+RUN npm install --global npm@6.4.1
+
 RUN echo '{"allow_root": true}' > /root/.bowerrc
 RUN npm config set unsafe-perm true
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ const concat = require('gulp-concat');
 const sourcemaps = require('gulp-sourcemaps');
 const cssnano = require('cssnano');
 const forOwn = require('lodash.forown');
-const git = require('git-rev-sync');
 const postcss = require('gulp-postcss');
 const postcssPresetEnv = require('postcss-preset-env');
 const webpack = require('webpack');
@@ -46,10 +45,6 @@ forOwn(supportedBrowsers, (version, browser) => {
   postcssBrowsers.push(`${browserForPostcss} >= ${version}`);
 });
 
-gulp.task('env', () => {
-  process.env.GIT_REVISION = git.short();
-});
-
 gulp.task('static', () => gulp.
   src(path.join(staticDir, '**/*')).
   pipe(gulp.dest(distDir)),
@@ -75,7 +70,7 @@ gulp.task('css', () => {
     pipe(browserSync.stream());
 });
 
-gulp.task('js', ['env'], () => new Promise((resolve, reject) => {
+gulp.task('js', () => new Promise((resolve, reject) => {
   webpack(
     webpackConfiguration(process.env.NODE_ENV),
     (error, stats) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7418,30 +7418,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "git-rev-sync": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.12.0.tgz",
-      "integrity": "sha1-RGhAbH5sO6TPRYeZnhrbKNnRr1U=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5",
-        "graceful-fs": "4.1.11",
-        "shelljs": "0.7.7"
-      },
-      "dependencies": {
-        "shelljs": {
-          "version": "0.7.7",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-          "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
-          }
-        }
-      }
-    },
     "github-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -278,7 +278,6 @@
     "eslint-plugin-react": "^7.10.0",
     "eslint_d": "^5.1.0",
     "exports-loader": "^0.7.0",
-    "git-rev-sync": "^1.6.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
     "gulp-postcss": "^7.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ const VisualizerPlugin = require('webpack-visualizer-plugin');
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 const webpack = require('webpack');
 const escapeRegExp = require('lodash.escaperegexp');
-const git = require('git-rev-sync');
 const babel = require('babel-core');
 
 const babelLoaderVersion =
@@ -68,7 +67,6 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
       FIREBASE_CLIENT_ID:
       /* eslint-disable-next-line max-len */
         '488497217137-c0mdq8uca6ot5o9u9avo3j5mfsi1q9v5.apps.googleusercontent.com',
-      GIT_REVISION: git.short(),
       NODE_ENV: env,
       WARN_ON_DROPPED_ERRORS: 'false',
       GOOGLE_ANALYTICS_TRACKING_ID: 'UA-90316486-2',


### PR DESCRIPTION
Run the build in Docker on Travis. This has a few advantages:

* Removes duplication—`Dockerfile` becomes the source of truth for Travis, as well as for development for those who use Docker in development
* Makes CI more portable
* Should in principle make builds faster, as we can push release images to Dockerhub, and then use the image layers as a cache for the next build. This will allow new builds to, at a minimum, reuse the OS-level dependency installations, and for branches that don’t change the node modules, reuse the NPM installation as well. However we need to merge this and get an initial image pushed to Dockerhub before I can add configuration to the build to use the Dockerhub image for caching