### PR TITLE
fix: handle duplicate js variable declaration

### DIFF
--- a/src/validations/__tests__/javascript.test.js
+++ b/src/validations/__tests__/javascript.test.js
@@ -72,6 +72,18 @@ describe('javascript validation', () => {
       partialRight(javascript, analyzer),
     ));
 
+  test('duplicated variable declaration', () =>
+    validationTest(
+      `let a = 1;
+      let a = 2;`,
+      partialRight(javascript, analyzer),
+      {
+        reason: 'duplicated-declaration',
+        row: 1,
+        payload: {variable: 'a'},
+      },
+    ));
+
   testValidatorAcceptance(
     partialRight(javascript, analyzerWithjQuery),
     'javascript',

--- a/src/validations/javascript/jshint.js
+++ b/src/validations/javascript/jshint.js
@@ -31,6 +31,11 @@ const match = {
 };
 
 const errorMap = {
+  E011: error => ({
+    reason: 'duplicated-declaration',
+    payload: {variable: error.a},
+  }),
+
   E019: error => ({
     reason: 'unmatched',
     payload: {openingSymbol: error.a, closingSymbol: match[error.a]},


### PR DESCRIPTION
This fix will show a helpful error message for multiple declarations using ES6 syntax (let/const). Doesn't do anything for multiple var declarations with the same name.

This is my first PR to Popcode, should I add tests? If so could you tell me where I should be looking for tests in a similar vein? Thanks!