### PR TITLE
Remove enumify from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,6 @@
     "css": "2.2.4",
     "delay": "4.3.0",
     "enum": "2.5.0",
-    "enumify": "1.0.4",
     "esprima": "4.0.1",
     "firebase": "7.7.0",
     "first-input-delay": "0.1.3",

--- a/src/validations/Validator.js
+++ b/src/validations/Validator.js
@@ -22,7 +22,7 @@ class Validator {
 
   mapError(rawError) {
     const key = this.keyForError(rawError);
-    if (has(this._errorMap, key)) {
+    if (has(this._errorMap, key.toString())) {
       return this._errorMap[key](rawError, this.source);
     }
     return null;

--- a/src/validations/html/rules/Code.js
+++ b/src/validations/html/rules/Code.js
@@ -1,10 +1,12 @@
-import {Enum} from 'enumify';
+import Enum from 'enum';
 
-export default class Code extends Enum {}
-Code.initEnum([
-  'MISPLACED_CLOSE_TAG',
-  'UNCLOSED_TAG',
-  'UNOPENED_TAG',
-  'INVALID_TEXT_OUTSIDE_BODY',
-  'INVALID_TAG_OUTSIDE_BODY',
-]);
+export default new Enum(
+  [
+    'MISPLACED_CLOSE_TAG',
+    'UNCLOSED_TAG',
+    'UNOPENED_TAG',
+    'INVALID_TEXT_OUTSIDE_BODY',
+    'INVALID_TAG_OUTSIDE_BODY',
+  ],
+  {name: 'Code'},
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4862,11 +4862,6 @@ enum@2.5.0:
   dependencies:
     is-buffer "^1.1.0"
 
-enumify@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/enumify/-/enumify-1.0.4.tgz#2bb6263071dd4551e54c55755707fad24a40cd7e"
-  integrity sha1-K7YmMHHdRVHlTFV1Vwf60kpAzX4=
-
 envify@^3.0.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/envify/-/envify-3.4.1.tgz#d7122329e8df1688ba771b12501917c9ce5cbce8"


### PR DESCRIPTION
Our preferred enum library is [enum](https://www.npmjs.com/package/enum), but [enumify](https://www.npmjs.com/package/enumify) snuck in there when I wasn’t paying attention. It’s got a goofy interface, which got goofier with the latest major version release. Just replace its one use in the codebase with enum.