### PR TITLE
Validator decodes HTML entities in error text

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "first-input-delay": "0.1.3",
     "github-api": "3.3.0",
     "hast-util-sanitize": "2.0.1",
+    "he": "^1.2.0",
     "highlight.js": "9.17.1",
     "html-inspector": "0.8.2",
     "htmllint": "0.8.0",

--- a/src/validations/Validator.js
+++ b/src/validations/Validator.js
@@ -1,3 +1,4 @@
+import {decode} from 'he';
 import i18next from 'i18next';
 import assign from 'lodash-es/assign';
 import compact from 'lodash-es/compact';
@@ -47,10 +48,12 @@ class Validator {
     const location = this.locationForError(rawError);
 
     return assign({}, location, error, {
-      text: remark()
-        .use(stripMarkdown)
-        .processSync(message)
-        .toString(),
+      text: decode(
+        remark()
+          .use(stripMarkdown)
+          .processSync(message)
+          .toString(),
+      ),
       raw: message,
       type: 'error',
     });


### PR DESCRIPTION
Attempt at a fix for #1685, adds `he` as a dependency.

Found that remark as called by Validator will return HTML instead of plain text. Right now this only produces error messages with all '<' characters encoded as '\&lt;', but it may affect future error messages with colons, ampersands, pipes and tildes as well.

I couldn't find a suitable addition to remark that would output plain text or decode the output of the last compiler step, so I opted to decode the result of the call to remark in Validator (line 52). 

Using the decode function from `he` seemed like the cleanest way to do this, but I know that adding a dependency might be poor form, so I'm open to defining a decode() function in Validator instead.