### PR TITLE
Source p5 from npm instead of bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "lodash": "^4.11.2",
     "mustache.js": "mustache#^2.2.1",
     "normalize-css": "normalize.css#^4.1.1",
-    "p5js": "^0.5.13",
     "react": "^15.0.1",
     "underscore": "^1.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "moment": "^2.22.2",
     "object-inspect": "^1.5.0",
     "offline-plugin": "^5.0.3",
+    "p5": "^0.8.0",
     "parse5-sax-parser": "^5.1.0",
     "pify": "^4.0.0",
     "postcss": "^6.0.22",

--- a/src/config/libraryAssets.js
+++ b/src/config/libraryAssets.js
@@ -7,7 +7,7 @@ import BOOTSTRAP_CSS from
   '../../bower_components/bootstrap/dist/css/bootstrap.min.css';
 import BOOTSTRAP_JS from
   '../../bower_components/bootstrap/dist/js/bootstrap.min.js';
-import P5 from '../../bower_components/p5js/lib/p5.min.js';
+import P5 from '../../node_modules/p5/lib/p5.min.js';
 
 export const jquery = {javascript: JQUERY};
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -198,6 +198,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
             path.resolve(__dirname, 'bower_components'),
             path.resolve(__dirname, 'templates'),
             path.resolve(__dirname, 'node_modules/jquery/dist'),
+            path.resolve(__dirname, 'node_modules/p5/lib'),
           ],
           use: ['raw-loader'],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10594,6 +10594,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
+p5@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/p5/-/p5-0.8.0.tgz#af4cd2f25b2e77023dff24d845cbdbdaa47d4fd2"
+  integrity sha512-X415HATmOwcbWpgXTCHyDNdcGTNuzuZFaW9GoOsZd3PFrTmugdf+xLr9AO+rGHxBOFgdqfaj766vJeH1wPkCrQ==
+
 pac-proxy-agent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz#11d578b72a164ad74bf9d5bac9ff462a38282432"


### PR DESCRIPTION
Take an upgrade to the latest version while we're at it.

Relates to: #1442 