### PR TITLE
Report to Bugsnag if user providers don't match credential providers

### DIFF
--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,5 +1,6 @@
 import {Map} from 'immutable';
 import find from 'lodash-es/find';
+import isUndefined from 'lodash-es/isUndefined';
 import reduce from 'lodash-es/reduce';
 
 import {
@@ -24,6 +25,9 @@ function addIdentityProvider(state, userData, credential) {
     userData.providerData,
     {providerId: credential.providerId},
   );
+  if (isUndefined(providerData)) {
+    return state;
+  }
   return state.setIn(
     ['account', 'identityProviders', credential.providerId],
     new UserIdentityProvider({

--- a/src/sagas/manageUserState.js
+++ b/src/sagas/manageUserState.js
@@ -1,8 +1,10 @@
 import {all, call, fork, put, race, take} from 'redux-saga/effects';
+import difference from 'lodash-es/difference';
 import isEmpty from 'lodash-es/isEmpty';
 import isError from 'lodash-es/isError';
 import isNil from 'lodash-es/isNil';
 import isString from 'lodash-es/isString';
+import map from 'lodash-es/map';
 import reject from 'lodash-es/reject';
 
 import {bugsnagClient} from '../util/bugsnag';
@@ -37,6 +39,8 @@ export function* handleInitialAuth(user) {
     return;
   }
 
+  yield* reportUserCredentialMismatch(user, credentials);
+
   yield put(userAuthenticated(user, credentials));
 }
 
@@ -61,6 +65,8 @@ export function* handleAuthChange(user, {newCredential} = {}) {
     );
     credentials.push(newCredential);
   }
+
+  yield* reportUserCredentialMismatch(user, credentials);
 
   yield put(userAuthenticated(user, credentials));
 }
@@ -103,6 +109,41 @@ export function* handleAuthError(e) {
         yield call([bugsnagClient, 'notify'], new Error(e));
       }
       break;
+  }
+}
+
+function* reportUserCredentialMismatch(user, credentials) {
+  const userProviders = map(user.providerData, 'providerId');
+  const credentialProviders = map(credentials, 'providerId');
+
+  const missingUserProviders = difference(userProviders, credentialProviders);
+  const missingCredentialProviders = difference(
+    credentialProviders,
+    userProviders,
+  );
+
+  if (!isEmpty(missingUserProviders)) {
+    const e = new Error(
+      `User ${user.uid} has credentials for ` +
+        `${missingUserProviders.join(',')} + but no linked account`,
+    );
+    yield call(
+      [bugsnagClient, 'notify'],
+      e,
+      {metaData: {user, credentials}, severity: 'warning'},
+    );
+  }
+
+  if (!isEmpty(missingCredentialProviders)) {
+    const e = new Error(
+      `User ${user.uid} has linked accounts for ` +
+        `${missingCredentialProviders.join(',')} + but no credentials`,
+    );
+    yield call(
+      [bugsnagClient, 'notify'],
+      e,
+      {metaData: {user, credentials}, severity: 'warning'},
+    );
   }
 }
 

--- a/test/unit/sagas/manageUserState.js
+++ b/test/unit/sagas/manageUserState.js
@@ -252,6 +252,12 @@ test('handleAuthError', (t) => {
 
 test('handleAuthChange', (t) => {
   const user = createUser();
+  user.providerData.push({
+    providerId: 'github.com',
+    displayName: 'GitHub User',
+    photoURL: 'https://github.com/popcodeuser.jpg',
+  });
+
   const credentials = [
     createCredential({providerId: 'google.com'}),
     createCredential({providerId: 'github.com'}),
@@ -261,7 +267,8 @@ test('handleAuthChange', (t) => {
     assert.doesNotThrow(() => {
       testSaga(handleAuthChange, user).
         next().call(loadCredentialsForUser, user.uid).
-        next(credentials).put(userAuthenticated(user, credentials));
+        next(credentials).
+        put(userAuthenticated(user, credentials));
     });
     assert.end();
   });


### PR DESCRIPTION
For reasons that are as yet unclear, some users have GitHub credentials but don’t actually have a GitHub account linked. Currently this causes an error when logging in, and the error is thrown before the user has successfully authenticated, meaning the error report has no user information.

For now we simply ignore credentials that don’t have a corresponding entry in `providerData`, and send a warning report to Bugsnag. This should allow me to accumulate enough data to figure out the problem.

Fixes #1647