### PR TITLE
Automerge all dependency upgrades except major

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -181,5 +181,6 @@
   "prConcurrentLimit": 3,
   "rebaseStalePrs": true,
   "reviewers": ["outoftime"],
+  "schedule": "nonOfficeHours",
   "separateMinorPatch": true
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,9 @@
 {
+  "automerge": true,
   "extends": ["config:base"],
+  "major": {
+    "automerge": false
+  },
   "masterIssue": true,
   "masterIssueAutoclose": true,
   "packageRules": [
@@ -173,10 +177,6 @@
       "prPriority": -1
     }
   ],
-  "patch": {
-    "automerge": true,
-    "prConcurrentLimit": 0
-  },
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
   "rebaseStalePrs": true,

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -181,6 +181,6 @@
   "prConcurrentLimit": 3,
   "rebaseStalePrs": true,
   "reviewers": ["outoftime"],
-  "schedule": "nonOfficeHours",
+  "schedule": "weekends",
   "separateMinorPatch": true
 }


### PR DESCRIPTION
Can’t remember a time when a minor version upgrade caused a breaking change that wasn’t caught in tests, so let’s have faith in semver.

To somewhat reduce the risk factor here, only perform dependency upgrades on weekends—makes it much more likely that any problem that slips through will be caught by instructors during lesson prep rather than in the classroom.