### PR TITLE
Revert "Allow tel: and mailto: patterns in href attributes"

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -154,7 +154,7 @@
       "doctype": "The first line of your HTML should always be:\n`<!DOCTYPE html>`",
       "duplicated-id": "You can't use the id \"{{-id}}\" more than once in your HTML",
       "img-src": "`<img>` tags need a `src` attribute, with the URL of the image you want to display.",
-      "href-style": "The `<a>` tag should have an `href` attribute with a value that starts with `http://`, `https://`, `mailto:`, or `tel:`",
+      "href-style": "The `<a>` tag should have an `href` attribute that starts with 'http' or 'https'",
       "deprecated-tag": {
         "b": "You shouldn't use the `<b>` tag. Use the `<strong>` tag or the CSS `font-weight` property instead",
         "big": "You shouldn't use the `<big>` tag. Use the CSS `font-size` property instead",
@@ -247,17 +247,29 @@
     },
     "javascriptRuntime": {
       "not-a-function_with-name": "You tried to call `{{-name}}()` as a function, but `{{-name}}` is not a function.",
+
       "not-a-function_with-name-type": "You tried to call `{{-name}}()` as a function, but `{{-name}}` is a `{{-type}}`, not a function.",
+
       "not-a-function_with-name-value": "You tried to call `{{-name}}()` as a function, but `{{-name}}` is `{{-value}}`, which is not a function.",
+
       "undefined-not-a-function_with-name": "You tried to call `{{-name}}()` as a function, but `{{-name}}` does not have a value.",
+
       "null-not-a-function_with-name": "You tried to call `{{-name}}()` as a function, but `{{-name}}` is null.",
+
       "access-property-of-undefined": "You are trying to access a property of something that doesn't have a value.",
+
       "access-property-of-null": "You are trying to access a property of a null value.",
+
       "access-property-of-undefined_with-name": "You are trying to access a property of `{{-name}}`, but `{{-name}}` doesn't have a value.",
+
       "access-property-of-null_with-name": "You are trying to access a property of a `{{-name}}`, but `{{-name}}` is null.",
+
       "read-property-of-undefined_with-property": "You are trying to access the property `{{-property}}` on something that doesn't have a value.",
+
       "read-property-of-null_with-property": "You are trying to access the property `{{-property}}` on a null value.",
+
       "set-property-of-undefined_with-property": "You are trying to set the property `{{-property}}` on something that doesn't have a value.",
+
       "set-property-of-null_with-property": "You are trying to set the property `{{-property}}` on a null value.",
       "infinite-loop": "There is a loop in your code that looks like it might run forever. Check the loop to make sure it has the right stopping condition."
     }

--- a/src/validations/__tests__/html.test.js
+++ b/src/validations/__tests__/html.test.js
@@ -45,28 +45,6 @@ describe('html validation', () => {
   test('<a> tag with fragment-only URL href', () =>
     validationTest(htmlWithBody('<a href="#fragment">Fragment</a>'), html));
 
-  test('<a> tag with improper href property', () =>
-    validationTest(
-      htmlWithBody('<a href="random-string">Invalid href</a>'),
-      html,
-      {
-        reason: 'href-style',
-        row: htmlWithBody.offset,
-      },
-    ));
-
-  test('<a> tag with mailto: href property', () =>
-    validationTest(
-      htmlWithBody('<a href="mailto:popcode@example.com">Email Popcode</a>'),
-      html,
-    ));
-
-  test('<a> tag with tel: href property', () =>
-    validationTest(
-      htmlWithBody('<a href="tel:1231231234">Call Someone</a>'),
-      html,
-    ));
-
   test('missing doctype', () =>
     validationTest('<html></html>', html, {reason: 'doctype', row: 0}));
 

--- a/src/validations/html/htmllint.js
+++ b/src/validations/html/htmllint.js
@@ -5,8 +5,6 @@ import reduce from 'lodash-es/reduce';
 
 import Validator from '../Validator';
 
-const domParser = new DOMParser();
-
 const errorMap = {
   E001: error => {
     switch (error.data.attribute.toLowerCase()) {
@@ -48,17 +46,7 @@ const errorMap = {
 
   E008: () => ({reason: 'doctype'}),
 
-  E009: (error, source) => {
-    const lines = source.split('\n');
-    const anchorString = lines[error.line - 1].slice(error.column - 1);
-    const doc = domParser.parseFromString(anchorString, 'text/html');
-    const hrefVal = doc.querySelector('a').attributes.href.value;
-
-    if (hrefVal.startsWith('mailto:') || hrefVal.startsWith('tel:')) {
-      return null;
-    }
-    return {reason: 'href-style'};
-  },
+  E009: () => ({reason: 'href-style'}),
 
   E012: error => ({reason: 'duplicated-id', payload: {id: error.data.id}}),
 


### PR DESCRIPTION
Reverts popcodeorg/popcode#1856

Rolling back because #1894 looks fairly bad—the validation loop permanently crashes when the validator sees an unfinished `<a  href`, which is bound to be very likely in the normal course of typing HTML.