### PR TITLE
Set padding for inline code in headers

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -317,6 +317,11 @@ body {
   & h5,
   & h6 {
     line-height: 1.2em;
+
+    /* postcss-bem-linter: ignore */
+    & code.hljs {
+      padding: 0 0.2em;
+    }
   }
 
   /* postcss-bem-linter: ignore */


### PR DESCRIPTION
Set padding for inline code in headers without affecting the padding of code blocks. This passes testing (although it's necessary to specify `postcss-bem-linter: ignore` on line 321 in order to do so).

<img width="399" alt="screen shot 2018-11-06 at 12 40 05 am" src="https://user-images.githubusercontent.com/6953434/48045020-9520dd80-e15c-11e8-91cf-6c23df6f0e5c.png">

Addresses [#1346](https://github.com/popcodeorg/popcode/issues/1346)