### PR TITLE
Use official VS Code Stylelint extension

### DIFF
--- a/contrib/vscode/extensions.json
+++ b/contrib/vscode/extensions.json
@@ -9,7 +9,7 @@
     "gamunu.vscode-yarn",
     "github.vscode-pull-request-github",
     "msjsdiag.debugger-for-chrome",
-    "thibaudcolas.stylelint",
+    "stylelint.vscode-stylelint",
     "wix.glean",
     "wix.vscode-import-cost"
   ],

--- a/contrib/vscode/settings.json
+++ b/contrib/vscode/settings.json
@@ -13,12 +13,16 @@
   "files.insertFinalNewline": true,
   "npm.autoDetect": "off",
   "npm.packageManager": "yarn",
-  "stylelint.enable": false,
   "travis.username": "popcodeorg",
   "travis.repository": "popcode",
   "travis.pro": true,
   "typescript.npm": "./tools/npm.py",
   "yarn.bin": "./tools/yarn.py",
+  "[css]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": true
+    }
+  },
   "[javascript]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true


### PR DESCRIPTION
As of https://github.com/stylelint/vscode-stylelint/issues/4 , the new(?) official VS Code stylelint extension bundles the latest version of stylelint and supports auto-fixing. So, point to that as the recommended extension, and reenable stylelint validation in the VS Code development environment.