### PR TITLE
Add minimize button to preview window

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,18 +1,24 @@
 import {
+  faChevronDown,
+  faChevronUp,
   faExternalLinkAlt,
   faSyncAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import get from 'lodash-es/get';
+import partial from 'lodash-es/partial';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import React from 'react';
+import classnames from 'classnames';
 
 import PreviewFrame from './PreviewFrame';
 
 export default function Preview({
   compiledProjects,
   consoleEntries,
+  currentProjectKey,
+  isOpen,
   showingErrors,
   onConsoleError,
   onConsoleLog,
@@ -20,6 +26,7 @@ export default function Preview({
   onPopOutProject,
   onRefreshClick,
   onRuntimeError,
+  onToggleVisible,
 }) {
   if (showingErrors) {
     return null;
@@ -40,9 +47,14 @@ export default function Preview({
 
   const mostRecentCompiledProject = compiledProjects.last();
   const title = get(mostRecentCompiledProject, 'title', '');
-
   return (
-    <div className="preview output__item">
+    <div
+      className={classnames(
+        'preview',
+        'output__item',
+        {output__item_collapsed: !isOpen},
+      )}
+    >
       <div className="preview__title-bar">
         <span className="preview__button preview__button_pop-out">
           <FontAwesomeIcon
@@ -51,6 +63,12 @@ export default function Preview({
           />
         </span>
         {title}
+        <span className="preview__button preview__button_toggle-visibility">
+          <FontAwesomeIcon
+            icon={isOpen ? faChevronDown : faChevronUp}
+            onClick={partial(onToggleVisible, currentProjectKey)}
+          />
+        </span>
         <span className="preview__button preview__button_reset">
           <FontAwesomeIcon icon={faSyncAlt} onClick={onRefreshClick} />
         </span>
@@ -63,6 +81,8 @@ export default function Preview({
 Preview.propTypes = {
   compiledProjects: ImmutablePropTypes.iterable.isRequired,
   consoleEntries: ImmutablePropTypes.iterable.isRequired,
+  currentProjectKey: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
   showingErrors: PropTypes.bool.isRequired,
   onConsoleError: PropTypes.func.isRequired,
   onConsoleLog: PropTypes.func.isRequired,
@@ -70,4 +90,5 @@ Preview.propTypes = {
   onPopOutProject: PropTypes.func.isRequired,
   onRefreshClick: PropTypes.func.isRequired,
   onRuntimeError: PropTypes.func.isRequired,
+  onToggleVisible: PropTypes.func.isRequired,
 };

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -22,6 +22,7 @@ import Instructions from '../containers/Instructions';
 import NotificationList from '../containers/NotificationList';
 import EditorsColumn from '../containers/EditorsColumn';
 import Output from '../containers/Output';
+import Preview from '../containers/Preview';
 
 import PopThrobber from './PopThrobber';
 
@@ -86,6 +87,17 @@ export default class Workspace extends React.Component {
         get(this.props, ['currentProject', 'projectKey']),
       );
     }
+  }
+
+  _isOutputHidden() {
+    if (isNull(this.props.currentProject)) {
+      return false;
+    }
+    const isOutputHidden = get(
+      this.props,
+      ['currentProject', 'hiddenUIComponents'],
+    ).includes('output');
+    return isOutputHidden;
   }
 
   _renderInstructionsBar() {
@@ -166,11 +178,19 @@ export default class Workspace extends React.Component {
             )}
           />
         </DraggableCore>
-        <Output
-          style={{flexGrow: resizableFlexGrow.get(1)}}
-          onRef={_handleOutputRef}
-        />
+        {!this._isOutputHidden() &&
+          <Output
+            style={{flexGrow: resizableFlexGrow.get(1)}}
+            onRef={_handleOutputRef}
+          />
+        }
       </div>
+    );
+  }
+
+  _maybeRenderCollapsedPreview() {
+    return (this._isOutputHidden() &&
+      <Preview />
     );
   }
 
@@ -186,6 +206,7 @@ export default class Workspace extends React.Component {
             {this._renderEnvironment()}
           </div>
         </div>
+        {this._maybeRenderCollapsedPreview()}
         <AccountMigration />
       </div>
     );

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -10,10 +10,13 @@ import {
   consoleValueProduced,
   popOutProject,
   refreshPreview,
+  toggleComponent,
 } from '../actions';
 import {
   getCompiledProjects,
   getConsoleHistory,
+  getCurrentProjectKey,
+  getHiddenUIComponents,
   isCurrentProjectSyntacticallyValid,
   isUserTyping,
 } from '../selectors';
@@ -22,6 +25,8 @@ function mapStateToProps(state) {
   return {
     compiledProjects: getCompiledProjects(state),
     consoleEntries: getConsoleHistory(state),
+    currentProjectKey: getCurrentProjectKey(state),
+    isOpen: !getHiddenUIComponents(state).includes('output'),
     showingErrors: (
       !isUserTyping(state) &&
         !isCurrentProjectSyntacticallyValid(state)
@@ -73,6 +78,10 @@ function mapDispatchToProps(dispatch) {
 
     onRuntimeError(error) {
       dispatch(addRuntimeError('javascript', error));
+    },
+
+    onToggleVisible(projectKey) {
+      dispatch(toggleComponent(projectKey, 'output'));
     },
   };
 }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -555,6 +555,11 @@ body {
   flex: 0 1 auto;
 }
 
+.output__item_collapsed {
+  flex: none;
+  height: 4.4vh; /* take up the height of the absolutely positioned child, 2.2vh + 1vh padding + 1vh padding */
+}
+
 .output__delayed-error-overlay {
   position: absolute;
   top: 0;
@@ -709,7 +714,8 @@ body {
   float: left;
 }
 
-.preview__button_reset {
+.preview__button_reset,
+.preview__button_toggle-visibility {
   float: right;
 }
 


### PR DESCRIPTION
I think the only controversial decision to note here is that I decided
that the preview frame should still be rendered, just not visible. It
seems useful to log to the console via your code without showing the
produced UI, for example.

Fixes: #1340