### PR TITLE
Development environment fixes

### DIFF
--- a/config/lintignore
+++ b/config/lintignore
@@ -1,5 +1,6 @@
 /.cache
 /bower_components
+/dist
 /node_modules
 /nodeenv
 /test/data

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -78,11 +78,13 @@ def _symlink_vscode_config():
         gitignore_path = os.path.join(POPCODE_ROOT, '.git', 'info', 'exclude')
         if not os.path.exists(os.path.dirname(gitignore_path)):
             os.mkdir(os.path.dirname(gitignore_path))
-        with open(gitignore_path, 'r') as gitignore_r:
-            needs_vscode_in_gitignore = not '.vscode' in gitignore_r
+        needs_vscode_in_gitignore = True
+        if os.path.exists(gitignore_path):
+            with open(gitignore_path, 'r') as gitignore_r:
+                needs_vscode_in_gitignore = not '.vscode' in gitignore_r
         if needs_vscode_in_gitignore:
             with open(gitignore_path, 'a') as gitignore_a:
-                gitignore_a.writelines([".vscode"])
+                gitignore_a.writelines(['/.vscode\n'])
 
 def _print_success_message():
     yarn_path = os.path.join('tools', 'yarn.py')


### PR DESCRIPTION
* Add `/dist` to linter ignore
* Check for existence of `.git/info/exclude` before trying to write to it
* Add newline after entry in `.git/info/exclude`

Fixes #1735 