### PR TITLE
Platform-agnostic path separators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,9 @@
       "rules": {
         "import/no-commonjs": "off",
         "import/no-nodejs-modules": "off"
+      },
+      "settings": {
+        "import/resolver": "node"
       }
     },
     {

--- a/src/services/babel-browser.gen.js
+++ b/src/services/babel-browser.gen.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const babel = require('@babel/core');
 const presetEnv = require('@babel/preset-env');
 
@@ -29,7 +31,7 @@ function getPluginNamesFromPresetEnv() {
 
   return result.options.plugins
     .map(plugin => plugin.key)
-    .filter(key => key.indexOf('/') !== 0);
+    .filter(key => path.parse(key).root === '');
 }
 
 module.exports = () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ function getCacheKeyForBabelConfigItem(configItem) {
     options: configItem.options,
     name: configItem.name,
   };
-  const pathSegments = configItem.file.resolved.split('/');
+  const pathSegments = configItem.file.resolved.split(path.sep);
   while (!('version' in cacheKey)) {
     pathSegments.pop();
     const packagePath = [...pathSegments, 'package.json'].join('/');
@@ -58,11 +58,13 @@ function makeBabelLoaderConfig({shouldCache = false} = {}) {
 }
 function matchModule(modulePath) {
   const modulePattern = new RegExp(
-    escapeRegExp(path.join('/node_modules', modulePath)),
+    escapeRegExp(path.join(path.sep, 'node_modules', modulePath)),
     'u',
   );
   const moduleDependencyPattern = new RegExp(
-    escapeRegExp(path.join('/node_modules', modulePath, 'node_modules')),
+    escapeRegExp(
+      path.join(path.sep, 'node_modules', modulePath, 'node_modules'),
+    ),
     'u',
   );
 
@@ -91,7 +93,12 @@ module.exports = (env = process.env.NODE_ENV || 'development') => {
       failOnError: true,
     }),
     new webpack.NormalModuleReplacementPlugin(
-      /node_modules\/stylelint\/lib\/requireRule.js$/u,
+      new RegExp(
+        `${escapeRegExp(
+          path.join('node_modules', 'stylelint', 'lib', 'requireRule.js'),
+        )}$`,
+        'u',
+      ),
       path.resolve(__dirname, 'src/patches/stylelint/lib/requireRule.js'),
     ),
   ];


### PR DESCRIPTION
In cases where we are inspecting paths from the filesystem, we should be agnostic to path separator, instead using the built-in functions available in the `path` module.

I don’t think this is necessary when _writing_ paths, as I believe Node normalizes paths using `/` on Windows.