### PR TITLE
Add task for pull with interactive rebase

### DIFF
--- a/contrib/vscode/tasks.json
+++ b/contrib/vscode/tasks.json
@@ -109,6 +109,13 @@
           "PROFILE_BUILD": "true"
         }
       }
+    },
+    {
+      "label": "Git: Interactive rebase from upstream master",
+      "type": "shell",
+      "command": "git pull --rebase=interactive upstream master",
+      "problemMatcher": [],
+      "presentation": {"reveal": "silent"}
     }
   ]
 }


### PR DESCRIPTION
Adds a VS Code task to pull from `upstream/master` with interactive rebase. This is a common enough workflow and it’s not supported by VS Code’s built-in git integration.