### PR TITLE
Project picker tile sizes

### DIFF
--- a/src/css/application.css
+++ b/src/css/application.css
@@ -453,6 +453,7 @@ body {
   padding: 1em;
   border-bottom: 1px solid var(--color-light-gray);
   cursor: pointer;
+  height: 4.55vh;
 }
 
 .project-preview:hover {

--- a/src/util/compileProject.js
+++ b/src/util/compileProject.js
@@ -199,7 +199,7 @@ export async function addJavascript(doc, {sources: {javascript}}, opts) {
 
 export function generateTextPreview(project) {
   const {title} = constructDocument(project);
-  return (title || '').trim();
+  return (title || 'Untitled Project').trim();
 }
 
 export default async function compileProject(project, {isInlinePreview} = {}) {

--- a/src/util/compileProject.js
+++ b/src/util/compileProject.js
@@ -199,7 +199,7 @@ export async function addJavascript(doc, {sources: {javascript}}, opts) {
 
 export function generateTextPreview(project) {
   const {title} = constructDocument(project);
-  return (title || 'Untitled Project').trim();
+  return (title || '').trim();
 }
 
 export default async function compileProject(project, {isInlinePreview} = {}) {


### PR DESCRIPTION
Closes #2102

Attempted both of the fixes suggested in the issue, but in the end I just set project-preview height relative to the viewport. Rationale was:

- Adding a separate div to act as a spacer may muddy separation of style and content
- My approaches for cleanly setting default names and timestamps broke function purity
- Absence of a project name is a small (if messy) tell that something basic needs fixing