### PR TITLE
Docker build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 services:
 - docker
 install:
-- docker build -t popcode .
+- docker build --cache-from popcodeorg/popcode:latest --tag popcode .
 script:
 - docker run popcode bash -c 'npm ls > /dev/null'
 - docker run --env NODE_ENV=test popcode npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   popcode
   npx eslint --no-eslintrc --env es5 dist
 before_deploy:
-- docker run --env FIREBASE_SECRET npx gulp syncFirebase
+- docker run --env FIREBASE_SECRET popcode npx gulp syncFirebase
 deploy:
 - provider: s3
   access_key_id: AKIAJY2GYDQBE4HFF32Q

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 
 ARG install_dependencies=true
 COPY package.json package-lock.json bower.json /app/
-RUN if [ $install_dependencies = true ]; then npm install; fi
+RUN if [ $install_dependencies = true ]; then npm ci; fi
 
 COPY . /app/
 


### PR DESCRIPTION
* Use `npm ci` rather than `npm install`
* Point Docker build at latest release image on Dockerhub to use as cache layer
* Add missing image name in run command for `syncFirebase`