### PR TITLE
Automerge test-only dependencies

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -20,6 +20,7 @@
     },
     {
       "groupName": "eslint",
+      "automerge": true,
       "packageNames": [
         "eslint",
         "eslint-config-prettier",
@@ -52,11 +53,13 @@
     },
     {
       "groupName": "Jest",
+      "automerge": true,
       "packageNames": ["jest", "jest-extended"]
     },
 
     {
       "groupName": "Karma",
+      "automerge": true,
       "packageNames": [
         "karma",
         "karma-browserstack-launcher",
@@ -105,6 +108,7 @@
     },
     {
       "groupName": "stylelint",
+      "automerge": true,
       "packageNames": [
         "stylelint",
         "stylelint-config-prettier",
@@ -114,6 +118,7 @@
     },
     {
       "groupName": "Tape",
+      "automerge": true,
       "packageNames": ["tape", "tape-catch"]
     },
     {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -152,6 +152,10 @@
         "webpack-dev-middleware",
         "webpack-visualizer-plugin"
       ]
+    },
+    {
+      "packagePatterns": ["yarn-deduplicate"],
+      "automerge": true
     }
   ],
   "patch": {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -73,6 +73,11 @@
       ]
     },
     {
+      "groupName": "lodash",
+      "packageNames": ["lodash"],
+      "packagePatterns": ["^lodash\\."]
+    },
+    {
       "groupName": "Node.js",
       "packageNames": ["node"],
       "automerge": false

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -74,7 +74,7 @@
     },
     {
       "groupName": "lodash",
-      "packageNames": ["lodash"],
+      "packageNames": ["lodash-es"],
       "packagePatterns": ["^lodash\\."]
     },
     {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -154,7 +154,16 @@
       ]
     },
     {
-      "packagePatterns": ["yarn-deduplicate"],
+      "packagePatterns": [
+        "browser-sync",
+        "doctoc",
+        "is-docker",
+        "jscodeshift",
+        "prettier",
+        "sinon",
+        "rosie",
+        "yarn-deduplicate"
+      ],
       "automerge": true
     }
   ],


### PR DESCRIPTION
For dependencies that are only used when linting/testing, a green build is by definition sufficient to ensure that they did not break anything. So, automerge those dependencies.

Also adds a group for `lodash` and the individual `lodash.*` packages used in build scripts, so they stay in sync.