### PR TITLE
Make `Preview` component collapsible and handle completely collapsed right column

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -4,6 +4,7 @@ import {
   faSyncAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 import partial from 'lodash-es/partial';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -26,7 +27,7 @@ export default function Preview({
   onRuntimeError,
   onToggleVisible,
 }) {
-  if (showingErrors || !isOpen) {
+  if (showingErrors) {
     return null;
   }
 
@@ -44,7 +45,13 @@ export default function Preview({
   ));
 
   return (
-    <div className="preview output__item">
+    <div
+      className={classnames(
+        'preview',
+        'output__item',
+        {u__hidden: !isOpen},
+      )}
+    >
       <div className="preview__title-bar">
         <span className="preview__button preview__button_pop-out">
           <FontAwesomeIcon

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,9 +1,10 @@
 import {
+  faChevronDown,
   faExternalLinkAlt,
   faSyncAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import get from 'lodash-es/get';
+import partial from 'lodash-es/partial';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import React from 'react';
@@ -13,13 +14,16 @@ import PreviewFrame from './PreviewFrame';
 export default function Preview({
   compiledProjects,
   consoleEntries,
+  currentProjectKey,
   showingErrors,
+  title,
   onConsoleError,
   onConsoleLog,
   onConsoleValue,
   onPopOutProject,
   onRefreshClick,
   onRuntimeError,
+  onToggleVisible,
 }) {
   if (showingErrors) {
     return null;
@@ -38,9 +42,6 @@ export default function Preview({
     />
   ));
 
-  const mostRecentCompiledProject = compiledProjects.last();
-  const title = get(mostRecentCompiledProject, 'title', '');
-
   return (
     <div className="preview output__item">
       <div className="preview__title-bar">
@@ -51,6 +52,12 @@ export default function Preview({
           />
         </span>
         {title}
+        <span className="preview__button preview__button_toggle-visibility">
+          <FontAwesomeIcon
+            icon={faChevronDown}
+            onClick={partial(onToggleVisible, currentProjectKey)}
+          />
+        </span>
         <span className="preview__button preview__button_reset">
           <FontAwesomeIcon icon={faSyncAlt} onClick={onRefreshClick} />
         </span>
@@ -63,11 +70,14 @@ export default function Preview({
 Preview.propTypes = {
   compiledProjects: ImmutablePropTypes.iterable.isRequired,
   consoleEntries: ImmutablePropTypes.iterable.isRequired,
+  currentProjectKey: PropTypes.string.isRequired,
   showingErrors: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
   onConsoleError: PropTypes.func.isRequired,
   onConsoleLog: PropTypes.func.isRequired,
   onConsoleValue: PropTypes.func.isRequired,
   onPopOutProject: PropTypes.func.isRequired,
   onRefreshClick: PropTypes.func.isRequired,
   onRuntimeError: PropTypes.func.isRequired,
+  onToggleVisible: PropTypes.func.isRequired,
 };

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -15,6 +15,7 @@ export default function Preview({
   compiledProjects,
   consoleEntries,
   currentProjectKey,
+  isOpen,
   showingErrors,
   title,
   onConsoleError,
@@ -25,7 +26,7 @@ export default function Preview({
   onRuntimeError,
   onToggleVisible,
 }) {
-  if (showingErrors) {
+  if (showingErrors || !isOpen) {
     return null;
   }
 
@@ -71,6 +72,7 @@ Preview.propTypes = {
   compiledProjects: ImmutablePropTypes.iterable.isRequired,
   consoleEntries: ImmutablePropTypes.iterable.isRequired,
   currentProjectKey: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
   showingErrors: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
   onConsoleError: PropTypes.func.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -165,9 +165,14 @@ export default class Workspace extends React.Component {
   _renderHiddenRightColumnComponents() {
     const {
       currentProject,
+      hasErrors,
       onComponentToggle,
       title,
     } = this.props;
+    // Errors take over the whole right side of the screen
+    if (hasErrors) {
+      return null;
+    }
     return RIGHT_COLUMN_COMPONENTS.
       filter(component => (
         includes(currentProject.hiddenUIComponents, component)
@@ -330,6 +335,7 @@ export default class Workspace extends React.Component {
 
 Workspace.propTypes = {
   currentProject: PropTypes.object,
+  hasErrors: PropTypes.bool.isRequired,
   hiddenLanguages: PropTypes.array.isRequired,
   isAnyTopBarMenuOpen: PropTypes.bool.isRequired,
   isDraggingColumnDivider: PropTypes.bool.isRequired,

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -17,6 +17,7 @@ import classnames from 'classnames';
 import prefix from '../services/inlineStylePrefixer';
 import {getQueryParameters, setQueryParameters} from '../util/queryParams';
 import {LANGUAGES} from '../util/editor';
+import {RIGHT_COLUMN_COMPONENTS} from '../util/ui';
 import {dehydrateProject, rehydrateProject} from '../clients/localStorage';
 
 import {isPristineProject} from '../util/projectUtils';
@@ -32,7 +33,6 @@ import CollapsedComponent from './CollapsedComponent';
 import Output from './Output';
 import PopThrobber from './PopThrobber';
 
-const RIGHT_COLUMN_COMPONENTS = ['preview', 'console'];
 export default class Workspace extends React.Component {
   constructor() {
     super();

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -32,6 +32,7 @@ import CollapsedComponent from './CollapsedComponent';
 import Output from './Output';
 import PopThrobber from './PopThrobber';
 
+const RIGHT_COLUMN_COMPONENTS = ['preview', 'console'];
 export default class Workspace extends React.Component {
   constructor() {
     super();
@@ -168,8 +169,7 @@ export default class Workspace extends React.Component {
       shouldShowCollapsedConsole,
       title,
     } = this.props;
-    const rightColumnComponents = ['preview', 'console']; // TODO: dedupe
-    return rightColumnComponents.
+    return RIGHT_COLUMN_COMPONENTS.
       filter(component => (
         includes(currentProject.hiddenUIComponents, component)
       )).
@@ -214,8 +214,7 @@ export default class Workspace extends React.Component {
     const {
       currentProject,
     } = this.props;
-    const rightColumnComponents = ['preview', 'console']; // TODO: dedupe
-    return some(rightColumnComponents,
+    return some(RIGHT_COLUMN_COMPONENTS,
       component => (
         !includes(currentProject.hiddenUIComponents, component)
       ));
@@ -231,7 +230,7 @@ export default class Workspace extends React.Component {
         {this._renderHiddenRightColumnComponents()}
         {this._renderHiddenLanguages()}
       </div>
-    )
+    );
   }
   _renderEnvironment() {
     const {

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -166,7 +166,6 @@ export default class Workspace extends React.Component {
     const {
       currentProject,
       onComponentToggle,
-      shouldShowCollapsedConsole,
       title,
     } = this.props;
     return RIGHT_COLUMN_COMPONENTS.
@@ -176,19 +175,16 @@ export default class Workspace extends React.Component {
       map((component) => {
         switch (component) {
           case 'console':
-            if (shouldShowCollapsedConsole) {
-              return (
-                <CollapsedComponent
-                  component="console"
-                  isRightJustified={false}
-                  key="console"
-                  projectKey={currentProject.projectKey}
-                  text={t('workspace.components.console')}
-                  onComponentUnhide={onComponentToggle}
-                />
-              );
-            }
-            return null;
+            return (
+              <CollapsedComponent
+                component="console"
+                isRightJustified={false}
+                key="console"
+                projectKey={currentProject.projectKey}
+                text={t('workspace.components.console')}
+                onComponentUnhide={onComponentToggle}
+              />
+            );
           case 'preview':
             return (
               <CollapsedComponent
@@ -213,8 +209,9 @@ export default class Workspace extends React.Component {
   _shouldRenderRightColumn() {
     const {
       currentProject,
+      shouldRenderOutput,
     } = this.props;
-    return some(RIGHT_COLUMN_COMPONENTS,
+    return shouldRenderOutput || some(RIGHT_COLUMN_COMPONENTS,
       component => (
         !includes(currentProject.hiddenUIComponents, component)
       ));
@@ -341,7 +338,6 @@ Workspace.propTypes = {
   resizableFlexGrow: ImmutablePropTypes.list.isRequired,
   resizableFlexRefs: PropTypes.array.isRequired,
   shouldRenderOutput: PropTypes.bool.isRequired,
-  shouldShowCollapsedConsole: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
   onApplicationLoaded: PropTypes.func.isRequired,
   onClickInstructionsEditButton: PropTypes.func.isRequired,

--- a/src/containers/Preview.js
+++ b/src/containers/Preview.js
@@ -10,10 +10,14 @@ import {
   consoleValueProduced,
   popOutProject,
   refreshPreview,
+  toggleComponent,
 } from '../actions';
 import {
   getCompiledProjects,
   getConsoleHistory,
+  getCurrentProjectKey,
+  getCurrentProjectPreviewTitle,
+  getHiddenUIComponents,
   isCurrentProjectSyntacticallyValid,
   isUserTyping,
 } from '../selectors';
@@ -22,10 +26,13 @@ function mapStateToProps(state) {
   return {
     compiledProjects: getCompiledProjects(state),
     consoleEntries: getConsoleHistory(state),
+    currentProjectKey: getCurrentProjectKey(state),
+    isOpen: !getHiddenUIComponents(state).includes('preview'),
     showingErrors: (
       !isUserTyping(state) &&
         !isCurrentProjectSyntacticallyValid(state)
     ),
+    title: getCurrentProjectPreviewTitle(state),
   };
 }
 
@@ -73,6 +80,10 @@ function mapDispatchToProps(dispatch) {
 
     onRuntimeError(error) {
       dispatch(addRuntimeError('javascript', error));
+    },
+
+    onToggleVisible(projectKey) {
+      dispatch(toggleComponent(projectKey, 'preview'));
     },
   };
 }

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -1,11 +1,14 @@
 import {connect} from 'react-redux';
+import every from 'lodash-es/every';
 
 import Workspace from '../components/Workspace';
 import {
   getCurrentProject,
   isDraggingColumnDivider,
   isEditingInstructions,
+  getCurrentProjectPreviewTitle,
   getHiddenAndVisibleLanguages,
+  getHiddenUIComponents,
   getOpenTopBarMenu,
   isCurrentProjectSyntacticallyValid,
 } from '../selectors';
@@ -20,13 +23,20 @@ import resizableFlex from '../higherOrderComponents/resizableFlex';
 
 function mapStateToProps(state) {
   const {hiddenLanguages} = getHiddenAndVisibleLanguages(state);
+  const isCurrentProjectValid = isCurrentProjectSyntacticallyValid(state);
+  const hiddenUIComponents = getHiddenUIComponents(state);
+  const areAllRightColumnComponentsCollapsed = every(
+    ['console', 'preview'], component => hiddenUIComponents.includes(component),
+  );
   return {
     currentProject: getCurrentProject(state),
     isAnyTopBarMenuOpen: Boolean(getOpenTopBarMenu(state)),
     isDraggingColumnDivider: isDraggingColumnDivider(state),
     isEditingInstructions: isEditingInstructions(state),
     hiddenLanguages,
-    shouldShowCollapsedConsole: isCurrentProjectSyntacticallyValid(state),
+    shouldShowCollapsedConsole: isCurrentProjectValid,
+    shouldRenderOutput: !isCurrentProjectValid || !areAllRightColumnComponentsCollapsed,
+    title: getCurrentProjectPreviewTitle(state),
   };
 }
 

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -39,6 +39,7 @@ function mapStateToProps(state) {
     !isUserTyping(state));
   return {
     currentProject: getCurrentProject(state),
+    hasErrors: !isCurrentProjectValid,
     isAnyTopBarMenuOpen: Boolean(getOpenTopBarMenu(state)),
     isDraggingColumnDivider: isDraggingColumnDivider(state),
     isEditingInstructions: isEditingInstructions(state),

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -26,7 +26,8 @@ function mapStateToProps(state) {
   const isCurrentProjectValid = isCurrentProjectSyntacticallyValid(state);
   const hiddenUIComponents = getHiddenUIComponents(state);
   const areAllRightColumnComponentsCollapsed = every(
-    ['console', 'preview'], component => hiddenUIComponents.includes(component),
+    ['console', 'preview'],
+    component => hiddenUIComponents.includes(component),
   );
   return {
     currentProject: getCurrentProject(state),
@@ -35,7 +36,8 @@ function mapStateToProps(state) {
     isEditingInstructions: isEditingInstructions(state),
     hiddenLanguages,
     shouldShowCollapsedConsole: isCurrentProjectValid,
-    shouldRenderOutput: !isCurrentProjectValid || !areAllRightColumnComponentsCollapsed,
+    shouldRenderOutput: !isCurrentProjectValid ||
+      !areAllRightColumnComponentsCollapsed,
     title: getCurrentProjectPreviewTitle(state),
   };
 }

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -20,13 +20,14 @@ import {
   startEditingInstructions,
 } from '../actions';
 import resizableFlex from '../higherOrderComponents/resizableFlex';
+import {RIGHT_COLUMN_COMPONENTS} from '../util/ui';
 
 function mapStateToProps(state) {
   const {hiddenLanguages} = getHiddenAndVisibleLanguages(state);
   const isCurrentProjectValid = isCurrentProjectSyntacticallyValid(state);
   const hiddenUIComponents = getHiddenUIComponents(state);
   const areAllRightColumnComponentsCollapsed = every(
-    ['console', 'preview'],
+    RIGHT_COLUMN_COMPONENTS,
     component => hiddenUIComponents.includes(component),
   );
   return {

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -4,6 +4,7 @@ import every from 'lodash-es/every';
 import Workspace from '../components/Workspace';
 import {
   getCurrentProject,
+  isCurrentlyValidating,
   isDraggingColumnDivider,
   isEditingInstructions,
   getCurrentProjectPreviewTitle,
@@ -11,6 +12,7 @@ import {
   getHiddenUIComponents,
   getOpenTopBarMenu,
   isCurrentProjectSyntacticallyValid,
+  isUserTyping,
 } from '../selectors';
 import {
   toggleComponent,
@@ -25,20 +27,23 @@ import {RIGHT_COLUMN_COMPONENTS} from '../util/ui';
 function mapStateToProps(state) {
   const {hiddenLanguages} = getHiddenAndVisibleLanguages(state);
   const isCurrentProjectValid = isCurrentProjectSyntacticallyValid(state);
+  const isCurrentProjectValidating = isCurrentlyValidating(state);
   const hiddenUIComponents = getHiddenUIComponents(state);
   const areAllRightColumnComponentsCollapsed = every(
     RIGHT_COLUMN_COMPONENTS,
     component => hiddenUIComponents.includes(component),
   );
+  const shouldRenderOutput = !areAllRightColumnComponentsCollapsed ||
+    (!isCurrentProjectValid &&
+    !isCurrentProjectValidating &&
+    !isUserTyping(state));
   return {
     currentProject: getCurrentProject(state),
     isAnyTopBarMenuOpen: Boolean(getOpenTopBarMenu(state)),
     isDraggingColumnDivider: isDraggingColumnDivider(state),
     isEditingInstructions: isEditingInstructions(state),
     hiddenLanguages,
-    shouldShowCollapsedConsole: isCurrentProjectValid,
-    shouldRenderOutput: !isCurrentProjectValid ||
-      !areAllRightColumnComponentsCollapsed,
+    shouldRenderOutput,
     title: getCurrentProjectPreviewTitle(state),
   };
 }

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -762,7 +762,7 @@ body {
 }
 
 .preview__button_reset,
-.preview__button_toggle-visibility  {
+.preview__button_toggle-visibility {
   float: right;
 }
 

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -761,7 +761,8 @@ body {
   float: left;
 }
 
-.preview__button_reset {
+.preview__button_reset,
+.preview__button_toggle-visibility  {
   float: right;
 }
 

--- a/src/selectors/getCurrentProjectPreviewTitle.js
+++ b/src/selectors/getCurrentProjectPreviewTitle.js
@@ -1,0 +1,13 @@
+import {createSelector} from 'reselect';
+import get from 'lodash-es/get';
+
+import getCompiledProjects from './getCompiledProjects';
+
+export default createSelector(
+  [getCompiledProjects],
+  (compiledProjects) => {
+    const mostRecentCompiledProject = compiledProjects.last();
+    const title = get(mostRecentCompiledProject, 'title', '');
+    return title;
+  },
+);

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -12,6 +12,7 @@ import getCurrentProjectInstructions from './getCurrentProjectInstructions';
 import getCurrentProjectExportedRepoName
   from './getCurrentProjectExportedRepoName';
 import getCurrentProjectPreview from './getCurrentProjectPreview';
+import getCurrentProjectPreviewTitle from './getCurrentProjectPreviewTitle';
 import getCurrentProjectKey from './getCurrentProjectKey';
 import getCurrentUser from './getCurrentUser';
 import getCurrentUserId from './getCurrentUserId';
@@ -66,6 +67,7 @@ export {
   getCurrentProjectInstructions,
   getCurrentProjectKey,
   getCurrentProjectPreview,
+  getCurrentProjectPreviewTitle,
   getCurrentUser,
   getCurrentUserId,
   getCurrentValidationState,

--- a/src/util/ui.js
+++ b/src/util/ui.js
@@ -1,0 +1,1 @@
+export const RIGHT_COLUMN_COMPONENTS = ['preview', 'console'];


### PR DESCRIPTION
Finishes the work around this feature.

- Make the `Preview` Component collapsible
- When `Preview` and `Console` are both collapsed, hide the whole right column
- Handle the case where everything is collapsed separately for clarity - I chose to handle it as a separate case as opposed to just picking the right or left column and throwing everything in there - in this case both the left and right column are not rendered and a third, different column is instead.
- Handle various edge cases regarding validation and errors while the preview is collapsed - general heuristic was if there are errors to show we show the right column even if everything is collapsed.

There are a few inconsistencies between how runtime errors and static analysis errors are handled, namely the static errors take over the whole right column while runtime errors still allow the console to be opened - these inconsistencies have mostly been left alone for future work.

Fixes: #1340