### PR TITLE
Upgrade Node to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:10.16.3
+FROM node:12.13.0
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
         apt-get update && \
         apt-get install -y google-chrome-stable
 
-ENV YARN_VERSION 1.19.0
+ENV YARN_VERSION 1.19.1
 
 RUN curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \

--- a/package.json
+++ b/package.json
@@ -276,8 +276,8 @@
     "whatwg-fetch": "3.0.0"
   },
   "engines": {
-    "node": "10.16.3",
-    "yarn": "~1.19.0"
+    "node": "12.13.0",
+    "yarn": "~1.19.1"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
Upgrades build/test runtime to Node 12, which is now in LTS. Also bump yarn to the latest patchlevel while we’re in there.