### PR TITLE
Fix initial login errors

### DIFF
--- a/src/channels/makeLoginState.js
+++ b/src/channels/makeLoginState.js
@@ -1,11 +1,10 @@
-import {eventChannel} from 'redux-saga';
+import {buffers, eventChannel} from 'redux-saga';
 
 import {onAuthStateChanged} from '../clients/firebase';
 
 export default function makeLoginState() {
   return eventChannel(
-    emitter => onAuthStateChanged(({user}) => {
-      emitter({user});
-    }),
+    emitter => onAuthStateChanged(emitter),
+    buffers.expanding(),
   );
 }

--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -13,7 +13,11 @@ import '@firebase/auth';
 import {bugsnagClient} from '../util/bugsnag';
 import config from '../config';
 import retryingFailedImports from '../util/retryingFailedImports';
-import {getGapiSync, SCOPES as GOOGLE_SCOPES} from '../services/gapi';
+import {
+  getGapiSync,
+  loadAndConfigureGapi,
+  SCOPES as GOOGLE_SCOPES,
+} from '../services/gapi';
 
 const GITHUB_SCOPES = ['gist', 'public_repo', 'read:user', 'user:email'];
 const VALID_SESSION_UID_COOKIE = 'firebaseAuth.validSessionUid';
@@ -208,7 +212,7 @@ async function signInWithGoogle() {
 }
 
 export async function signOut() {
-  const gapi = getGapiSync();
+  const gapi = await loadAndConfigureGapi();
   if (await gapi.auth2.getAuthInstance().isSignedIn.get()) {
     gapi.auth2.getAuthInstance().signOut();
   }

--- a/src/services/gapi.js
+++ b/src/services/gapi.js
@@ -14,6 +14,8 @@ const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/classroom/
 
 class LoadError extends ExtendableError {}
 
+let isGapiLoadedAndConfigured = false;
+
 const loadGapi = once(async() => new Promise((resolve, reject) => {
   loadjs('https://apis.google.com/js/client.js', {
     success() {
@@ -47,14 +49,17 @@ export const loadAndConfigureGapi = once(async() => {
     scope: SCOPES.join(' '),
   });
 
+  isGapiLoadedAndConfigured = true;
+
   return gapi;
 });
 
 export function getGapiSync() {
-  if ('gapi' in window) {
-    return window.gapi;
+  if (!isGapiLoadedAndConfigured) {
+    throw new Error(
+      'Attempted to synchronously access `gapi` before it was loaded',
+    );
   }
-  throw new Error(
-    'Attempted to synchronously access `gapi` before it was loaded',
-  );
+
+  return window.gapi;
 }


### PR DESCRIPTION
Two fixes, not directly related but both in the same code path.

First, in the case where we need to instruct `gapi` to open a popup, we have to do so in the context of a synchronous user action handler. So, we can’t use the usual approach of awaiting the promise of loading and configuring `gapi` and then calling the popup on the resolved value. For that case, we expose `getGapiSync()`, which returns `gapi` if it’s loaded and throws an error if it isn’t. The idea is that callers to `getGapiSync()` are responsible for ensuring that `gapi` is definitely loaded before calling the method.

However, `signOut()` can be called very early in the application lifecycle, specifically if there is a Firebase session that no longer has a corresponding short-lived session cookie. Further, we don’t need to invoke `gapi` synchronously, because signing out does not involve displaying a popup. This was causing an error where in some cases we were calling `signOut()`, which was calling methods on a not-fully-loaded `gapi` instance.

So, fix that issue by switching to the standard `loadAndConfigureGapi()`, and also change the logic of `loadGapiSync` to fail fast unless `gapi` is not only loaded but fully configured.

Second, `eventChannel`s are not buffered at all by default; however, we want to buffer all changes to login state. In particular, the handler for the first message on the channel (i.e. the initial login state) may itself change the login state (by signing out in the case that the user logged in via Firebase no longer has a valid short-lived session cookie). This caused a bug where the call to sign out from Firebase occurred before the next call to `take` the login state from the channel, leaving the user in an indeterminate authentication state. So, add a buffer to the channel.

Fixes #1612 
Fixes #1613