### PR TITLE
Switch from react-onclickoutside to use-onclickoutside

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,6 @@
     "react-dom": "16.10.2",
     "react-draggable": "3.3.2",
     "react-immutable-proptypes": "2.1.0",
-    "react-onclickoutside": "6.7.1",
     "react-prevent-clickthrough": "0.0.3",
     "react-redux": "7.1.1",
     "reduce-reducers": "1.0.4",
@@ -267,6 +266,7 @@
     "strip-markdown": "3.1.1",
     "stylelint": "11.1.1",
     "sweetalert2": "7.28.13",
+    "use-onclickoutside": "^0.3.1",
     "uuid": "3.3.3",
     "void-elements": "3.1.0",
     "whatwg-fetch": "3.0.0"

--- a/src/components/TopBar/createMenu.jsx
+++ b/src/components/TopBar/createMenu.jsx
@@ -4,11 +4,10 @@ import classnames from 'classnames';
 import {connect} from 'react-redux';
 import constant from 'lodash-es/constant';
 import noop from 'lodash-es/noop';
-import onClickOutside from 'react-onclickoutside';
+import useOnClickOutside from 'use-onclickoutside';
 import preventClickthrough from 'react-prevent-clickthrough';
-import property from 'lodash-es/property';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useRef} from 'react';
 
 import {closeTopBarMenu, toggleTopBarMenu} from '../../actions';
 import {getOpenTopBarMenu} from '../../selectors';
@@ -37,6 +36,7 @@ MenuItem.propTypes = {
 MenuItem.defaultProps = {
   isActive: false,
   isDisabled: false,
+  isOpen: false,
 };
 
 export default function createMenu({
@@ -50,7 +50,6 @@ export default function createMenu({
     const isOpen = getOpenTopBarMenu(state) === name;
     return {
       isOpen,
-      disableOnClickOutside: !isOpen,
     };
   }
 
@@ -72,7 +71,10 @@ export default function createMenu({
         return null;
       }
 
-      const {isOpen, onToggle} = props;
+      const {isOpen, onClose, onToggle} = props;
+      const ref = useRef(null);
+      useOnClickOutside(ref, isOpen ? onClose : noop);
+
       const menu = isOpen ? (
         <div
           className={classnames('top-bar__menu', menuClass)}
@@ -86,6 +88,7 @@ export default function createMenu({
           className={classnames('top-bar__menu-button', buttonClass, {
             'top-bar__menu-button_active': isOpen,
           })}
+          ref={ref}
           onClick={onToggle}
         >
           <MenuLaunchButton {...props} />
@@ -98,12 +101,13 @@ export default function createMenu({
 
     Menu.propTypes = {
       isOpen: PropTypes.bool.isRequired,
+      onClose: PropTypes.func.isRequired,
       onToggle: PropTypes.func.isRequired,
     };
 
     return connect(
       mapStateToProps,
       mapDispatchToProps,
-    )(onClickOutside(Menu, {handleClickOutside: property('props.onClose')}));
+    )(Menu);
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,6 +1957,11 @@ archy@^1.0.0:
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
+are-passive-events-supported@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/are-passive-events-supported/-/are-passive-events-supported-1.1.1.tgz#3db180a1753a2186a2de50a32cded3ac0979f5dc"
+  integrity sha512-5wnvlvB/dTbfrCvJ027Y4L4gW/6Mwoy1uFSavney0YO++GU+0e/flnjiBBwH+1kh7xNCgCOGvmJC3s32joYbww==
+
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
@@ -11211,11 +11216,6 @@ react-lowlight@^1.0.4:
     lowlight "^1.0.0"
     prop-types "^15.5.8"
 
-react-onclickoutside@6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
-  integrity sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==
-
 react-prevent-clickthrough@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/react-prevent-clickthrough/-/react-prevent-clickthrough-0.0.3.tgz#42d5cd85d7dd76dbb5862062ee7c70f1056edb80"
@@ -13923,6 +13923,19 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-latest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.0.0.tgz#c86d2e4893b15f27def69da574a47136d107facb"
+  integrity sha512-CxmFi75KTXeTIBlZq3LhJ4Hz98pCaRKZHCpnbiaEHIr5QnuHvH8lKYoluPBt/ik7j/hFVPB8K3WqF6mQvLyQTg==
+
+use-onclickoutside@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/use-onclickoutside/-/use-onclickoutside-0.3.1.tgz#fdd723a6a499046b6bc761e4a03af432eee5917b"
+  integrity sha512-aahvbW5+G0XJfzj31FJeLsvc6qdKbzeTsQ8EtkHHq5qTg6bm/qkJeKLcgrpnYeHDDbd7uyhImLGdkbM9BRzOHQ==
+  dependencies:
+    are-passive-events-supported "^1.1.0"
+    use-latest "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Upgrading `react-onclickoutside` to the latest version broke its behavior for reasons I wasn’t able to fully unravel, but ultimately I have always found its approach a little clunky. Switch to [`use-onclickoutside`](https://github.com/Andarist/use-onclickoutside), which just exposes a nice little hook that takes a `ref`. And it works!