### PR TITLE
Explicitly load credentials from Firebase

### DIFF
--- a/src/channels/index.js
+++ b/src/channels/index.js
@@ -1,3 +1,1 @@
-import loginState from './loginState';
-
-export {loginState};
+export {default as makeLoginState} from './makeLoginState';

--- a/src/channels/loginState.js
+++ b/src/channels/loginState.js
@@ -1,9 +1,0 @@
-import {eventChannel} from 'redux-saga';
-
-import {onAuthStateChanged} from '../clients/firebase';
-
-export default eventChannel(
-  emit => onAuthStateChanged(
-    ({user, credentials}) => emit({user, credentials}),
-  ),
-);

--- a/src/channels/makeLoginState.js
+++ b/src/channels/makeLoginState.js
@@ -1,0 +1,11 @@
+import {eventChannel} from 'redux-saga';
+
+import {onAuthStateChanged} from '../clients/firebase';
+
+export default function makeLoginState() {
+  return eventChannel(
+    emitter => onAuthStateChanged(({user}) => {
+      emitter({user});
+    }),
+  );
+}

--- a/src/createApplicationStore.js
+++ b/src/createApplicationStore.js
@@ -19,6 +19,10 @@ const compose = get(
 export default function createApplicationStore() {
   const sagaMiddleware = createSagaMiddleware({
     onError(error) {
+      if (get(console, 'error')) {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
       bugsnagClient.notify(error);
     },
   });

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,4 +1,6 @@
 import {all} from 'redux-saga/effects';
+
+import manageUserState from './manageUserState';
 import watchErrors from './errors';
 import watchProjects from './projects';
 import watchUi from './ui';
@@ -8,6 +10,7 @@ import watchCompiledProjects from './compiledProjects';
 
 export default function* rootSaga() {
   yield all([
+    manageUserState(),
     watchErrors(),
     watchProjects(),
     watchUi(),

--- a/src/sagas/manageUserState.js
+++ b/src/sagas/manageUserState.js
@@ -1,0 +1,134 @@
+import {all, call, fork, put, race, take} from 'redux-saga/effects';
+import isEmpty from 'lodash-es/isEmpty';
+import isError from 'lodash-es/isError';
+import isNil from 'lodash-es/isNil';
+import isString from 'lodash-es/isString';
+import reject from 'lodash-es/reject';
+
+import {bugsnagClient} from '../util/bugsnag';
+import {
+  getSessionUid,
+  loadCredentialsForUser,
+  saveUserCredential,
+  signIn,
+  signOut,
+  startSessionHeartbeat,
+} from '../clients/firebase';
+import {makeLoginState} from '../channels';
+import {notificationTriggered} from '../actions/ui';
+import {userAuthenticated, userLoggedOut} from '../actions/user';
+
+export function* handleInitialAuth(user) {
+  if (isNil(user)) {
+    yield put(userLoggedOut());
+    return;
+  }
+
+  const sessionUid = yield call(getSessionUid);
+  if (user.uid !== sessionUid) {
+    yield call(signOut);
+    return;
+  }
+
+  const credentials = yield call(loadCredentialsForUser, user.uid);
+
+  if (isEmpty(credentials)) {
+    yield call(signOut);
+    return;
+  }
+
+  yield put(userAuthenticated(user, credentials));
+}
+
+export function* handleAuthChange(user, {newCredential} = {}) {
+  if (isNil(user)) {
+    yield put(userLoggedOut());
+  } else {
+    if (!isNil(newCredential)) {
+      yield fork(saveUserCredential, {user, credential: newCredential});
+    }
+    let credentials;
+
+    const storedCredentials = yield call(loadCredentialsForUser, user.uid);
+    if (isNil(newCredential)) {
+      credentials = storedCredentials;
+    } else {
+      credentials = reject(
+        storedCredentials,
+        {providerId: newCredential.providerId},
+      );
+      credentials.push(newCredential);
+    }
+
+    yield put(userAuthenticated(user, credentials));
+  }
+}
+export function* handleAuthError(e) {
+  if ('message' in e && e.message === 'popup_closed_by_user') {
+    yield put(notificationTriggered('user-cancelled-auth'));
+    return;
+  }
+
+  switch (e.code) {
+    case 'auth/popup-closed-by-user':
+      yield put(notificationTriggered('user-cancelled-auth'));
+      break;
+
+    case 'auth/network-request-failed':
+      yield put(notificationTriggered('auth-network-error'));
+      break;
+
+    case 'auth/cancelled-popup-request':
+      break;
+
+    case 'auth/web-storage-unsupported':
+    case 'auth/operation-not-supported-in-this-environment':
+      yield put(
+        notificationTriggered('auth-third-party-cookies-disabled'),
+      );
+      break;
+
+    case 'access_denied':
+    case 'auth/internal-error':
+      yield put(notificationTriggered('auth-error'));
+      break;
+
+    default:
+      yield put(notificationTriggered('auth-error'));
+
+      if (isError(e)) {
+        yield call([bugsnagClient, 'notify'], e, {metaData: {code: e.code}});
+      } else if (isString(e)) {
+        yield call([bugsnagClient, 'notify'], new Error(e));
+      }
+      break;
+  }
+}
+
+export default function* manageUserState(loginState = makeLoginState()) {
+  yield fork(startSessionHeartbeat);
+
+  const {user: initialUser} = yield take(loginState);
+  yield call(handleInitialAuth, initialUser);
+
+  while (true) {
+    const {loginStateChange, logInAction} = yield race({
+      logInAction: take('LOG_IN'),
+      loginStateChange: take(loginState),
+    });
+
+    if (isNil(logInAction)) {
+      yield call(handleAuthChange, loginStateChange.user);
+    } else {
+      try {
+        const [{user, credential}] = yield all([
+          call(signIn, logInAction.payload.provider),
+          take(loginState),
+        ]);
+        yield call(handleAuthChange, user, {newCredential: credential});
+      } catch (e) {
+        yield handleAuthError(e);
+      }
+    }
+  }
+}

--- a/src/sagas/user.js
+++ b/src/sagas/user.js
@@ -1,7 +1,4 @@
 import {bugsnagClient} from '../util/bugsnag';
-import isEmpty from 'lodash-es/isEmpty';
-import isError from 'lodash-es/isError';
-import isString from 'lodash-es/isString';
 import {
   all,
   call,
@@ -12,113 +9,27 @@ import {
   takeEvery,
 } from 'redux-saga/effects';
 import {delay} from 'redux-saga';
-import isNil from 'lodash-es/isNil';
-import {notificationTriggered} from '../actions/ui';
 import {
   accountMigrationComplete,
   accountMigrationNeeded,
   accountMigrationUndoPeriodExpired,
   identityLinked,
   linkIdentityFailed,
-  userAuthenticated,
-  userLoggedOut,
   accountMigrationError,
 } from '../actions/user';
 import {getCurrentAccountMigration} from '../selectors';
-import loginState from '../channels/loginState';
 import {
-  getSessionUid,
   linkGithub,
   migrateAccount,
-  signIn,
   signOut,
-  startSessionHeartbeat,
+  saveCredentialForCurrentUser,
 } from '../clients/firebase';
 import {getProfileForAuthenticatedUser} from '../clients/github';
-
-export function* applicationLoaded() {
-  yield call(startSessionHeartbeat);
-  yield* handleInitialAuth();
-  yield* handleAuthChange();
-}
-
-function* handleInitialAuth() {
-  const {user: authUser, credentials} = yield take(loginState);
-
-  if (isNil(authUser)) {
-    yield put(userLoggedOut());
-  } else {
-    if (isEmpty(credentials)) {
-      yield call(signOut);
-      return;
-    }
-
-    const sessionUid = yield call(getSessionUid);
-    if (authUser.uid !== sessionUid) {
-      yield call(signOut);
-      return;
-    }
-
-    yield put(userAuthenticated(authUser, credentials));
-  }
-}
-
-function* handleAuthChange() {
-  while (true) {
-    const {user: authUser, credentials} = yield take(loginState);
-    if (isNil(authUser)) {
-      yield put(userLoggedOut());
-    } else {
-      yield put(userAuthenticated(authUser, credentials));
-    }
-  }
-}
-
-export function* logIn({payload: {provider}}) {
-  try {
-    yield call(signIn, provider);
-  } catch (e) {
-    switch (e.code) {
-      case 'popup-closed-by-user':
-      case 'auth/popup-closed-by-user':
-        yield put(notificationTriggered('user-cancelled-auth'));
-        break;
-
-      case 'auth/network-request-failed':
-        yield put(notificationTriggered('auth-network-error'));
-        break;
-
-      case 'auth/cancelled-popup-request':
-        break;
-
-      case 'auth/web-storage-unsupported':
-      case 'auth/operation-not-supported-in-this-environment':
-        yield put(
-          notificationTriggered('auth-third-party-cookies-disabled'),
-        );
-        break;
-
-      case 'access_denied':
-      case 'auth/internal-error':
-        yield put(notificationTriggered('auth-error'));
-        break;
-
-      default:
-        yield put(notificationTriggered('auth-error'));
-
-        if (isError(e)) {
-          yield call([bugsnagClient, 'notify'], e, {metaData: {code: e.code}});
-        } else if (isString(e)) {
-          yield call([bugsnagClient, 'notify'], new Error(e));
-        }
-        break;
-    }
-  }
-}
 
 export function* linkGithubIdentity() {
   try {
     const credential = yield call(linkGithub);
+    yield call(saveCredentialForCurrentUser, credential);
     yield put(identityLinked(credential));
   } catch (e) {
     switch (e.code) {
@@ -165,9 +76,7 @@ export function* logOut() {
 
 export default function* user() {
   yield all([
-    takeEvery('APPLICATION_LOADED', applicationLoaded),
     takeEvery('LINK_GITHUB_IDENTITY', linkGithubIdentity),
-    takeEvery('LOG_IN', logIn),
     takeEvery('LOG_OUT', logOut),
     takeEvery('START_ACCOUNT_MIGRATION', startAccountMigration),
   ]);

--- a/test/helpers/Scenario.js
+++ b/test/helpers/Scenario.js
@@ -7,7 +7,7 @@ import {
 } from '../../src/actions/user';
 import Analyzer from '../../src/analyzers';
 
-import {userWithCredentials} from './factory';
+import {userCredential} from './factory';
 
 export default class Scenario {
   constructor() {
@@ -16,8 +16,8 @@ export default class Scenario {
   }
 
   logIn() {
-    const {user, credentials} = userWithCredentials();
-    this._reduce(userAuthenticated(user, credentials));
+    const {user, credential} = userCredential();
+    this._reduce(userAuthenticated(user, [credential]));
     return this;
   }
 

--- a/test/helpers/factory.js
+++ b/test/helpers/factory.js
@@ -29,13 +29,13 @@ export function gistData({
   return {files};
 }
 
-export function userWithCredentials({
+export function userCredential({
   user: userIn,
   credential: credentialIn,
 } = {}) {
   return {
     user: user(userIn),
-    credentials: [credential(credentialIn)],
+    credential: credential(credentialIn),
   };
 }
 

--- a/test/unit/reducers/user.js
+++ b/test/unit/reducers/user.js
@@ -5,7 +5,7 @@ import {Map} from 'immutable';
 
 import reducerTest from '../../helpers/reducerTest';
 import {user as states} from '../../helpers/referenceStates';
-import {userWithCredentials} from '../../helpers/factory';
+import {userCredential} from '../../helpers/factory';
 import reducer from '../../../src/reducers/user';
 import {
   accountMigrationComplete,
@@ -21,7 +21,7 @@ import {
 import {AccountMigrationState, LoginState} from '../../../src/enums';
 import {AccountMigration, User, UserAccount} from '../../../src/records';
 
-const userWithCredentialsIn = userWithCredentials();
+const userCredentialIn = userCredential();
 
 const loggedOutState = new User({
   loginState: LoginState.ANONYMOUS,
@@ -30,11 +30,11 @@ const loggedOutState = new User({
 const loggedInState = new User({
   loginState: LoginState.AUTHENTICATED,
   account: new UserAccount({
-    id: userWithCredentialsIn.user.uid,
-    displayName: userWithCredentialsIn.user.displayName,
-    avatarUrl: userWithCredentialsIn.user.photoURL,
+    id: userCredentialIn.user.uid,
+    displayName: userCredentialIn.user.displayName,
+    avatarUrl: userCredentialIn.user.photoURL,
     accessTokens: new Map({
-      'github.com': userWithCredentialsIn.credentials[0].accessToken,
+      'github.com': userCredentialIn.credential.accessToken,
     }),
   }),
 });
@@ -44,8 +44,8 @@ test('userAuthenticated', reducerTest(
   states.initial,
   partial(
     userAuthenticated,
-    userWithCredentialsIn.user,
-    userWithCredentialsIn.credentials,
+    userCredentialIn.user,
+    [userCredentialIn.credential],
   ),
   loggedInState,
 ));

--- a/test/unit/sagas/manageUserState.js
+++ b/test/unit/sagas/manageUserState.js
@@ -1,0 +1,298 @@
+import test from 'tape';
+import {testSaga} from 'redux-saga-test-plan';
+import {call, take} from 'redux-saga/effects';
+import {channel} from 'redux-saga';
+
+import {bugsnagClient} from '../../../src/util/bugsnag';
+
+import {
+  credential as createCredential,
+  user as createUser,
+  userCredential as createUserCredential,
+} from '../../helpers/factory';
+
+import manageUserState, {
+  handleInitialAuth,
+  handleAuthChange,
+  handleAuthError,
+} from '../../../src/sagas/manageUserState';
+
+import {
+  getSessionUid,
+  loadCredentialsForUser,
+  signIn,
+  signOut,
+  startSessionHeartbeat,
+  saveUserCredential,
+} from '../../../src/clients/firebase';
+
+import {
+  logIn,
+  userAuthenticated,
+  userLoggedOut,
+} from '../../../src/actions/user';
+
+import {notificationTriggered} from '../../../src/actions/ui';
+
+const provider = 'google.com';
+
+class MockFirebaseError extends Error {
+  constructor(code) {
+    super(code);
+    this.code = code;
+  }
+}
+
+const loginState = channel();
+
+test('manageUserState', (t) => {
+  function testSagaInitialAuth() {
+    const user = createUser();
+
+    return testSaga(manageUserState, loginState).
+      next().fork(startSessionHeartbeat).
+      next().take(loginState).
+      next({user}).call(handleInitialAuth, user).
+      next().race({
+        logInAction: take('LOG_IN'),
+        loginStateChange: take(loginState),
+      });
+  }
+
+  t.test('successful explicit login', (assert) => {
+    const logInUserCredential = createUserCredential();
+    assert.doesNotThrow(() => {
+      testSagaInitialAuth().
+        next({logInAction: logIn(provider)}).all([
+          call(signIn, provider),
+          take(loginState),
+        ]).
+        next([logInUserCredential]).call(
+          handleAuthChange,
+          logInUserCredential.user,
+          {newCredential: logInUserCredential.credential},
+        );
+    });
+
+    assert.end();
+  });
+
+  t.test('failed explicit login', (assert) => {
+    const logInUserCredential = createUserCredential();
+    assert.doesNotThrow(() => {
+      testSagaInitialAuth().
+        next({logInAction: logIn(provider)}).all([
+          call(signIn, provider),
+          take(loginState),
+        ]).
+        next([logInUserCredential]).call(
+          handleAuthChange,
+          logInUserCredential.user,
+          {newCredential: logInUserCredential.credential},
+        );
+    });
+
+    assert.end();
+  });
+
+  t.test('implicit login', (assert) => {
+    const user = createUser();
+    assert.doesNotThrow(() => {
+      testSagaInitialAuth().
+        next({loginStateChange: {user}}).
+        call(handleAuthChange, user);
+    });
+
+    assert.end();
+  });
+
+  t.test('implicit logout', (assert) => {
+    assert.doesNotThrow(() => {
+      testSagaInitialAuth().
+        next({loginStateChange: {user: null}}).
+        call(handleAuthChange, null);
+    });
+
+    assert.end();
+  });
+
+  t.end();
+});
+
+test('handleInitialAuth', (t) => {
+  t.test('with no logged in user', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(handleInitialAuth, null).
+        next({user: null}).put(userLoggedOut());
+    });
+
+    assert.end();
+  });
+
+  t.test('with logged in user', (assert) => {
+    const {user, credential} = createUserCredential();
+    assert.doesNotThrow(() => {
+      testSaga(handleInitialAuth, user).
+        next().call(getSessionUid).
+        next(user.uid).call(loadCredentialsForUser, user.uid).
+        next([credential]).put(userAuthenticated(user, [credential]));
+    });
+
+    assert.end();
+  });
+
+  t.test('with expired session', (assert) => {
+    const user = createUser();
+    assert.doesNotThrow(() => {
+      testSaga(handleInitialAuth, user).
+        next().call(getSessionUid).
+        next(undefined).call(signOut);
+    });
+
+    assert.end();
+  });
+});
+
+test('handleAuthError', (t) => {
+  t.test('popup closed by user', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(
+        handleAuthError,
+        new MockFirebaseError('auth/popup-closed-by-user'),
+      ).
+        next().put(notificationTriggered('user-cancelled-auth')).
+        next().isDone();
+    });
+
+    assert.end();
+  });
+
+  t.test('network request failed', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(
+        handleAuthError,
+        new MockFirebaseError('auth/network-request-failed'),
+      ).
+        next().put(notificationTriggered('auth-network-error')).
+        next().isDone();
+    });
+
+    assert.end();
+  });
+
+  t.test('cancelled popup request', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(
+        handleAuthError,
+        new MockFirebaseError('auth/cancelled-popup-request'),
+      ).
+        next().isDone();
+
+      assert.end();
+    });
+  });
+
+  t.test('web storage unsupported', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(
+        handleAuthError,
+        new MockFirebaseError('auth/web-storage-unsupported'),
+      ).
+        next().put(notificationTriggered('auth-third-party-cookies-disabled')).
+        next().isDone();
+    });
+
+    assert.end();
+  });
+
+  t.test('operation not supported in this environment', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(
+        handleAuthError,
+        new MockFirebaseError(
+          'auth/operation-not-supported-in-this-environment',
+        ),
+      ).
+        next().put(notificationTriggered('auth-third-party-cookies-disabled')).
+        next().isDone();
+    });
+
+    assert.end();
+  });
+
+  t.test('internal error', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(
+        handleAuthError,
+        new MockFirebaseError('auth/internal-error'),
+      ).
+        next().put(notificationTriggered('auth-error')).
+        next().isDone();
+    });
+
+    assert.end();
+  });
+
+  t.test('unrecognized error', (assert) => {
+    const e = new MockFirebaseError('auth/bogus-error');
+    assert.doesNotThrow(() => {
+      testSaga(handleAuthError, e).
+        next().put(notificationTriggered('auth-error')).
+        next().call(
+          [bugsnagClient, 'notify'],
+          e,
+          {metaData: {code: 'auth/bogus-error'}},
+        ).
+        next().isDone();
+    });
+
+    assert.end();
+  });
+});
+
+test('handleAuthChange', (t) => {
+  const user = createUser();
+  const credentials = [
+    createCredential({providerId: 'google.com'}),
+    createCredential({providerId: 'github.com'}),
+  ];
+
+  t.test('with no new credential', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(handleAuthChange, user).
+        next().call(loadCredentialsForUser, user.uid).
+        next(credentials).put(userAuthenticated(user, credentials));
+    });
+    assert.end();
+  });
+
+  t.test('with new credential', (assert) => {
+    const newCredential = createCredential({
+      providerId: 'google.com',
+      accessToken: 'hhh',
+    });
+
+    assert.doesNotThrow(() => {
+      testSaga(handleAuthChange, user, {newCredential}).
+        next().fork(saveUserCredential, {user, credential: newCredential}).
+        next().call(loadCredentialsForUser, user.uid).
+        next(credentials).inspect(({PUT: {action}}) => {
+          assert.deepEqual(
+            action,
+            userAuthenticated(user, [credentials[1], newCredential]),
+          );
+        });
+    });
+    assert.end();
+  });
+
+  t.test('log out', (assert) => {
+    assert.doesNotThrow(() => {
+      testSaga(handleAuthChange, null).
+        next().put(userLoggedOut());
+    });
+    assert.end();
+  });
+
+  t.end();
+});

--- a/test/unit/sagas/projects.js
+++ b/test/unit/sagas/projects.js
@@ -38,7 +38,7 @@ import Scenario from '../../helpers/Scenario';
 import {
   gistData,
   project,
-  userWithCredentials,
+  userCredential,
 } from '../../helpers/factory';
 import {
   getCurrentUserId,
@@ -226,7 +226,11 @@ test('importGist()', (t) => {
 test('userAuthenticated', (assert) => {
   const scenario = new Scenario().logIn();
   const projects = [project()];
-  testSaga(userAuthenticatedSaga, userAuthenticated(userWithCredentials())).
+  const {user, credential} = userCredential();
+  testSaga(
+    userAuthenticatedSaga,
+    userAuthenticated({user, credentials: [credential]}),
+  ).
     next().inspect(effect => assert.ok(effect.SELECT)).
     next(scenario.state).fork(saveCurrentProject).
     next(scenario.state).call(loadAllProjects, scenario.user.account.id).

--- a/test/unit/sagas/user.js
+++ b/test/unit/sagas/user.js
@@ -3,12 +3,7 @@ import {testSaga} from 'redux-saga-test-plan';
 import {delay} from 'redux-saga';
 import {call, take, race} from 'redux-saga/effects';
 
-import {
-  applicationLoaded,
-  linkGithubIdentity,
-  notificationTriggered,
-  userLoggedOut,
-} from '../../../src/actions';
+import {linkGithubIdentity} from '../../../src/actions';
 import {
   accountMigrationComplete,
   accountMigrationError,
@@ -16,163 +11,26 @@ import {
   accountMigrationUndoPeriodExpired,
   identityLinked,
   linkIdentityFailed,
-  logIn,
   logOut,
   startAccountMigration,
-  userAuthenticated,
 } from '../../../src/actions/user';
 import {getCurrentAccountMigration} from '../../../src/selectors';
 import {
   AccountMigration,
 } from '../../../src/records';
 import {
-  getSessionUid,
   linkGithub,
   migrateAccount,
-  signIn,
   signOut,
-  startSessionHeartbeat,
+  saveCredentialForCurrentUser,
 } from '../../../src/clients/firebase';
 import {getProfileForAuthenticatedUser} from '../../../src/clients/github';
 import {
-  applicationLoaded as applicationLoadedSaga,
-  logIn as logInSaga,
   logOut as logOutSaga,
   linkGithubIdentity as linkGithubIdentitySaga,
   startAccountMigration as startAccountMigrationSaga,
 } from '../../../src/sagas/user';
-import {loginState} from '../../../src/channels';
-import {
-  userWithCredentials as createUserWithCredentials,
-} from '../../helpers/factory';
 import {bugsnagClient} from '../../../src/util/bugsnag';
-
-class MockFirebaseError extends Error {
-  constructor(code) {
-    super(code);
-    this.code = code;
-  }
-}
-
-test('applicationLoaded', (t) => {
-  t.test('with no logged in user', (assert) => {
-    testSaga(applicationLoadedSaga, applicationLoaded()).
-      next().call(startSessionHeartbeat).
-      next().take(loginState).
-      next({user: null}).put(userLoggedOut());
-
-    assert.end();
-  });
-
-  t.test('with logged in user', (assert) => {
-    const {user, credentials} = createUserWithCredentials();
-    testSaga(applicationLoadedSaga, applicationLoaded()).
-      next().call(startSessionHeartbeat).
-      next().take(loginState).
-      next({user, credentials}).call(getSessionUid).
-      next(user.uid).put(userAuthenticated(user, credentials));
-
-    assert.end();
-  });
-
-  t.test('with expired session', (assert) => {
-    const {user, credentials} = createUserWithCredentials();
-    testSaga(applicationLoadedSaga, applicationLoaded()).
-      next().call(startSessionHeartbeat).
-      next().take(loginState).
-      next({user, credentials}).call(getSessionUid).
-      next(undefined).call(signOut);
-
-    assert.end();
-  });
-});
-
-const provider = 'google';
-
-test('logIn', (t) => {
-  t.test('success', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('popup closed by user', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(new MockFirebaseError('auth/popup-closed-by-user')).
-      put(notificationTriggered('user-cancelled-auth')).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('network request failed', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(new MockFirebaseError('auth/network-request-failed')).
-      put(notificationTriggered('auth-network-error')).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('cancelled popup request', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(new MockFirebaseError('auth/cancelled-popup-request')).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('web storage unsupported', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(new MockFirebaseError('auth/web-storage-unsupported')).
-      put(notificationTriggered('auth-third-party-cookies-disabled')).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('operation not supported in this environment', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(new MockFirebaseError(
-        'auth/operation-not-supported-in-this-environment',
-      )).put(notificationTriggered('auth-third-party-cookies-disabled')).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('internal error', (assert) => {
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(new MockFirebaseError('auth/internal-error')).
-      put(notificationTriggered('auth-error')).
-      next().isDone();
-
-    assert.end();
-  });
-
-  t.test('unrecognized error', (assert) => {
-    const e = new MockFirebaseError('auth/bogus-error');
-    testSaga(logInSaga, logIn(provider)).
-      next().call(signIn, provider).
-      throw(e).put(notificationTriggered('auth-error')).
-      next().call(
-        [bugsnagClient, 'notify'],
-        e,
-        {metaData: {code: 'auth/bogus-error'}},
-      ).
-      next().isDone();
-
-    assert.end();
-  });
-});
 
 test('linkGithubIdentity', (t) => {
   t.test('success', (assert) => {
@@ -180,7 +38,8 @@ test('linkGithubIdentity', (t) => {
 
     testSaga(linkGithubIdentitySaga, linkGithubIdentity()).
       next().call(linkGithub).
-      next(credential).put(identityLinked(credential));
+      next(credential).call(saveCredentialForCurrentUser, credential).
+      next().put(identityLinked(credential));
 
     assert.end();
   });


### PR DESCRIPTION
When Popcode first integrated Firebase, the Firebase client stored provider credentials and exposed them in the `onAuthStateChange` callback. However, that changed a long time ago, obliging us to store provider credentials in the Firebase database.

At the time, I decided to keep the interface of the Firebase client the same, keeping the storage and retrieval of credentials abstracted from the caller (in this case, the saga). Ultimately, this was a path-dependent outcome, and there’s no reason the saga shouldn’t just handle that task itself.

With an eye toward both becoming more robust to mismatches between stored credential information and actual linked accounts; and to loading and storing more information about the user’s provider accounts (specifically the provider profiles), move handling of credential persistence into the saga.

While in general we’re able to handle this reasonably elegantly in the saga, there is one wrinkle, which is that the channel for auth state changes fires regardless of whether the auth state change is due to an explicit user action or an implicit change (e.g. the user logged in/out in a different tab). Oddly, the Firebase client fires the auth state change handler _before_ resolving the promise returned by the call to log in.

So, when the user logs in explicitly, we now wait for the promise to resolve (which gives us a credential we want to store and use), and in parallel we pull the next auth state change off the channel, simply discarding it, since it’s redundant with the login promise but contains less information.