### PR TITLE
Source jQuery from npm, not bower

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -491,6 +491,10 @@
     "no-regex-spaces": [
       "error"
     ],
+    "no-restricted-imports": [
+      "error",
+      "jquery"
+    ],
     "no-return-assign": [
       "error"
     ],

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,6 @@
     "ember": "^2.5.1",
     "foundation": "^5.5.3",
     "handlebars": "^4.0.5",
-    "jquery": "^3.2.1",
     "lodash": "^4.11.2",
     "mustache.js": "mustache#^2.2.1",
     "normalize-css": "normalize.css#^4.1.1",

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "immutable": "^3.7.5",
     "immutable-devtools": "0.1.3",
     "inline-style-prefixer": "^4.0.2",
+    "jquery": "3.2.1",
     "js-beautify": "^1.7.4",
     "js-cookie": "^2.1.3",
     "jschannel": "^1.0.2",

--- a/src/config/libraryAssets.js
+++ b/src/config/libraryAssets.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/extensions */
 
-import JQUERY from '../../bower_components/jquery/dist/jquery.min.js';
+import JQUERY from '../../node_modules/jquery/dist/jquery.min.js';
 import LODASH from '../../bower_components/lodash/dist/lodash.min.js';
 import MUSTACHE from '../../bower_components/mustache.js/mustache.js';
 import BOOTSTRAP_CSS from

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,6 +187,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
           include: [
             path.resolve(__dirname, 'bower_components'),
             path.resolve(__dirname, 'templates'),
+            path.resolve(__dirname, 'node_modules/jquery/dist'),
           ],
           use: ['raw-loader'],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7469,6 +7469,11 @@ isstream@0.1.x, isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+jquery@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
+  integrity sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=
+
 js-base64@^2.1.9:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"


### PR DESCRIPTION
This one was straightforward - jQuery's npm package ships with a dist
version that can be easily dropped in where the bower one was before.

The first of many steps for #1442