### PR TITLE
Source `normalize.css` from npm instead of bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "lodash": "^4.11.2",
-    "mustache.js": "mustache#^2.2.1",
-    "normalize-css": "normalize.css#^4.1.1"
+    "mustache.js": "mustache#^2.2.1"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ const codemirrorStylesheets = [
   'node_modules/codemirror/addon/lint/lint.css',
 ];
 const staticDir = path.join(srcDir, 'static');
-const bowerComponents = 'bower_components';
+const normalizeCssDir = 'node_modules/normalize.css';
 
 const postcssBrowsers = [];
 const supportedBrowsers = JSON.parse(
@@ -62,7 +62,7 @@ gulp.task('css', () => {
 
   return gulp
     .src([
-      path.join(bowerComponents, 'normalize-css/normalize.css'),
+      path.join(normalizeCssDir, 'normalize.css'),
       path.join(highlightStylesheetsDir, 'github.css'),
       ...codemirrorStylesheets,
       path.join(stylesheetsDir, '**/*.css'),

--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
     "mixpanel-browser": "2.35.0",
     "moment": "2.24.0",
     "mousetrap": "1.6.5",
+    "normalize.css": "8.0.1",
     "object-inspect": "1.7.0",
     "offline-plugin": "5.0.7",
     "p5": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9775,6 +9775,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+normalize.css@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
+  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
 now-and-later@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz#8e579c8685764a7cc02cb680380e94f43ccb1f7c"


### PR DESCRIPTION
This also upgrades us from 4.1.1 -> 8.0.1. Diffing these two versions
makes it look like the changes are not trivial but a visual inspection
turns up no obvious visual regressions.

Partially Fixes: #1442