### PR TITLE
Ensure environment is up to date from all tools commands

### DIFF
--- a/tools/node.py
+++ b/tools/node.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 from util import nodeenv_delegate
+from setup import setup
 
 if __name__ == '__main__':
+    setup()
     nodeenv_delegate('node')

--- a/tools/npx.py
+++ b/tools/npx.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 from util import nodeenv_delegate
+from setup import setup
 
 if __name__ == '__main__':
+    setup(skip_dependencies=True)
     nodeenv_delegate('npx')

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -77,6 +77,7 @@ def _install_dependencies():
     run_in_nodeenv(['yarn',
                     'install',
                     '--frozen-lockfile',
+                    '--check-files',
                     '--non-interactive',
                     '--no-progress',
                     '--silent'])

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -77,10 +77,8 @@ def _install_dependencies():
     run_in_nodeenv(['yarn',
                     'install',
                     '--frozen-lockfile',
-                    '--check-files',
                     '--non-interactive',
-                    '--no-progress',
-                    '--silent'])
+                    '--no-progress'])
 
 def _symlink_vscode_config():
     vscode_dir = os.path.join(POPCODE_ROOT, '.vscode')
@@ -115,7 +113,7 @@ or
   {yarn_path} run autotest.karma
 """.format(yarn_path=yarn_path))
 
-def setup():
+def setup(skip_dependencies=False):
     if _is_nodeenv_installed() and not _is_nodeenv_node_version_correct():
         shutil.rmtree(NODEENV_DIR)
     if not _is_nodeenv_installed():
@@ -123,7 +121,8 @@ def setup():
         _create_nodeenv(nodeenv_package_dir)
     if not _is_yarn_version_correct():
         _install_yarn()
-    _install_dependencies()
+    if not skip_dependencies:
+        _install_dependencies()
     _symlink_vscode_config()
 
 if __name__ == "__main__":

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -57,13 +57,23 @@ def _create_nodeenv(nodeenv_package_dir):
         os.path.join(nodeenv_package_dir, 'nodeenv.py'),
         '--node=' + NODE_VERSION, NODEENV_DIR])
 
-def _install_dependencies():
+def _is_yarn_version_correct():
+    try:
+        version = _normalize_version_string(
+            run_and_capture_in_nodeenv(['yarn', '--version']))
+        return version == YARN_VERSION
+    except subprocess.CalledProcessError:
+        return False
+
+def _install_yarn():
     run_in_nodeenv(['npm', 'config', 'set', 'update-notifier', 'false'])
     run_in_nodeenv(['npm',
                     'install',
                     '--quiet',
                     '--global',
                     'yarn@{yarn_version}'.format(yarn_version=YARN_VERSION)])
+
+def _install_dependencies():
     run_in_nodeenv(['yarn',
                     'install',
                     '--frozen-lockfile',
@@ -110,6 +120,8 @@ def setup():
     if not _is_nodeenv_installed():
         nodeenv_package_dir = _install_nodeenv()
         _create_nodeenv(nodeenv_package_dir)
+    if not _is_yarn_version_correct():
+        _install_yarn()
     _install_dependencies()
     _symlink_vscode_config()
 

--- a/tools/util/__init__.py
+++ b/tools/util/__init__.py
@@ -83,8 +83,12 @@ def _has_powershell_nodeenv():
     return path.exists(NODEENV_POWERSHELL_ACTIVATE)
 
 def _run_and_capture_output(args):
-    (out, _) = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()
-    return out.decode('utf-8')
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (out, err) = process.communicate()
+    if process.returncode == 0:
+        return out.decode('utf-8')
+    else:
+        raise subprocess.CalledProcessError(returncode=process.returncode, cmd=args, output=err.decode('utf-8'))
 
 def shell_join(command):
     return ' '.join([shell_quote(arg) for arg in command])

--- a/tools/yarn.py
+++ b/tools/yarn.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python
 
+import sys
+from setup import setup
 from util import nodeenv_delegate
 
+YARN_DEPENDENCY_MANAGEMENT_COMMANDS = [
+    'add',
+    'install',
+    'link',
+    'remove',
+    'unlink',
+    'upgrade',
+    'upgrade-interactive'
+]
+
 if __name__ == '__main__':
+    command = next((arg for arg in sys.argv[1:] if not arg.startswith('-')), 'install')
+    setup(skip_dependencies=(command in YARN_DEPENDENCY_MANAGEMENT_COMMANDS))
     nodeenv_delegate('yarn')


### PR DESCRIPTION
Running a `tools/` command should implicitly guarantee that the environment is correctly set up. To support this:

* Streamline `tools/setup.py` for the no-op case, in particular cheaply checking if the correct version of `yarn` is installed before installing it
* Add calls to `setup()` from relevant `tools/` scripts; in some cases, we skip installing node module dependencies via yarn (e.g. if you invoke `yarn.py` with an installation-related command)