### PR TITLE
Use tape-catch instead of regular tape

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -32,7 +32,7 @@
   },
   "test/unit/*.js": {
     "type": "test",
-    "template": "import test from 'tape';\n\ntest('{}', (assert) => {open}\n{close});"
+    "template": "import test from 'tape-catch';\n\ntest('{}', (assert) => {open}\n{close});"
   },
   "src/validations/*.js": {"type": "validation"},
   "src/static/*": {"type": "static"},

--- a/package.json
+++ b/package.json
@@ -336,6 +336,7 @@
     "svgo": "^1.0.1",
     "svgo-loader": "^2.0.0",
     "tape": "^4.6.3",
+    "tape-catch": "^1.0.6",
     "transform-loader": "^0.2.3",
     "webpack": "^4.16.5",
     "webpack-bundle-analyzer": "^2.11.1",

--- a/test/unit/Analyzer.js
+++ b/test/unit/Analyzer.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import Analyzer from '../../src/analyzers';
 import {Project} from '../../src/records';

--- a/test/unit/higherOrderComponents/resizableFlex/calculateFlexGrowAfterDrag.js
+++ b/test/unit/higherOrderComponents/resizableFlex/calculateFlexGrowAfterDrag.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import almostEqual from 'almost-equal';
 import every from 'lodash-es/every';
 import zip from 'lodash-es/zip';

--- a/test/unit/localization/localization.js
+++ b/test/unit/localization/localization.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import getI18nInstance from '../../helpers/i18nFactory';
 import localizationTest from '../../helpers/localizationTest';

--- a/test/unit/reducers/clients.js
+++ b/test/unit/reducers/clients.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import Immutable from 'immutable';
 import partial from 'lodash-es/partial';
 

--- a/test/unit/reducers/console.js
+++ b/test/unit/reducers/console.js
@@ -1,6 +1,6 @@
 import {OrderedMap} from 'immutable';
 import partial from 'lodash-es/partial';
-import test from 'tape';
+import test from 'tape-catch';
 
 import {ConsoleEntry, ConsoleError, ConsoleState} from '../../../src/records';
 import {

--- a/test/unit/reducers/currentProject.js
+++ b/test/unit/reducers/currentProject.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import partial from 'lodash-es/partial';
 import Immutable from 'immutable';
 

--- a/test/unit/reducers/errors.js
+++ b/test/unit/reducers/errors.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import partial from 'lodash-es/partial';
 import {List} from 'immutable';
 

--- a/test/unit/reducers/projects.js
+++ b/test/unit/reducers/projects.js
@@ -1,5 +1,5 @@
 import assign from 'lodash-es/assign';
-import test from 'tape';
+import test from 'tape-catch';
 import reduce from 'lodash-es/reduce';
 import tap from 'lodash-es/tap';
 import partial from 'lodash-es/partial';

--- a/test/unit/reducers/resizableFlex.js
+++ b/test/unit/reducers/resizableFlex.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import {List, Map} from 'immutable';
 import partial from 'lodash-es/partial';
 

--- a/test/unit/reducers/ui.js
+++ b/test/unit/reducers/ui.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import tap from 'lodash-es/tap';
 import partial from 'lodash-es/partial';
 import {Map} from 'immutable';

--- a/test/unit/reducers/user.js
+++ b/test/unit/reducers/user.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import partial from 'lodash-es/partial';
 import tap from 'lodash-es/tap';
 import {Map} from 'immutable';

--- a/test/unit/sagas/clients.js
+++ b/test/unit/sagas/clients.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import {testSaga} from 'redux-saga-test-plan';
 import {
   createSnapshot as createSnapshotSaga,

--- a/test/unit/sagas/compiledProjects.js
+++ b/test/unit/sagas/compiledProjects.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import {testSaga} from 'redux-saga-test-plan';
 import {
   validatedSource as validatedSourceSaga,

--- a/test/unit/sagas/errors.js
+++ b/test/unit/sagas/errors.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import isEqual from 'lodash-es/isEqual';
 import {createMockTask} from '@redux-saga/testing-utils';
 import {testSaga} from 'redux-saga-test-plan';

--- a/test/unit/sagas/manageUserState.js
+++ b/test/unit/sagas/manageUserState.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import {testSaga} from 'redux-saga-test-plan';
 import {call, take} from 'redux-saga/effects';
 import {channel} from 'redux-saga';

--- a/test/unit/sagas/projects.js
+++ b/test/unit/sagas/projects.js
@@ -1,5 +1,5 @@
 import omit from 'lodash-es/omit';
-import test from 'tape';
+import test from 'tape-catch';
 import {testSaga} from 'redux-saga-test-plan';
 import {
   applicationLoaded as applicationLoadedSaga,

--- a/test/unit/sagas/ui.js
+++ b/test/unit/sagas/ui.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import {testSaga} from 'redux-saga-test-plan';
 import {
   userDoneTyping as userDoneTypingSaga,

--- a/test/unit/sagas/user.js
+++ b/test/unit/sagas/user.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import {testSaga} from 'redux-saga-test-plan';
 import {delay, take, race} from 'redux-saga/effects';
 

--- a/test/unit/util/javascript.js
+++ b/test/unit/util/javascript.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import {hasExpressionStatement} from '../../../src/util/javascript';
 

--- a/test/unit/util/queryParams.js
+++ b/test/unit/util/queryParams.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import {getQueryParameters} from '../../../src/util/queryParams';
 

--- a/test/unit/validations/css.js
+++ b/test/unit/validations/css.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import css from '../../../src/validations/css';
 import validationTest from '../../helpers/validationTest';

--- a/test/unit/validations/html.js
+++ b/test/unit/validations/html.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import html from '../../../src/validations/html';
 import validationTest from '../../helpers/validationTest';

--- a/test/unit/validations/html/rules.js
+++ b/test/unit/validations/html/rules.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import Code from '../../../../src/validations/html/rules/Code';
 import MismatchedTag

--- a/test/unit/validations/html/runRules.js
+++ b/test/unit/validations/html/runRules.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 
 import runRules from '../../../../src/validations/html/runRules';
 

--- a/test/unit/validations/javascript.js
+++ b/test/unit/validations/javascript.js
@@ -1,4 +1,4 @@
-import test from 'tape';
+import test from 'tape-catch';
 import partialRight from 'lodash-es/partialRight';
 
 import validationTest from '../../helpers/validationTest';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4389,6 +4389,11 @@ dom-storage@2.1.0:
   resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.1.0.tgz#00fb868bc9201357ea243c7bcfd3304c1e34ea39"
   integrity sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -6089,6 +6094,14 @@ global-prefix@^1.0.1:
     ini "^1.3.4"
     is-windows "^1.0.1"
     which "^1.2.14"
+
+global@~4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^11.1.0, globals@^11.7.0:
   version "11.10.0"
@@ -8641,6 +8654,13 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
+  dependencies:
+    dom-walk "^0.1.0"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -10655,6 +10675,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+  integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
 
 progress@^1.1.8:
   version "1.1.8"
@@ -12945,6 +12970,13 @@ tapable@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
   integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
+
+tape-catch@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tape-catch/-/tape-catch-1.0.6.tgz#12931d5ea60a03a97d9bd19d0d7d8cfc3f6cecf1"
+  integrity sha1-EpMdXqYKA6l9m9GdDX2M/D9s7PE=
+  dependencies:
+    global "~4.3.0"
 
 tape@^4.6.3:
   version "4.9.0"


### PR DESCRIPTION
I’d like to move away from tape entirely, but at least it would be nice for errors thrown from tests to be reported as test failures, rather than crashing the entire process.