### PR TITLE
Test logics by running them through middleware in mock store

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,6 +376,7 @@
     "prettier": "1.19.1",
     "raw-loader": "4.0.0",
     "react-test-renderer": "16.12.0",
+    "redux-mock-store": "1.5.4",
     "redux-saga-test-plan": "4.0.0-rc.3",
     "rosie": "2.0.1",
     "script-ext-html-webpack-plugin": "2.1.4",

--- a/src/logic/__tests__/helpers.js
+++ b/src/logic/__tests__/helpers.js
@@ -1,0 +1,17 @@
+export async function processLogic({process, processOptions}, deps) {
+  const dispatchReturn =
+    'dispatchReturn' in processOptions
+      ? processOptions.dispatchReturn
+      : process.length === 1;
+
+  const dispatch = jest.fn();
+  if (dispatchReturn) {
+    const actionToDispatch = await process(deps);
+    dispatch(actionToDispatch);
+  } else {
+    await new Promise(resolve => {
+      process(deps, dispatch, resolve);
+    });
+  }
+  return dispatch;
+}

--- a/src/logic/__tests__/helpers.js
+++ b/src/logic/__tests__/helpers.js
@@ -1,17 +1,27 @@
-export async function processLogic({process, processOptions}, deps) {
-  const dispatchReturn =
-    'dispatchReturn' in processOptions
-      ? processOptions.dispatchReturn
-      : process.length === 1;
+import configureStore from 'redux-mock-store';
+import {createLogicMiddleware} from 'redux-logic';
+import {first} from 'rxjs/operators';
+import noop from 'lodash-es/noop';
 
-  const dispatch = jest.fn();
-  if (dispatchReturn) {
-    const actionToDispatch = await process(deps);
-    dispatch(actionToDispatch);
-  } else {
-    await new Promise(resolve => {
-      process(deps, dispatch, resolve);
-    });
-  }
-  return dispatch;
+export function makeTestLogic(logic) {
+  return async (action, {state = {}, afterDispatch = noop} = {}) => {
+    const logicMiddleware = createLogicMiddleware([logic]);
+    const mockStore = configureStore([logicMiddleware]);
+    const store = mockStore(state);
+
+    const logicDone = logicMiddleware.monitor$
+      .pipe(first(({op}) => op === 'end'))
+      .toPromise();
+
+    store.dispatch(action);
+    await Promise.resolve();
+    afterDispatch(store);
+    await logicDone;
+
+    const dispatch = jest.fn();
+    for (const dispatchedAction of store.getActions()) {
+      dispatch(dispatchedAction);
+    }
+    return dispatch;
+  };
 }

--- a/src/logic/__tests__/linkGithubIdentity.test.js
+++ b/src/logic/__tests__/linkGithubIdentity.test.js
@@ -6,10 +6,11 @@ import {bugsnagClient} from '../../util/bugsnag';
 import {
   accountMigrationNeeded,
   linkIdentityFailed,
+  linkGithubIdentity as linkGithubIdentityAction,
   identityLinked,
 } from '../../actions/user';
 
-import {processLogic} from './helpers';
+import {makeTestLogic} from './helpers';
 
 import {
   credentialFactory,
@@ -25,6 +26,8 @@ jest.mock('../../clients/github.js');
 jest.mock('../../util/bugsnag.js');
 
 describe('linkGithubIdentity', () => {
+  const testLogic = makeTestLogic(linkGithubIdentity);
+
   test('success', async () => {
     const mockCredential = credentialFactory.build();
     const mockUser = userFactory.build();
@@ -34,7 +37,7 @@ describe('linkGithubIdentity', () => {
       credential: mockCredential,
     });
 
-    const dispatch = await processLogic(linkGithubIdentity);
+    const dispatch = await testLogic(linkGithubIdentityAction());
     expect(dispatch).toHaveBeenCalledWith(
       identityLinked(mockUser, mockCredential),
     );
@@ -50,7 +53,7 @@ describe('linkGithubIdentity', () => {
     linkGithub.mockRejectedValue(error);
     getProfileForAuthenticatedUser.mockResolvedValue({data: githubProfile});
 
-    const dispatch = await processLogic(linkGithubIdentity);
+    const dispatch = await testLogic(linkGithubIdentityAction());
 
     expect(linkGithub).toHaveBeenCalledWith();
     expect(getProfileForAuthenticatedUser).toHaveBeenCalledWith(
@@ -67,7 +70,7 @@ describe('linkGithubIdentity', () => {
     linkGithub.mockRejectedValue(otherError);
     bugsnagClient.notify.mockResolvedValue();
 
-    const dispatch = await processLogic(linkGithubIdentity);
+    const dispatch = await testLogic(linkGithubIdentityAction());
     expect(linkGithub).toHaveBeenCalledWith();
     expect(bugsnagClient.notify).toHaveBeenCalledWith(otherError);
     expect(dispatch).toHaveBeenCalledWith(linkIdentityFailed(otherError));

--- a/src/logic/__tests__/linkGithubIdentity.test.js
+++ b/src/logic/__tests__/linkGithubIdentity.test.js
@@ -4,6 +4,14 @@ import {getProfileForAuthenticatedUser} from '../../clients/github';
 import {bugsnagClient} from '../../util/bugsnag';
 
 import {
+  accountMigrationNeeded,
+  linkIdentityFailed,
+  identityLinked,
+} from '../../actions/user';
+
+import {processLogic} from './helpers';
+
+import {
   credentialFactory,
   credentialInUseErrorFactory,
   firebaseErrorFactory,
@@ -26,19 +34,13 @@ describe('linkGithubIdentity', () => {
       credential: mockCredential,
     });
 
-    const {
-      type,
-      payload: {
-        credential: {providerId},
-        user,
-      },
-    } = await linkGithubIdentity.process();
+    const dispatch = await processLogic(linkGithubIdentity);
+    expect(dispatch).toHaveBeenCalledWith(
+      identityLinked(mockUser, mockCredential),
+    );
 
     expect(linkGithub).toHaveBeenCalledWith();
     expect(saveCredentialForCurrentUser).toHaveBeenCalledWith(mockCredential);
-    expect(type).toBe('IDENTITY_LINKED');
-    expect(providerId).toBe(mockCredential.providerId);
-    expect(user).toEqual(mockUser);
   });
 
   test('credential already in use', async () => {
@@ -46,21 +48,17 @@ describe('linkGithubIdentity', () => {
     const githubProfile = githubProfileFactory.build();
 
     linkGithub.mockRejectedValue(error);
-    getProfileForAuthenticatedUser.mockResolvedValue(githubProfile);
+    getProfileForAuthenticatedUser.mockResolvedValue({data: githubProfile});
 
-    const {
-      type,
-      payload: {
-        credential: {providerId, accessToken},
-      },
-    } = await linkGithubIdentity.process();
+    const dispatch = await processLogic(linkGithubIdentity);
+
     expect(linkGithub).toHaveBeenCalledWith();
     expect(getProfileForAuthenticatedUser).toHaveBeenCalledWith(
       error.credential.accessToken,
     );
-    expect(type).toBe('ACCOUNT_MIGRATION_NEEDED');
-    expect(providerId).toBe(error.credential.providerId);
-    expect(accessToken).toBe(error.credential.accessToken);
+    expect(dispatch).toHaveBeenCalledWith(
+      accountMigrationNeeded(githubProfile, error.credential),
+    );
   });
 
   test('other error', async () => {
@@ -69,15 +67,9 @@ describe('linkGithubIdentity', () => {
     linkGithub.mockRejectedValue(otherError);
     bugsnagClient.notify.mockResolvedValue();
 
-    const {
-      type,
-      error,
-      payload: {message},
-    } = await linkGithubIdentity.process();
+    const dispatch = await processLogic(linkGithubIdentity);
     expect(linkGithub).toHaveBeenCalledWith();
     expect(bugsnagClient.notify).toHaveBeenCalledWith(otherError);
-    expect(type).toBe('LINK_IDENTITY_FAILED');
-    expect(error).toBe(true);
-    expect(message).toBe(otherError.code);
+    expect(dispatch).toHaveBeenCalledWith(linkIdentityFailed(otherError));
   });
 });

--- a/src/logic/__tests__/logout.test.js
+++ b/src/logic/__tests__/logout.test.js
@@ -2,9 +2,11 @@ import logout from '../logout';
 
 import {signOut} from '../../clients/firebase';
 
+import {processLogic} from './helpers';
+
 jest.mock('../../clients/firebase.js');
 
 test('logOut', async () => {
-  await logout.process();
+  await processLogic(logout);
   expect(signOut).toHaveBeenCalledWith();
 });

--- a/src/logic/__tests__/logout.test.js
+++ b/src/logic/__tests__/logout.test.js
@@ -1,12 +1,17 @@
 import logout from '../logout';
+import {logOut as logOutAction} from '../../actions/user';
 
 import {signOut} from '../../clients/firebase';
 
-import {processLogic} from './helpers';
+import {makeTestLogic} from './helpers';
 
 jest.mock('../../clients/firebase.js');
 
-test('logOut', async () => {
-  await processLogic(logout);
-  expect(signOut).toHaveBeenCalledWith();
+describe('logout', () => {
+  const testLogic = makeTestLogic(logout);
+
+  test('calls sign out', async () => {
+    await testLogic(logOutAction());
+    expect(signOut).toHaveBeenCalledWith();
+  });
 });

--- a/src/logic/__tests__/startAccountMigration.test.js
+++ b/src/logic/__tests__/startAccountMigration.test.js
@@ -15,6 +15,8 @@ import {
 import {migrateAccount} from '../../clients/firebase';
 import {bugsnagClient} from '../../util/bugsnag';
 
+import {processLogic} from './helpers';
+
 import {
   credentialFactory,
   firebaseErrorFactory,
@@ -28,9 +30,6 @@ jest.mock('../../util/bugsnag');
 jest.useFakeTimers();
 
 describe('startAccountMigration', () => {
-  const dispatch = jest.fn();
-  const done = jest.fn();
-
   test('not dismissed during undo period, successful migration', async () => {
     const mockUser = userFactory.build();
     const mockCredential = credentialFactory.build();
@@ -51,11 +50,10 @@ describe('startAccountMigration', () => {
     });
 
     const emptyAction = new Observable();
-    const migrationDone = startAccountMigration.process(
-      {action$: emptyAction, getState: () => state},
-      dispatch,
-      done,
-    );
+    const migrationDone = processLogic(startAccountMigration, {
+      action$: emptyAction,
+      getState: () => state,
+    });
     jest.advanceTimersByTime(5000);
     await migrationDone;
 
@@ -80,11 +78,10 @@ describe('startAccountMigration', () => {
     bugsnagClient.notify.mockResolvedValue();
 
     const emptyAction = new Observable();
-    const migrationDone = startAccountMigration.process(
-      {action$: emptyAction, getState: () => state},
-      dispatch,
-      done,
-    );
+    const migrationDone = processLogic(startAccountMigration, {
+      action$: emptyAction,
+      getState: () => state,
+    });
     jest.advanceTimersByTime(5000);
     await migrationDone;
 
@@ -109,11 +106,10 @@ describe('startAccountMigration', () => {
       dismissAccountMigration(),
     );
 
-    await startAccountMigration.process(
-      {action$: cancelAction, getState: () => state},
-      dispatch,
-      done,
-    );
+    await processLogic(startAccountMigration, {
+      action$: cancelAction,
+      getState: () => state,
+    });
 
     expect(migrateAccount).not.toHaveBeenCalledWith(mockCredential);
   });

--- a/src/logic/__tests__/unlinkGithubIdentity.test.js
+++ b/src/logic/__tests__/unlinkGithubIdentity.test.js
@@ -1,15 +1,14 @@
 import unlinkGithubIdentity from '../unlinkGithubIdentity';
 
 import {unlinkGithub} from '../../clients/firebase';
+import {identityUnlinked} from '../../actions/user';
+
+import {processLogic} from './helpers';
 
 jest.mock('../../clients/firebase');
 
 test('should unlink Github Identity', async () => {
-  const {
-    type,
-    payload: {providerId},
-  } = await unlinkGithubIdentity.process();
+  const dispatch = await processLogic(unlinkGithubIdentity);
   expect(unlinkGithub).toHaveBeenCalledWith();
-  expect(type).toBe('IDENTITY_UNLINKED');
-  expect(providerId).toBe('github.com');
+  expect(dispatch).toHaveBeenCalledWith(identityUnlinked('github.com'));
 });

--- a/src/logic/__tests__/unlinkGithubIdentity.test.js
+++ b/src/logic/__tests__/unlinkGithubIdentity.test.js
@@ -1,14 +1,22 @@
 import unlinkGithubIdentity from '../unlinkGithubIdentity';
 
-import {unlinkGithub} from '../../clients/firebase';
-import {identityUnlinked} from '../../actions/user';
+import {
+  unlinkGithubIdentity as unlinkGithubIdentityAction,
+  identityUnlinked,
+} from '../../actions/user';
 
-import {processLogic} from './helpers';
+import {unlinkGithub} from '../../clients/firebase';
+
+import {makeTestLogic} from './helpers';
 
 jest.mock('../../clients/firebase');
 
-test('should unlink Github Identity', async () => {
-  const dispatch = await processLogic(unlinkGithubIdentity);
-  expect(unlinkGithub).toHaveBeenCalledWith();
-  expect(dispatch).toHaveBeenCalledWith(identityUnlinked('github.com'));
+describe('unlinkGithubIdentity', () => {
+  const testLogic = makeTestLogic(unlinkGithubIdentity);
+
+  test('should unlink Github Identity', async () => {
+    const dispatch = await testLogic(unlinkGithubIdentityAction());
+    expect(unlinkGithub).toHaveBeenCalledWith();
+    expect(dispatch).toHaveBeenCalledWith(identityUnlinked('github.com'));
+  });
 });

--- a/src/logic/startAccountMigration.js
+++ b/src/logic/startAccountMigration.js
@@ -25,6 +25,7 @@ export default createLogic({
     const shouldCancel = await Promise.race([continuePromise, cancelPromise]);
 
     if (shouldCancel) {
+      done();
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8572,6 +8572,11 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -11667,6 +11672,13 @@ redux-logic@2.1.1:
     is-promise "^2.1.0"
     loose-envify "^1.4.0"
     rxjs "^6.3.1"
+
+redux-mock-store@1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
+  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux-saga-test-plan@4.0.0-rc.3:
   version "4.0.0-rc.3"


### PR DESCRIPTION
Instead of exercising logics by calling the `process()` method directly, creates a `makeTestLogic` test helper that sets up a mock store with the `redux-logic` middleware configured with only the logic under test.

This change was initially motivated by an observation that several of our logic tests were relying on the implementation detail that our `process()` methods tend to be async methods that settle when the logic is done; however, in those cases, what actually matters is the `done()` callback being called.

After a first cut that created a test helper that replicated the way `redux-logic` handles different implementations of the `process()` method, I still didn’t like how much manual testing of Observables and such we had to do for the more advanced logics.

So, instead, test logics by running them through `redux-logic`. The test helper abstracts creating the middleware and mock store, so actual tests are still just concerned with the behavior of the logic. The helper returns a promise that resolves when the logic completes, by hooking into the global `monitor$` observable in `redux-logic`. Tests can optionally pass an `afterDispatch` function to trigger behaviors that the logic waits for.

It’s reasonable to question whether this approach really qualifies as unit testing—after all, we’re creating an entire Redux store to test behavior here—but I think it still fully qualifies. We’re still testing one particular software component (a logic) in isolation from the rest of our application; the question is just how to test that component most effectively. In the case of `redux-logic`, the behavior of the logic is the result of a fairly complex interaction between our code and library code; so testing it in the context of the library is the best way to ensure that it’s working the way we want.

As it happens, switching to the helper caught a bug in one of the logic’s implementations, which is fixed here as well.