### PR TITLE
Store linked identity information in objects

### DIFF
--- a/src/records/UserAccount.js
+++ b/src/records/UserAccount.js
@@ -4,5 +4,5 @@ export default Record({
   id: null,
   displayName: null,
   avatarUrl: null,
-  accessTokens: new Map(),
+  identityProviders: new Map(),
 }, 'UserAccount');

--- a/src/records/UserIdentityProvider.js
+++ b/src/records/UserIdentityProvider.js
@@ -1,0 +1,5 @@
+import {Record} from 'immutable';
+
+export default Record({
+  accessToken: null,
+}, 'UserIdentityProvider');

--- a/src/records/index.js
+++ b/src/records/index.js
@@ -1,31 +1,15 @@
-import AccountMigration from './AccountMigration';
-import CompiledProject from './CompiledProject';
-import ConsoleEntry from './ConsoleEntry';
-import ConsoleError from './ConsoleError';
-import ConsoleState from './ConsoleState';
-import EditorLocation from './EditorLocation';
-import Error from './Error';
-import ErrorList from './ErrorList';
-import ErrorReport from './ErrorReport';
-import Notification from './Notification';
-import Project from './Project';
-import UiState from './UiState';
-import User from './User';
-import UserAccount from './UserAccount';
-
-export {
-  AccountMigration,
-  CompiledProject,
-  ConsoleEntry,
-  ConsoleError,
-  ConsoleState,
-  EditorLocation,
-  Error,
-  ErrorList,
-  ErrorReport,
-  Notification,
-  Project,
-  User,
-  UserAccount,
-  UiState,
-};
+export {default as AccountMigration} from './AccountMigration';
+export {default as CompiledProject} from './CompiledProject';
+export {default as ConsoleEntry} from './ConsoleEntry';
+export {default as ConsoleError} from './ConsoleError';
+export {default as ConsoleState} from './ConsoleState';
+export {default as EditorLocation} from './EditorLocation';
+export {default as Error} from './Error';
+export {default as ErrorList} from './ErrorList';
+export {default as ErrorReport} from './ErrorReport';
+export {default as Notification} from './Notification';
+export {default as Project} from './Project';
+export {default as UiState} from './UiState';
+export {default as User} from './User';
+export {default as UserAccount} from './UserAccount';
+export {default as UserIdentityProvider} from './UserIdentityProvider';

--- a/src/sagas/clients.js
+++ b/src/sagas/clients.js
@@ -34,17 +34,19 @@ export function* createSnapshot() {
 export function* exportProject({payload: {exportType}}) {
   const state = yield select();
   const project = getCurrentProject(state);
-  const user = state.get('user').toJS();
+  const user = state.get('user');
   let exportData = {};
   let url, name;
 
   try {
-    const accessToken = user.account.accessTokens['github.com'];
-
     if (exportType === 'gist') {
+      const {accessToken} = user.account.identityProviders.get('github.com');
+
       ({html_url: url} =
         yield call(createGistFromProject, project, accessToken));
     } else if (exportType === 'repo') {
+      const {accessToken} = user.account.identityProviders.get('github.com');
+
       ({url, name} =
         yield call(createOrUpdateRepoFromProject, project, accessToken));
       if (name) {

--- a/src/sagas/manageUserState.js
+++ b/src/sagas/manageUserState.js
@@ -43,25 +43,26 @@ export function* handleInitialAuth(user) {
 export function* handleAuthChange(user, {newCredential} = {}) {
   if (isNil(user)) {
     yield put(userLoggedOut());
-  } else {
-    if (!isNil(newCredential)) {
-      yield fork(saveUserCredential, {user, credential: newCredential});
-    }
-    let credentials;
-
-    const storedCredentials = yield call(loadCredentialsForUser, user.uid);
-    if (isNil(newCredential)) {
-      credentials = storedCredentials;
-    } else {
-      credentials = reject(
-        storedCredentials,
-        {providerId: newCredential.providerId},
-      );
-      credentials.push(newCredential);
-    }
-
-    yield put(userAuthenticated(user, credentials));
+    return;
   }
+
+  if (!isNil(newCredential)) {
+    yield fork(saveUserCredential, {user, credential: newCredential});
+  }
+  let credentials;
+
+  const storedCredentials = yield call(loadCredentialsForUser, user.uid);
+  if (isNil(newCredential)) {
+    credentials = storedCredentials;
+  } else {
+    credentials = reject(
+      storedCredentials,
+      {providerId: newCredential.providerId},
+    );
+    credentials.push(newCredential);
+  }
+
+  yield put(userAuthenticated(user, credentials));
 }
 export function* handleAuthError(e) {
   if ('message' in e && e.message === 'popup_closed_by_user') {

--- a/src/selectors/makeIsUserAuthenticatedWith.js
+++ b/src/selectors/makeIsUserAuthenticatedWith.js
@@ -3,6 +3,12 @@ import isUserAuthenticated from './isUserAuthenticated';
 export default function makeIsUserAuthenticatedWith(provider) {
   return function isUserAuthenticatedWithProvider(state) {
     return isUserAuthenticated(state) &&
-      Boolean(state.getIn(['user', 'account', 'accessTokens', provider]));
+      Boolean(state.getIn([
+        'user',
+        'account',
+        'identityProviders',
+        provider,
+        'accessToken',
+      ]));
   };
 }

--- a/test/helpers/Scenario.js
+++ b/test/helpers/Scenario.js
@@ -3,11 +3,12 @@ import {
   projectCreated,
 } from '../../src/actions/projects';
 import {
+  identityLinked,
   userAuthenticated,
 } from '../../src/actions/user';
 import Analyzer from '../../src/analyzers';
 
-import {userCredential} from './factory';
+import {githubCredential, userCredential} from './factory';
 
 export default class Scenario {
   constructor() {
@@ -19,6 +20,12 @@ export default class Scenario {
     const {user, credential} = userCredential();
     this._reduce(userAuthenticated(user, [credential]));
     return this;
+  }
+
+  authGitHub() {
+    const credential = githubCredential();
+    this._reduce(identityLinked(credential));
+    return credential;
   }
 
   get project() {

--- a/test/helpers/factory.js
+++ b/test/helpers/factory.js
@@ -1,6 +1,5 @@
 import defaultsDeep from 'lodash-es/defaultsDeep';
 import isNil from 'lodash-es/isNil';
-import merge from 'lodash-es/merge';
 
 export function gistData({
   html, css, javascript, enabledLibraries, hiddenUIComponents,
@@ -44,7 +43,23 @@ export function user(userIn) {
     displayName: 'Popcode User',
     photoURL: 'https://camo.github.com/popcodeuser.jpg',
     uid: 'abc123',
+    providerData: [{providerId: 'google.com'}],
   });
+}
+
+export function credential(credentialIn = {}) {
+  if (credentialIn.providerId === 'github.com') {
+    return githubCredential(credentialIn.accessToken);
+  }
+  return googleCredential(credentialIn.idToken);
+}
+
+export function googleCredential(idToken = '0123456789abcdef') {
+  return {providerId: 'google.com', idToken};
+}
+
+export function githubCredential(accessToken) {
+  return {providerId: 'github.com', accessToken};
 }
 
 export function project(projectIn) {
@@ -59,11 +74,4 @@ export function project(projectIn) {
     hiddenUIComponents: ['console'],
     updatedAt: Date.now(),
   });
-}
-
-export function credential(credentialIn) {
-  return merge({
-    accessToken: '0123456789abcdef',
-    providerId: 'github.com',
-  }, credentialIn);
 }

--- a/test/unit/sagas/clients.js
+++ b/test/unit/sagas/clients.js
@@ -54,6 +54,7 @@ test('export gist', (t) => {
   const exportType = 'gist';
   const scenario = new Scenario();
   scenario.logIn();
+  scenario.authGitHub();
 
   function initiateExport(assert) {
     return testSaga(exportProjectSaga, {payload: {exportType}}).
@@ -63,7 +64,11 @@ test('export gist', (t) => {
       next(scenario.state).call(
         createGistFromProject,
         scenario.project.toJS(),
-        scenario.user.account.accessTokens.get('github.com'),
+        scenario.user.account.getIn([
+          'identityProviders',
+          'github.com',
+          'accessToken',
+        ]),
       );
   }
 
@@ -98,6 +103,7 @@ test('export repo', (t) => {
   const exportType = 'repo';
   const scenario = new Scenario();
   scenario.logIn();
+  scenario.authGitHub();
 
   function initiateExport(assert) {
     return testSaga(exportProjectSaga, {payload: {exportType}}).
@@ -107,7 +113,11 @@ test('export repo', (t) => {
       next(scenario.state).call(
         createOrUpdateRepoFromProject,
         scenario.project.toJS(),
-        scenario.user.account.accessTokens.get('github.com'),
+        scenario.user.account.getIn([
+          'identityProviders',
+          'github.com',
+          'accessToken',
+        ]),
       );
   }
 
@@ -141,6 +151,7 @@ test('update repo', (t) => {
   const exportType = 'repo';
   const scenario = new Scenario();
   scenario.logIn();
+  scenario.authGitHub();
 
   function initiateExport(assert) {
     return testSaga(exportProjectSaga, {payload: {exportType}}).
@@ -150,7 +161,11 @@ test('update repo', (t) => {
       next(scenario.state).call(
         createOrUpdateRepoFromProject,
         scenario.project.toJS(),
-        scenario.user.account.accessTokens.get('github.com'),
+        scenario.user.account.getIn([
+          'identityProviders',
+          'github.com',
+          'accessToken',
+        ]),
       );
   }
 


### PR DESCRIPTION
Creates a UserIdentityProvider record, which contains information about a linked user identity (Google, GitHub, etc). Currently this just stores a single property, which is an `accessToken`. Replaces the previous approach of storing access tokens as in a map with string values. The `identityProviders` collection is still a map, with the keys as the `providerId` (`"github.com"`, `"google.com"`, etc.)

This doesn’t get us anything immediately, but is a prerequisite to two needed changes:

1. Detect situations where the user has linked an identity provider (information that’s available in their Firebase user account object when they log in), but we don’t have a stored credential for that identity (e.g. a network error prevented us from saving the GitHub credential after they linked their account). This can now be represented (though is not yet) as a `UserIdentityProvider` with a `null` credential.
2. Store additional information about the identities. In particular, we want to show the username and avatar for each service in the user drop-down, with the option to unlink the identity where appropriate (i.e. for GitHub). This would allow students to solve the common issue of accidentally linking someone else’s already-logged-in GitHub account.