### PR TITLE
Revert "Updates CurrentUserMenu with icons"

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -28,7 +28,7 @@
     "send-feedback": "Send Feedback",
     "session": {
       "link-github": "Link GitHub",
-      "unlink-github": "Unlink {{displayName}}'s Github",
+      "unlink-github": "Unlink GitHub account for {{displayName}}",
       "log-in-prompt": "Log in to save",
       "log-out-prompt": "Log out",
       "log-in-github": "Log in with GitHub"

--- a/src/components/TopBar/CurrentUserMenu.jsx
+++ b/src/components/TopBar/CurrentUserMenu.jsx
@@ -3,9 +3,6 @@ import isUndefined from 'lodash-es/isUndefined';
 import PropTypes from 'prop-types';
 import React, {Fragment} from 'react';
 import {t} from 'i18next';
-import {faGithub} from '@fortawesome/free-brands-svg-icons';
-import {faUnlink, faSignOutAlt} from '@fortawesome/free-solid-svg-icons';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 
 import {UserAccount} from '../../records';
 
@@ -30,36 +27,17 @@ const CurrentUserMenu = createMenu({
       <Fragment>
         {isUndefined(githubIdentityProvider) ? (
           <MenuItem onClick={onLinkGitHub}>
-            <div className="top-bar__menu-item_container">
-              {t('top-bar.session.link-github')}
-              <div className="top-bar__menu-item-icon">
-                <FontAwesomeIcon icon={faGithub} />
-              </div>
-            </div>
+            {t('top-bar.session.link-github')}
           </MenuItem>
         ) : (
           <MenuItem onClick={onUnlinkGitHub}>
-            <div className="top-bar__menu-item_container">
-              <img
-                className="top-bar__avatar top-bar__menu-item_avatar"
-                src={githubIdentityProvider.avatarUrl}
-              />
-              {t('top-bar.session.unlink-github', {
-                displayName: githubIdentityProvider.displayName.split(' ')[0],
-              })}
-              <div className="top-bar__menu-item-icon">
-                <FontAwesomeIcon icon={faUnlink} />
-              </div>
-            </div>
+            {t('top-bar.session.unlink-github', {
+              displayName: githubIdentityProvider.displayName,
+            })}
           </MenuItem>
         )}
         <MenuItem onClick={onLogOut}>
-          <div className="top-bar__menu-item_container">
-            {t('top-bar.session.log-out-prompt')}
-            <div className="top-bar__menu-item-icon">
-              <FontAwesomeIcon icon={faSignOutAlt} />
-            </div>
-          </div>
+          {t('top-bar.session.log-out-prompt')}
         </MenuItem>
       </Fragment>
     );

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -236,16 +236,6 @@ body {
   white-space: nowrap;
 }
 
-.top-bar__menu-item_container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.top-bar__menu-item_avatar {
-  margin-right: 5px;
-}
-
 .top-bar__menu-item_icons {
   text-align: center;
 }


### PR DESCRIPTION
Reverts popcodeorg/popcode#1712

The call to `split` causes an error when the display name is null; this is happening enough that we should fix and then re-release this.