### PR TITLE
Run all node_modules through babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -29,10 +29,5 @@ module.exports = (api) => {
     ],
     plugins,
     compact: false,
-    overrides: [
-      {
-        include: './node_modules/parse5-sax-parser/lib/index.js',
-      },
-    ],
   };
 };

--- a/config/browsers.json
+++ b/config/browsers.json
@@ -1,6 +1,6 @@
 {
-  "firefox": "28",
-  "chrome": "23",
-  "chromium": "23",
-  "safari": "7.1"
+  "firefox": "43",
+  "chrome": "38",
+  "chromium": "38",
+  "safari": "8.0"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -260,18 +260,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
         },
         {
           test: /\.js$/u,
-          include: [
-            matchModule('ansi-styles'),
-            matchModule('ast-types'),
-            matchModule('chalk'),
-            matchModule('lodash-es'),
-            matchModule('parse5'),
-            matchModule('parse5-sax-parser'),
-            matchModule('postcss-html'),
-            matchModule('recast'),
-            matchModule('redux'),
-            matchModule('stylelint'),
-          ],
+          include: [path.resolve(__dirname, 'node_modules')],
           use: {loader: 'babel-loader', options: babelLoaderConfig},
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -261,6 +261,7 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
         {
           test: /\.js$/u,
           include: [path.resolve(__dirname, 'node_modules')],
+          exclude: [matchModule('brace')],
           use: {loader: 'babel-loader', options: babelLoaderConfig},
         },
         {


### PR DESCRIPTION
This reimplements https://github.com/popcodeorg/popcode/pull/1674, which was previously reverted because it fails on Chrome 38. With this change, one option was to preventing the `@babel/plugin-transform-typeof-symbol` module from being run through the build, because that transform causes issues in chrome 38. The other option was to find already-ES5 modules that don't need to be recompiled, and `brace` fixes the issue.