### PR TITLE
Actually use react-hooks linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,7 +147,14 @@
     }
   ],
   "parser": "babel-eslint",
-  "plugins": ["import", "react", "prettier", "promise", "private-props"],
+  "plugins": [
+    "import",
+    "prettier",
+    "private-props",
+    "promise",
+    "react",
+    "react-hooks"
+  ],
   "rules": {
     "accessor-pairs": "error",
     "camelcase": [
@@ -344,6 +351,8 @@
         "callbacksLast": true
       }
     ],
+    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/rules-of-hooks": "error",
     "require-atomic-updates": "warn",
     "require-unicode-regexp": "warn",
     "require-yield": "error",


### PR DESCRIPTION
In #1896 I added `eslint-plugin-react-hooks` to dependencies but forgot to actually add it to the config or enable any rules.