### PR TITLE
Update Google Classroom API discovery docs URL

### DIFF
--- a/src/services/gapi.js
+++ b/src/services/gapi.js
@@ -10,7 +10,7 @@ export const SCOPES = [
   'https://www.googleapis.com/auth/classroom.coursework.me',
 ];
 
-const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/classroom/v1/rest'];
+const DISCOVERY_DOCS = ['https://classroom.googleapis.com/$discovery/rest?version=v1'];
 
 class LoadError extends ExtendableError {}
 


### PR DESCRIPTION
Because they changed it without warning and broke the old one.

Fixes #1628