### PR TITLE
Upgrade bowser

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -25,7 +25,7 @@
   },
   "bad-browser": {
     "message": "Popcode doesn’t work with your version of {{name}}.",
-    "ie-message": "Popcode doesn’t work with Internet Explorer or IE Edge. Please use another browser.",
+    "ie-message": "Popcode doesn’t work with Internet Explorer or Microsoft Edge. Please use another browser.",
     "download": "Click here to download a new version."
   },
   "notifications": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "@fortawesome/react-fontawesome": "^0.1.3",
     "PrettyCSS": "^0.3.19",
     "array-to-sentence": "^2.0.0",
-    "bowser": "^1.9.4",
+    "bowser": "^2.1.2",
     "brace": "^0.11.0",
     "classnames": "^2.2.6",
     "css": "^2.2.4",

--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -1,7 +1,8 @@
+import mapValues from 'lodash-es/mapValues';
 import React from 'react';
 import {Provider} from 'react-redux';
-import bowser from 'bowser';
 
+import bowser from '../services/bowser';
 import createApplicationStore from '../createApplicationStore';
 import {ErrorBoundary, includeStoreInBugReports} from '../util/bugsnag';
 import supportedBrowsers from '../../config/browsers.json';
@@ -19,15 +20,15 @@ class Application extends React.Component {
   }
 
   _isIEOrEdge() {
-    return (bowser.msie || bowser.msedge);
+    return bowser.some(['Internet Explorer', 'Microsoft Edge']);
   }
 
   _isUnsupportedBrowser() {
-    return bowser.isUnsupportedBrowser(
+    const supportedBrowsersForBowser = mapValues(
       supportedBrowsers,
-      true,
-      window.navigator.userAgent,
+      version => `>=${version}`,
     );
+    return !bowser.satisfies(supportedBrowsersForBowser);
   }
 
   render() {

--- a/src/components/BrowserError.jsx
+++ b/src/components/BrowserError.jsx
@@ -3,24 +3,24 @@ import PropTypes from 'prop-types';
 import {t} from 'i18next';
 
 function getBrowserLink(browser) {
-  if (browser.firefox) {
+  if (browser.is('Firefox')) {
     return 'https://www.mozilla.org/en-US/firefox/new/';
   }
-  if (browser.safari) {
+  if (browser.is('Safari')) {
     return 'https://support.apple.com/downloads/safari';
   }
   return 'https://www.google.com/chrome/browser/desktop/';
 }
 
-function BrowserError(props) {
-  const browserName = props.browser.name;
+function BrowserError({browser}) {
+  const browserName = browser.getBrowserName();
 
   return (
     <div className="unsupported-browser">
       <p>{t('bad-browser.message', {name: browserName})}</p>
 
       <p>
-        <a href={getBrowserLink(props.browser)}>
+        <a href={getBrowserLink(browser)}>
           {t('bad-browser.download')}
         </a>
       </p>

--- a/src/components/PreviewFrame.jsx
+++ b/src/components/PreviewFrame.jsx
@@ -2,11 +2,11 @@ import Channel from 'jschannel';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import Bowser from 'bowser';
 import bindAll from 'lodash-es/bindAll';
 import constant from 'lodash-es/constant';
 import {t} from 'i18next';
 
+import bowser from '../services/bowser';
 import normalizeError from '../util/normalizeError';
 import retryingFailedImports from '../util/retryingFailedImports';
 import {sourceDelimiter} from '../util/compileProject';
@@ -104,7 +104,7 @@ class PreviewFrame extends React.Component {
       new ErrorConstructor(error.message),
     );
 
-    if (Bowser.safari) {
+    if (bowser.is('Safari')) {
       line = 1;
     }
 

--- a/src/services/bowser.js
+++ b/src/services/bowser.js
@@ -1,0 +1,3 @@
+import Bowser from 'bowser';
+
+export default Bowser.getParser(window.navigator.userAgent);

--- a/src/util/normalizeError.js
+++ b/src/util/normalizeError.js
@@ -1,9 +1,10 @@
-import Bowser from 'bowser';
 import get from 'lodash-es/get';
 import keys from 'lodash-es/keys';
 import isEmpty from 'lodash-es/isEmpty';
 import assign from 'lodash-es/assign';
 import {t} from 'i18next';
+
+import bowser from '../services/bowser';
 
 const normalizers = {
   Chrome: {
@@ -101,7 +102,7 @@ function attachMessage(normalizedError) {
 }
 
 function normalizeError(error) {
-  const normalizer = get(normalizers, [Bowser.name, error.name]);
+  const normalizer = get(normalizers, [bowser.getBrowserName(), error.name]);
   if (normalizer !== undefined) {
     const normalizedError = normalizer(error.message);
     if (normalizedError !== null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,10 +2570,15 @@ bower@^1.7.9:
   resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.4.tgz#e7876a076deb8137f7d06525dc5e8c66db82f28a"
   integrity sha1-54dqB23rgTf30GUl3F6MZtuC8oo=
 
-bowser@^1.7.3, bowser@^1.9.4:
+bowser@^1.7.3:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
   integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
+
+bowser@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.1.2.tgz#35cba0487362ab6a8cea8fd094bf5670b408c8d3"
+  integrity sha512-K64ZigDayqlptyKVEiCDPPKQ2/SyPT/jsgJPwZOcpR3WA2bYojlHLeTHN+IRc/vbMz3F6CV62nnAo01+0zYrsQ==
 
 boxen@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
Upgrades from 1.9.4 &rarr; 2.1.2. Major breaking API change, now export a singleton parser from the `bowser` service.