### PR TITLE
Fix hook order in createMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,6 +337,7 @@
     "eslint-plugin-private-props": "0.3.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.16.0",
+    "eslint-plugin-react-hooks": "2.1.2",
     "eslint_d": "8.0.0",
     "exports-loader": "0.7.0",
     "gulp": "4.0.2",

--- a/src/components/TopBar/createMenu.jsx
+++ b/src/components/TopBar/createMenu.jsx
@@ -67,13 +67,13 @@ export default function createMenu({
 
   return function createMenuWithMappedProps(MenuLaunchButton) {
     function Menu(props) {
+      const ref = useRef(null);
+      const {isOpen, onClose, onToggle} = props;
+      useOnClickOutside(ref, isOpen ? onClose : noop);
+
       if (!isVisible(props)) {
         return null;
       }
-
-      const {isOpen, onClose, onToggle} = props;
-      const ref = useRef(null);
-      useOnClickOutside(ref, isOpen ? onClose : noop);
 
       const menu = isOpen ? (
         <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -4923,6 +4923,11 @@ eslint-plugin-promise@4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
   integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
+eslint-plugin-react-hooks@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.1.2.tgz#1358d2acb2c5e02b7e90c37e611ac258a488e3a7"
+  integrity sha512-ZR+AyesAUGxJAyTFlF3MbzeVHAcQTFQt1fFVe5o0dzY/HFoj1dgQDMoIkiM+ltN/HhlHBYX4JpJwYonjxsyQMA==
+
 eslint-plugin-react@7.16.0:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz#9928e4f3e2122ed3ba6a5b56d0303ba3e41d8c09"


### PR DESCRIPTION
Fixes the order of hooks in `createMenu`; also adds `eslint-plugin-react-hooks` to catch any future problems along these lines.