### PR TITLE
Upgrade Node and Yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.15.0
+FROM node:10.16.0
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
         apt-get update && \
         apt-get install -y google-chrome-stable
 
-ENV YARN_VERSION 1.13.0
+ENV YARN_VERSION 1.17.3
 
 RUN curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \

--- a/package.json
+++ b/package.json
@@ -270,8 +270,8 @@
     "whatwg-fetch": "^3.0.0"
   },
   "engines": {
-    "node": "10.16.0",
-    "yarn": "^1.13.0"
+    "node": "^10.16.0",
+    "yarn": "^1.17.3"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "engines": {
-    "node": "^8.12.0",
+    "node": "10.16.0",
     "yarn": "^1.13.0"
   },
   "scripts": {


### PR DESCRIPTION
Upgrades Node in the build environment to 10.16.0, the current LTS version. Also upgrades Yarn to 1.17.3, the latest.