### PR TITLE
Set the Secure flag on Popcode's session token cookie

### DIFF
--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -262,7 +262,8 @@ export function setSessionUid() {
     Cookies.set(
       VALID_SESSION_UID_COOKIE,
       uid,
-      {expires: new Date(Date.now() + SESSION_TTL_MS)},
+      {expires: new Date(Date.now() + SESSION_TTL_MS),
+       secure: true},
     );
   }
 }


### PR DESCRIPTION
Sets the [Secure flag](https://www.owasp.org/index.php/SecureFlag) to `true` on the Popcode's session token cookie.

It would be nice to also set the [HttpOnly flag](https://www.owasp.org/index.php/HttpOnly), but this is not supported: https://github.com/js-cookie/js-cookie/issues/344.

NOTE: This should not be considered an important security issue, just a minor nit that's probably worth merging eventually :-)