### PR TITLE
Yarn-related improvements

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
---add.exact
---upgrade.exact
---upgrade-interactive.exact
+--add.exact true
+--upgrade.exact true
+--upgrade-interactive.exact true

--- a/contrib/vscode/extensions.json
+++ b/contrib/vscode/extensions.json
@@ -6,6 +6,7 @@
     "dbaeumer.vscode-eslint",
     "dsznajder.es7-react-js-snippets",
     "esbenp.prettier-vscode",
+    "gamunu.vscode-yarn",
     "github.vscode-pull-request-github",
     "msjsdiag.debugger-for-chrome",
     "shinnn.stylelint",

--- a/contrib/vscode/settings.json
+++ b/contrib/vscode/settings.json
@@ -17,6 +17,7 @@
   "travis.username": "popcodeorg",
   "travis.repository": "popcode",
   "travis.pro": true,
+  "yarn.bin": "./tools/yarn.py",
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   }

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "strip-markdown": "3.1.1",
     "stylelint": "11.1.1",
     "sweetalert2": "7.33.1",
-    "use-onclickoutside": "^0.3.1",
+    "use-onclickoutside": "0.3.1",
     "uuid": "3.3.3",
     "void-elements": "3.1.0",
     "whatwg-fetch": "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13949,7 +13949,7 @@ use-latest@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.0.0.tgz#c86d2e4893b15f27def69da574a47136d107facb"
   integrity sha512-CxmFi75KTXeTIBlZq3LhJ4Hz98pCaRKZHCpnbiaEHIr5QnuHvH8lKYoluPBt/ik7j/hFVPB8K3WqF6mQvLyQTg==
 
-use-onclickoutside@^0.3.1:
+use-onclickoutside@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/use-onclickoutside/-/use-onclickoutside-0.3.1.tgz#fdd723a6a499046b6bc761e4a03af432eee5917b"
   integrity sha512-aahvbW5+G0XJfzj31FJeLsvc6qdKbzeTsQ8EtkHHq5qTg6bm/qkJeKLcgrpnYeHDDbd7uyhImLGdkbM9BRzOHQ==


### PR DESCRIPTION
* Fixes `.yarnrc` syntax so that we are, in fact, pinning versions on install
* Adds `vscode-yarn` to recommended extensions and configures it to use `tools/yarn.py`
* Pins the version of recently-installed `use-onclickoutside`