### PR TITLE
Added default project title to generateTextPreview()

### DIFF
--- a/src/util/compileProject.js
+++ b/src/util/compileProject.js
@@ -199,7 +199,7 @@ export async function addJavascript(doc, {sources: {javascript}}, opts) {
 
 export function generateTextPreview(project) {
   const {title} = constructDocument(project);
-  return (title || '').trim();
+  return (title || 'Untitled Project').trim();
 }
 
 export default async function compileProject(project, {isInlinePreview} = {}) {


### PR DESCRIPTION
Closes #2102

Modified generateTextPreview() to return "Untitled Project" instead of an empty string when project.title is empty or undefined. Tried both solutions suggested on the issue, but felt specifying a min-height in px was a bad call when flex handles most other sizing in the modal.

