### PR TITLE
Consolidate build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM node:8.12.0
 
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
+        apt-get update && \
+        apt-get install -y google-chrome-stable
 
 RUN npm install --global npm@6.4.1
 
-RUN echo '{"allow_root": true}' > /root/.bowerrc
-RUN npm config set unsafe-perm true
+RUN echo '{"allow_root": true}' > /root/.bowerrc && \
+    npm config set unsafe-perm true
 
 WORKDIR /app
 


### PR DESCRIPTION
It’s generally good practice to combine multiple `RUN` commands that form a single logical operation into a single `RUN` command with multiple shell statements therein. This avoids creating unnecessary intermediate build layers, thus making build caching more efficient.

Specifically we combine:

* Steps to add Google’s apt signing key, add Google’s apt repository, update all dependencies, and install Chrome
* Steps to configure Bower and NPM respectively to run as root