### PR TITLE
Explicitly pull latest release Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: minimal
 services:
 - docker
 install:
-- docker build --cache-from popcodeorg/popcode:latest --tag popcode .
+- docker pull popcodeorg/popcode:latest
+- docker build --pull --cache-from popcodeorg/popcode:latest --tag popcode .
 script:
 - docker run popcode bash -c 'npm ls > /dev/null'
 - docker run --env NODE_ENV=test popcode npm test

--- a/README.md
+++ b/README.md
@@ -132,14 +132,7 @@ feedback from dozens of instructors.
 
 ### Running locally ###
 
-#### With Docker
-
-If you already use Docker, your best bet is to use it for Popcode development
-too. A simple `docker-compose up` will do the trick.
-
-#### Without Docker
-
-Still pretty easy. You’ll just need a local installation of [Node.js](https://nodejs.org/en/download/).
+Make sure you have a local installation of [Node.js](https://nodejs.org/en/download/).
 
 Once you’ve got it run:
 
@@ -186,6 +179,7 @@ with no local Node installation needed. If you’re a Docker user, you can insta
 and run Popcode locally with:
 
 ```bash
+$ docker pull popcodeorg/popcode:latest # Not required, but will speed up installation
 $ docker-compose up
 ```
 


### PR DESCRIPTION
`--cache-from` won’t pull the image for you.

Also mention doing this in the README.