### PR TITLE
Upgrade i18next to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "highlight.js": "^9.12.0",
     "html-inspector": "^0.8.2",
     "htmllint": "^0.7.3",
-    "i18next": "^11.9.0",
+    "i18next": "^15.0.6",
     "immutable": "^3.7.5",
     "immutable-devtools": "0.1.3",
     "inline-style-prefixer": "^4.0.2",

--- a/test/helpers/i18nFactory.js
+++ b/test/helpers/i18nFactory.js
@@ -1,4 +1,5 @@
 import {createInstance} from 'i18next';
+import tap from 'lodash-es/tap';
 
 import applyCustomI18nFormatters from '../../src/util/i18nFormatting';
 
@@ -28,5 +29,5 @@ export default function getI18nInstance() {
     },
   };
 
-  return createInstance(options).init();
+  return tap(createInstance(options), instance => instance.init());
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6666,10 +6666,12 @@ i18next-resource-store-loader@^0.1.1:
     loader-utils "^0.2.11"
     lodash "^4.6.1"
 
-i18next@^11.9.0:
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-11.9.0.tgz#c30c0a5e0a857124923a8dd1ce8f1df603e30c70"
-  integrity sha512-NDuIoELzyJ+29kc29j9aKgzjZht4kEKh3PPdz0qCEC9ZUpgRVaWUdkMRES/NVTcpe1ei4MMwY8DNWBWCIUlAng==
+i18next@^15.0.6:
+  version "15.0.6"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-15.0.6.tgz#2bad22b180043dce4ebc89763b07b752a5379675"
+  integrity sha512-pFka7P9InL0UvvQeKKxXR9khyblG6wB4QSQliIRJII2BiWv8OXXYUPeXIa+4rSnZJFhq86aMl4d0hRF0Lgs6Jw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 iconv-lite@0.4.15:
   version "0.4.15"


### PR DESCRIPTION
11.9.0 &rarr; 15.0.6

Had to update a call to `init()` in the test helper to not expect `init()` to return the instance.

Otherwise, nothing particularly interesting in the [changelog](https://github.com/i18next/i18next/blob/master/CHANGELOG.md).