### PR TITLE
fix(deps): Downgrade highlight.js

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -105,6 +105,11 @@
       "allowedVersions": "< 0.7.0"
     },
     {
+      "packageNames": ["highlight.js"],
+      "allowedVersions": "< 10.1 || > 10.1.2",
+      "automerge": false
+    },
+    {
       "groupName": "stylelint",
       "automerge": true,
       "packageNames": [

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "github-api": "3.3.0",
     "hast-util-sanitize": "2.0.3",
     "he": "1.2.0",
-    "highlight.js": "10.1.2",
+    "highlight.js": "10.0.3",
     "html-inspector": "0.8.2",
     "htmllint": "0.8.0",
     "i18next": "19.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6838,10 +6838,10 @@ highlight-es@^1.0.0:
     is-es2016-keyword "^1.0.0"
     js-tokens "^3.0.0"
 
-highlight.js@10.1.2:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.2.tgz#c20db951ba1c22c055010648dfffd7b2a968e00c"
-  integrity sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==
+highlight.js@10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.0.3.tgz#5effcc58420f113f279a0badb8ac50c4be06e63b"
+  integrity sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==
 
 highlight.js@~9.16.0:
   version "9.16.2"


### PR DESCRIPTION
Downgrades `highlight.js` to 10.0, prior to the introduction of the `SHEBANG` utility which seems to have caused a regression.

Renovate is configured to only upgrade when a new version is released, and not to automerge when that happens.

Fixes #2336 