### PR TITLE
Add eslint-plugin-lodash

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "eslint:recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
+    "plugin:lodash/recommended",
     "plugin:react/recommended",
     "plugin:promise/recommended",
     "plugin:prettier/recommended"
@@ -54,7 +55,8 @@
       },
       "rules": {
         "import/no-commonjs": "off",
-        "import/no-nodejs-modules": "off"
+        "import/no-nodejs-modules": "off",
+        "lodash/import-scope": ["warn", "method-package"]
       },
       "settings": {
         "import/resolver": "node"
@@ -86,7 +88,7 @@
         "jest/valid-expect": "error",
         "jest/prefer-called-with": "warn"
       },
-      "plugins": ["import", "jest", "react", "promise", "private-props"],
+      "plugins": ["import", "jest", "lodash", "react", "prettier", "promise", "private-props"],
       "settings": {
         "import/resolver": {
           "@popcodeorg/eslint-import-resolver-jest": {
@@ -149,6 +151,7 @@
   "parser": "babel-eslint",
   "plugins": [
     "import",
+    "lodash",
     "prettier",
     "private-props",
     "promise",
@@ -230,6 +233,39 @@
       }
     ],
     "import/unambiguous": "warn",
+    "lodash/chain-style": "warn",
+    "lodash/chaining": "warn",
+    "lodash/collection-ordering": "warn",
+    "lodash/consistent-compose": "warn",
+    "lodash/identity-shorthand": "warn",
+    "lodash/import-scope": "warn",
+    "lodash/matches-prop-shorthand": "warn",
+    "lodash/matches-shorthand": "warn",
+    "lodash/path-style": ["warn", "array"],
+    "lodash/prefer-compact": "warn",
+    "lodash/prefer-constant": "warn",
+    "lodash/prefer-filter": "warn",
+    "lodash/prefer-find": "warn",
+    "lodash/prefer-flat-map": "warn",
+    "lodash/prefer-get": "warn",
+    "lodash/prefer-includes": "warn",
+    "lodash/prefer-invoke-map": "warn",
+    "lodash/prefer-is-nil": "warn",
+    "lodash/prefer-lodash-chain": "warn",
+    "lodash/prefer-lodash-method": "off",
+    "lodash/prefer-lodash-typecheck": "warn",
+    "lodash/prefer-map": "warn",
+    "lodash/prefer-matches": "warn",
+    "lodash/prefer-noop": "warn",
+    "lodash/prefer-over-quantifier": "warn",
+    "lodash/prefer-reject": "warn",
+    "lodash/prefer-some": "warn",
+    "lodash/prefer-startswith": "warn",
+    "lodash/prefer-thru": "warn",
+    "lodash/prefer-times": "warn",
+    "lodash/prefer-wrapper-method": "warn",
+    "lodash/preferred-alias": "warn",
+    "lodash/prop-shorthand": "warn",
     "new-cap": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,7 +88,15 @@
         "jest/valid-expect": "error",
         "jest/prefer-called-with": "warn"
       },
-      "plugins": ["import", "jest", "lodash", "react", "prettier", "promise", "private-props"],
+      "plugins": [
+        "import",
+        "jest",
+        "lodash",
+        "react",
+        "prettier",
+        "promise",
+        "private-props"
+      ],
       "settings": {
         "import/resolver": {
           "@popcodeorg/eslint-import-resolver-jest": {

--- a/package.json
+++ b/package.json
@@ -335,6 +335,7 @@
     "eslint-loader": "3.0.2",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "23.1.1",
+    "eslint-plugin-lodash": "6.0.0",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-private-props": "0.3.0",
     "eslint-plugin-promise": "4.2.1",

--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -277,7 +277,7 @@ export function getSessionUid() {
 }
 
 export function setSessionUid() {
-  const uid = get(auth, 'currentUser.uid');
+  const uid = get(auth, ['currentUser', 'uid']);
   if (!isNil(uid)) {
     Cookies.set(VALID_SESSION_UID_COOKIE, uid, {
       expires: new Date(Date.now() + SESSION_TTL_MS),

--- a/src/components/ConsoleInput.jsx
+++ b/src/components/ConsoleInput.jsx
@@ -41,7 +41,7 @@ export default class ConsoleInput extends Component {
   }
 
   _focusRequestedLine(requestedFocusedLine) {
-    if (get(requestedFocusedLine, 'component') !== 'console') {
+    if (get(requestedFocusedLine, ['component']) !== 'console') {
       return;
     }
 

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -80,7 +80,8 @@ class Editor extends React.Component {
 
   _focusRequestedLine(requestedFocusedLine) {
     if (
-      get(requestedFocusedLine, 'component') !== `editor.${this.props.language}`
+      get(requestedFocusedLine, ['component']) !==
+      `editor.${this.props.language}`
     ) {
       return;
     }

--- a/src/components/ErrorReport.jsx
+++ b/src/components/ErrorReport.jsx
@@ -15,7 +15,7 @@ function ErrorReport({errors, isValidating, onErrorClick}) {
     );
   }
 
-  const hasErrors = Boolean(find(errors, list => list.items.length));
+  const hasErrors = Boolean(find(errors, 'items.length'));
   if (!hasErrors) {
     return null;
   }

--- a/src/containers/AssignmentCreatorForm.js
+++ b/src/containers/AssignmentCreatorForm.js
@@ -14,7 +14,7 @@ function validate(values) {
   if (isEmpty(course)) {
     errors.course = i18next.t('assignment-creator.no-class-selected');
   }
-  if (isNil(get(date, 'parsedDate'))) {
+  if (isNil(get(date, ['parsedDate']))) {
     errors.date = i18next.t('assignment-creator.date-not-valid');
   } else if (date.parsedDate < Date.now()) {
     errors.date = i18next.t('assignment-creator.past-date-not-valid');

--- a/src/createApplicationStore.js
+++ b/src/createApplicationStore.js
@@ -14,14 +14,14 @@ import {bugsnagClient} from './util/bugsnag';
 
 const compose = get(
   window,
-  '__REDUX_DEVTOOLS_EXTENSION_COMPOSE__',
+  ['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'],
   composeWithoutDevTools,
 );
 
 export default function createApplicationStore() {
   const sagaMiddleware = createSagaMiddleware({
     onError(error) {
-      if (get(console, 'error')) {
+      if (get(console, ['error'])) {
         // eslint-disable-next-line no-console
         console.error(error);
       }

--- a/src/higherOrderComponents/resizableFlex/index.js
+++ b/src/higherOrderComponents/resizableFlex/index.js
@@ -1,4 +1,5 @@
 import {connectAdvanced} from 'react-redux';
+import constant from 'lodash-es/constant';
 import at from 'lodash-es/at';
 import findIndex from 'lodash-es/findIndex';
 import isNull from 'lodash-es/isNull';
@@ -29,7 +30,7 @@ export default function resizableFlex(size) {
   return connectAdvanced(
     dispatch => {
       const regions = times(size, () => ({current: null}));
-      const initialMainSizes = times(size, () => null);
+      const initialMainSizes = times(size, constant(null));
 
       const stateIndependentFunctions = {
         isFlexResizingSupported: true,

--- a/src/higherOrderComponents/resizableFlex/sham.js
+++ b/src/higherOrderComponents/resizableFlex/sham.js
@@ -1,3 +1,4 @@
+import constant from 'lodash-es/constant';
 import {List} from 'immutable';
 import React from 'react';
 import times from 'lodash-es/times';
@@ -6,7 +7,7 @@ import noop from 'lodash-es/noop';
 export default function resizableFlex(size) {
   const props = {
     isFlexResizingSupported: false,
-    resizableFlexGrow: new List(times(size, () => null)),
+    resizableFlexGrow: new List(times(size, constant(null))),
     resizableFlexRefs: times(size, () => noop),
     onResizableFlexDividerDrag: noop,
   };

--- a/src/init/DOMParserShim.js
+++ b/src/init/DOMParserShim.js
@@ -1,3 +1,5 @@
+import includes from 'lodash-es/includes';
+
 const proto = DOMParser.prototype;
 const nativeParse = proto.parseFromString;
 
@@ -13,7 +15,7 @@ if (!isParsingNativelySupported()) {
   proto.parseFromString = function parseFromString(markup, type, ...rest) {
     if (/^\s*text\/html\s*(?:;|$)/iu.test(type)) {
       const doc = document.implementation.createHTMLDocument('');
-      if (markup.toLowerCase().indexOf('<!doctype') > -1) {
+      if (includes(markup.toLowerCase(), '<!doctype')) {
         doc.documentElement.innerHTML = markup;
       } else {
         doc.body.innerHTML = markup;

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -39,22 +39,19 @@ function unhideComponent(state, projectKey, component, timestamp) {
 }
 
 function contentForLanguage(files, language) {
-  const filesForLanguage = sortBy(
-    filter(files, {language}),
-    file => file.filename,
-  );
+  const filesForLanguage = sortBy(filter(files, {language}), 'filename');
   return map(filesForLanguage, 'content').join('\n\n');
 }
 
 function importGist(state, projectKey, gistData) {
   const files = values(gistData.files);
   const popcodeJsonFile = find(files, {filename: 'popcode.json'});
-  const popcodeJson = JSON.parse(get(popcodeJsonFile, 'content', '{}'));
+  const popcodeJson = JSON.parse(get(popcodeJsonFile, ['content'], '{}'));
 
   return addProject(state, {
     projectKey,
     sources: {
-      html: get(find(files, {language: 'HTML'}), 'content', ''),
+      html: get(find(files, {language: 'HTML'}), ['content'], ''),
       css: contentForLanguage(files, 'CSS'),
       javascript: contentForLanguage(files, 'JavaScript'),
     },

--- a/src/sagas/compiledProjects.js
+++ b/src/sagas/compiledProjects.js
@@ -9,7 +9,7 @@ import {projectCompiled, projectCompilationFailed} from '../actions';
 
 export function* validatedSource() {
   const errors = yield select(getErrors);
-  if (every(errors, errorList => errorList.state === 'passed')) {
+  if (every(errors, {state: 'passed'})) {
     const currentProject = yield select(getCurrentProject);
     const timestamp = Date.now();
     try {

--- a/src/sagas/projects.js
+++ b/src/sagas/projects.js
@@ -77,7 +77,7 @@ export function* importGist({payload: {gistId}}) {
     const gistData = yield call(loadGistFromId, gistId);
     yield put(gistImported(generateProjectKey(), gistData));
   } catch (error) {
-    if (get(error, 'response.status') === 404) {
+    if (get(error, ['response', 'status']) === 404) {
       yield put(gistNotFound(gistId));
     } else {
       yield put(gistImportError());

--- a/src/selectors/getCurrentCompiledProjectKey.js
+++ b/src/selectors/getCurrentCompiledProjectKey.js
@@ -1,5 +1,5 @@
 import get from 'lodash-es/get';
 
 export default function getCurrentCompiledProjectKey(state) {
-  return get(state.get('compiledProjects').last(), 'compiledProjectKey');
+  return get(state.get('compiledProjects').last(), ['compiledProjectKey']);
 }

--- a/src/selectors/getCurrentProjectPreviewTitle.js
+++ b/src/selectors/getCurrentProjectPreviewTitle.js
@@ -5,6 +5,6 @@ import getCompiledProjects from './getCompiledProjects';
 
 export default createSelector([getCompiledProjects], compiledProjects => {
   const mostRecentCompiledProject = compiledProjects.last();
-  const title = get(mostRecentCompiledProject, 'title', '');
+  const title = get(mostRecentCompiledProject, ['title'], '');
   return title;
 });

--- a/src/selectors/getHiddenUIComponents.js
+++ b/src/selectors/getHiddenUIComponents.js
@@ -4,5 +4,5 @@ import {createSelector} from 'reselect';
 import getCurrentProject from './getCurrentProject';
 
 export default createSelector([getCurrentProject], currentProject =>
-  get(currentProject, 'hiddenUIComponents', []),
+  get(currentProject, ['hiddenUIComponents'], []),
 );

--- a/src/util/performWithRetries.js
+++ b/src/util/performWithRetries.js
@@ -1,9 +1,10 @@
 import assign from 'lodash-es/assign';
+import constant from 'lodash-es/constant';
 import promiseRetry from 'promise-retry';
 
 export default function performWithRetries(
   perform,
-  shouldRetryFn = () => false,
+  shouldRetryFn = constant(false),
   options = {},
 ) {
   return promiseRetry(

--- a/src/validations/__tests__/validationHelper.js
+++ b/src/validations/__tests__/validationHelper.js
@@ -1,5 +1,5 @@
 import map from 'lodash-es/map';
-import orderBy from 'lodash-es/orderBy';
+import sortBy from 'lodash-es/sortBy';
 import pick from 'lodash-es/pick';
 
 export default async function validationTest(
@@ -9,8 +9,8 @@ export default async function validationTest(
 ) {
   const errors = await validate(input);
   expect(
-    map(orderBy(errors, ['reason', 'row']), error =>
+    map(sortBy(errors, ['reason', 'row']), error =>
       pick(error, ['reason', 'row', 'payload']),
     ),
-  ).toEqual(orderBy(expectedErrors, ['reason', 'row']));
+  ).toEqual(sortBy(expectedErrors, ['reason', 'row']));
 }

--- a/src/validations/html/rules/MismatchedTag.js
+++ b/src/validations/html/rules/MismatchedTag.js
@@ -36,10 +36,7 @@ export default class MismatchedTag {
   }
 
   closeTag(location, name) {
-    const openIndex = findLastIndex(
-      this._openTagStack,
-      openTag => openTag.name === name,
-    );
+    const openIndex = findLastIndex(this._openTagStack, {name});
 
     const isOpened = openIndex >= 0;
     if (isOpened) {

--- a/src/validations/html/rules/NodeOutsideBody.js
+++ b/src/validations/html/rules/NodeOutsideBody.js
@@ -31,10 +31,7 @@ export default class NodeOutsideBody {
   }
 
   closeTag(location, name) {
-    const openIndex = findLastIndex(
-      this._openTagStack,
-      openTag => openTag.name === name,
-    );
+    const openIndex = findLastIndex(this._openTagStack, {name});
 
     const isOpened = openIndex >= 0;
     if (isOpened) {

--- a/test/unit/sagas/ui.js
+++ b/test/unit/sagas/ui.js
@@ -1,4 +1,6 @@
 import test from 'tape-catch';
+import noop from 'lodash-es/noop';
+
 import {testSaga} from 'redux-saga-test-plan';
 import {
   userDoneTyping as userDoneTypingSaga,
@@ -66,7 +68,7 @@ test('exportProject', t => {
   });
 
   t.test('with project export error', assert => {
-    const mockWindow = {closed: false, close() {}};
+    const mockWindow = {closed: false, close: noop};
     const exportType = 'gist';
     testSaga(exportProjectSaga)
       .next()
@@ -83,7 +85,7 @@ test('exportProject', t => {
 });
 
 test('popOutProject', assert => {
-  const mockWindow = {closed: false, close() {}};
+  const mockWindow = {closed: false, close: noop};
   const project = {};
   const preview = {src: '<html></html>'};
   testSaga(popOutProjectSaga, popOutProject())

--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,6 +4982,13 @@ eslint-plugin-jest@23.1.1:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
+eslint-plugin-lodash@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-6.0.0.tgz#70fa487ab632e62627ecf01ad3e85c228e3ab9d3"
+  integrity sha512-iuxToisjIYAJdxWtW8OamFyc3yAsGCjU5WokvuBfTc/k5XdWOp9fAmzw+aFjj520/QXspCc8//xJpqkhYUj4qw==
+  dependencies:
+    lodash "^4.17.15"
+
 eslint-plugin-prettier@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"


### PR DESCRIPTION
Adds eslint-plugin-lodash, and enables a modified version of the recommended configuration. In particular, most rules are downgraded to warnings; and the `prefer-lodash-method` rule is turned off (it’s a bit aggressive, though I like it from a “one right way to do things” perspective). Also, the path style is set to `array`, as this is meaningfully faster per https://jsperf.com/lodash-get-string-vs-array