### PR TITLE
Switch to maintained Stylelint extension

### DIFF
--- a/contrib/vscode/extensions.json
+++ b/contrib/vscode/extensions.json
@@ -9,7 +9,7 @@
     "gamunu.vscode-yarn",
     "github.vscode-pull-request-github",
     "msjsdiag.debugger-for-chrome",
-    "shinnn.stylelint",
+    "thibaudcolas.stylelint",
     "wix.glean",
     "wix.vscode-import-cost"
   ],

--- a/contrib/vscode/settings.json
+++ b/contrib/vscode/settings.json
@@ -14,6 +14,7 @@
   "files.insertFinalNewline": true,
   "npm.autoDetect": "off",
   "npm.packageManager": "yarn",
+  "stylelint.enable": false,
   "travis.username": "popcodeorg",
   "travis.repository": "popcode",
   "travis.pro": true,


### PR DESCRIPTION
The old canonical VS Code stylelint extension was pulled because it is unmaintained. There are several forks but this one looks like it will probably become the new canonical: https://github.com/ilokoodi/vscode-stylelint

So, switched recommended extensions to this but it’s disabled in the config for now, because the extension ships with an outdated version of stylelint which does not recognize some newer rules that are enabled with presets we use. Per https://github.com/ilokoodi/vscode-stylelint/issues/4 this is being actively worked on; I will monitor that issue and reenable the extension once a fixed version is shipped.