### PR TITLE
Run all node_modules through babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -29,10 +29,5 @@ module.exports = (api) => {
     ],
     plugins,
     compact: false,
-    overrides: [
-      {
-        include: './node_modules/parse5-sax-parser/lib/index.js',
-      },
-    ],
   };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -25,7 +25,13 @@ module.exports = (api) => {
   return {
     presets: [
       '@babel/preset-react',
-      ['@babel/preset-env', {targets, modules: isJest ? 'auto' : false}],
+      [
+        '@babel/preset-env', {
+          targets,
+          modules: isJest ? 'auto' : false,
+          exclude: ['@babel/plugin-transform-typeof-symbol'],
+        },
+      ],
     ],
     plugins,
     compact: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,18 +252,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
         },
         {
           test: /\.js$/u,
-          include: [
-            matchModule('ansi-styles'),
-            matchModule('ast-types'),
-            matchModule('chalk'),
-            matchModule('lodash-es'),
-            matchModule('parse5'),
-            matchModule('parse5-sax-parser'),
-            matchModule('postcss-html'),
-            matchModule('recast'),
-            matchModule('redux'),
-            matchModule('stylelint'),
-          ],
+          include: [path.resolve(__dirname, 'node_modules')],
           use: {loader: 'babel-loader', options: babelLoaderConfig},
         },
         {


### PR DESCRIPTION
This is a revert of a revert, previously reviewed at #1674 

This PR causes a runtime error that prevents Popcode from loading at all in Chrome 40 and below.