### PR TITLE
Link unlink icons fix

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -28,7 +28,7 @@
     "send-feedback": "Send Feedback",
     "session": {
       "link-github": "Link GitHub",
-      "unlink-github": "Unlink GitHub account for {{displayName}}",
+      "unlink-github": "Unlink {{displayName}}'s Github",
       "log-in-prompt": "Log in to save",
       "log-out-prompt": "Log out",
       "log-in-github": "Log in with GitHub"

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -29,6 +29,7 @@
     "session": {
       "link-github": "Link GitHub",
       "unlink-github": "Unlink {{displayName}}'s Github",
+      "unlink-github-default": "Unlink Your Github",
       "log-in-prompt": "Log in to save",
       "log-out-prompt": "Log out",
       "log-in-github": "Log in with GitHub"

--- a/src/components/TopBar/CurrentUserMenu.jsx
+++ b/src/components/TopBar/CurrentUserMenu.jsx
@@ -1,4 +1,5 @@
 import isUndefined from 'lodash-es/isUndefined';
+import isNull from 'lodash-es/isNull';
 
 import PropTypes from 'prop-types';
 import React, {Fragment} from 'react';
@@ -25,7 +26,6 @@ const CurrentUserMenu = createMenu({
     /* eslint-enable react/prop-types */
   }) {
     const githubIdentityProvider = user.identityProviders.get('github.com');
-
     return (
       <Fragment>
         {isUndefined(githubIdentityProvider) ? (
@@ -44,9 +44,13 @@ const CurrentUserMenu = createMenu({
                 className="top-bar__avatar top-bar__menu-item_avatar"
                 src={githubIdentityProvider.avatarUrl}
               />
-              {t('top-bar.session.unlink-github', {
-                displayName: githubIdentityProvider.displayName.split(' ')[0],
-              })}
+              {isNull(githubIdentityProvider.displayName)
+                ? t('top-bar.session.unlink-github-default')
+                : t('top-bar.session.unlink-github', {
+                    displayName: githubIdentityProvider.displayName.split(
+                      ' ',
+                    )[0],
+                  })}
               <div className="top-bar__menu-item-icon">
                 <FontAwesomeIcon icon={faUnlink} />
               </div>

--- a/src/components/TopBar/CurrentUserMenu.jsx
+++ b/src/components/TopBar/CurrentUserMenu.jsx
@@ -3,6 +3,9 @@ import isUndefined from 'lodash-es/isUndefined';
 import PropTypes from 'prop-types';
 import React, {Fragment} from 'react';
 import {t} from 'i18next';
+import {faGithub} from '@fortawesome/free-brands-svg-icons';
+import {faUnlink, faSignOutAlt} from '@fortawesome/free-solid-svg-icons';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 
 import {UserAccount} from '../../records';
 
@@ -27,17 +30,36 @@ const CurrentUserMenu = createMenu({
       <Fragment>
         {isUndefined(githubIdentityProvider) ? (
           <MenuItem onClick={onLinkGitHub}>
-            {t('top-bar.session.link-github')}
+            <div className="top-bar__menu-item_container">
+              {t('top-bar.session.link-github')}
+              <div className="top-bar__menu-item-icon">
+                <FontAwesomeIcon icon={faGithub} />
+              </div>
+            </div>
           </MenuItem>
         ) : (
           <MenuItem onClick={onUnlinkGitHub}>
-            {t('top-bar.session.unlink-github', {
-              displayName: githubIdentityProvider.displayName,
-            })}
+            <div className="top-bar__menu-item_container">
+              <img
+                className="top-bar__avatar top-bar__menu-item_avatar"
+                src={githubIdentityProvider.avatarUrl}
+              />
+              {t('top-bar.session.unlink-github', {
+                displayName: githubIdentityProvider.displayName.split(' ')[0],
+              })}
+              <div className="top-bar__menu-item-icon">
+                <FontAwesomeIcon icon={faUnlink} />
+              </div>
+            </div>
           </MenuItem>
         )}
         <MenuItem onClick={onLogOut}>
-          {t('top-bar.session.log-out-prompt')}
+          <div className="top-bar__menu-item_container">
+            {t('top-bar.session.log-out-prompt')}
+            <div className="top-bar__menu-item-icon">
+              <FontAwesomeIcon icon={faSignOutAlt} />
+            </div>
+          </div>
         </MenuItem>
       </Fragment>
     );

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -236,6 +236,16 @@ body {
   white-space: nowrap;
 }
 
+.top-bar__menu-item_container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.top-bar__menu-item_avatar {
+  margin-right: 5px;
+}
+
 .top-bar__menu-item_icons {
   text-align: center;
 }


### PR DESCRIPTION
Adds icons from fontAwesome to CurrentUserMenu items (link Github account, unlink Github account , and logout). Fixes bug for when user displayName is null. Changes top-bar-unlink-github text translation and adds a top-bar-unlink-github-default text translation.