### PR TITLE
Make sweetalert2 last priority for upgrades

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -155,8 +155,9 @@
       ]
     },
     {
-      "packagePatterns": [
+      "packageNames": [
         "browser-sync",
+        "caniuse-lite",
         "doctoc",
         "is-docker",
         "jscodeshift",
@@ -166,6 +167,10 @@
         "yarn-deduplicate"
       ],
       "automerge": true
+    },
+    {
+      "packageNames": ["sweetalert2"],
+      "prPriority": -1
     }
   ],
   "patch": {


### PR DESCRIPTION
Sweetalert2 is constantly releasing new versions, and the changes are never relevant to us—manually reduce its priority in Renovate so that it does not get in the way of other things.

Also add `caniuse-lite` to the automatic upgrade list.