### PR TITLE
Display user-friendly runtime error message in console

### DIFF
--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -74,10 +74,21 @@ class PreviewFrame extends React.Component {
         );
       },
       error: (name, message) => {
+        let errorMessage;
+        if (name === 'TypeError') {
+          const ErrorConstructor = window[name] || Error;
+          const normalizedError = normalizeError(
+            new ErrorConstructor(message),
+          );
+          errorMessage = normalizedError.message;
+        }
+        if (!errorMessage) {
+          errorMessage = message;
+        }
         this.props.onConsoleError(
           key,
           name,
-          message,
+          errorMessage,
           this.props.compiledProject.compiledProjectKey,
         );
       },


### PR DESCRIPTION
Hi @outoftime, this addresses [1260](https://github.com/popcodeorg/popcode/issues/1260). I omitted any handling of infinite loop error messages in the console for now, since running an infinite loop inside the console causes the browser to crash. Looking forward to your feedback, thanks!