### PR TITLE
chore(tests): Skip environment setup when running Jest debugger

### DIFF
--- a/contrib/vscode/launch.json
+++ b/contrib/vscode/launch.json
@@ -35,7 +35,7 @@
       "disableOptimisticBPs": true,
       "sourceMaps": true,
       "timeout": 30000,
-      "env": {"NODE_ENV": "test"}
+      "env": {"NODE_ENV": "test", "SKIP_POPCODE_SETUP": "true"}
     }
   ]
 }

--- a/tools/node.py
+++ b/tools/node.py
@@ -2,7 +2,8 @@
 
 from util import nodeenv_delegate
 from setup import setup
+import os
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup()
-    nodeenv_delegate('node')
+    nodeenv_delegate("node")

--- a/tools/npx.py
+++ b/tools/npx.py
@@ -3,6 +3,6 @@
 from util import nodeenv_delegate
 from setup import setup
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(skip_dependencies=True)
-    nodeenv_delegate('npx')
+    nodeenv_delegate("npx")

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -15,89 +15,104 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
-from util import (
-    NODEENV_DIR,
-    POPCODE_ROOT,
-    run_in_nodeenv,
-    run_and_capture_in_nodeenv)
+from util import NODEENV_DIR, POPCODE_ROOT, run_in_nodeenv, run_and_capture_in_nodeenv
 
-NODEENV_VERSION = '1.3.3'
+NODEENV_VERSION = "1.3.3"
+
 
 def _normalize_version_string(version_string):
-    return re.sub('^\\D+', '', version_string.strip())
+    return re.sub("^\\D+", "", version_string.strip())
 
-with open(os.path.join(POPCODE_ROOT, 'package.json')) as package_json:
-    engines = json.load(package_json)['engines']
-    NODE_VERSION = _normalize_version_string(engines['node'])
-    YARN_VERSION =  _normalize_version_string(engines['yarn'])
+
+with open(os.path.join(POPCODE_ROOT, "package.json")) as package_json:
+    engines = json.load(package_json)["engines"]
+    NODE_VERSION = _normalize_version_string(engines["node"])
+    YARN_VERSION = _normalize_version_string(engines["yarn"])
+
 
 def _is_nodeenv_installed():
     return os.path.exists(NODEENV_DIR)
 
+
 def _is_nodeenv_node_version_correct():
     version = _normalize_version_string(
-        run_and_capture_in_nodeenv(['node', '--version']))
+        run_and_capture_in_nodeenv(["node", "--version"])
+    )
     return version == NODE_VERSION
+
 
 def _install_nodeenv():
     nodeenv_tmpdir = tempfile.mkdtemp()
     nodeenv_zip_response = urlopen(
-        'https://github.com/ekalinin/nodeenv/archive/'
-        + NODEENV_VERSION
-        + '.zip')
+        "https://github.com/ekalinin/nodeenv/archive/" + NODEENV_VERSION + ".zip"
+    )
     nodeenv_zip_bytes = BytesIO(nodeenv_zip_response.read())
     nodeenv_zip_response.close()
     nodeenv_zip = ZipFile(nodeenv_zip_bytes)
     nodeenv_zip.extractall(nodeenv_tmpdir)
-    return os.path.join(nodeenv_tmpdir, 'nodeenv-' + NODEENV_VERSION)
+    return os.path.join(nodeenv_tmpdir, "nodeenv-" + NODEENV_VERSION)
+
 
 def _create_nodeenv(nodeenv_package_dir):
-    subprocess.call([
-        'python',
-        os.path.join(nodeenv_package_dir, 'nodeenv.py'),
-        '--node=' + NODE_VERSION, NODEENV_DIR])
+    subprocess.call(
+        [
+            "python",
+            os.path.join(nodeenv_package_dir, "nodeenv.py"),
+            "--node=" + NODE_VERSION,
+            NODEENV_DIR,
+        ]
+    )
+
 
 def _is_yarn_version_correct():
     try:
         version = _normalize_version_string(
-            run_and_capture_in_nodeenv(['yarn', '--version']))
+            run_and_capture_in_nodeenv(["yarn", "--version"])
+        )
         return version == YARN_VERSION
     except subprocess.CalledProcessError:
         return False
 
+
 def _install_yarn():
-    run_in_nodeenv(['npm', 'config', 'set', 'update-notifier', 'false'])
-    run_in_nodeenv(['npm',
-                    'install',
-                    '--quiet',
-                    '--global',
-                    'yarn@{yarn_version}'.format(yarn_version=YARN_VERSION)])
+    run_in_nodeenv(["npm", "config", "set", "update-notifier", "false"])
+    run_in_nodeenv(
+        [
+            "npm",
+            "install",
+            "--quiet",
+            "--global",
+            "yarn@{yarn_version}".format(yarn_version=YARN_VERSION),
+        ]
+    )
+
 
 def _install_dependencies():
-    run_in_nodeenv(['yarn',
-                    'install',
-                    '--frozen-lockfile',
-                    '--non-interactive',
-                    '--no-progress'])
+    run_in_nodeenv(
+        ["yarn", "install", "--frozen-lockfile", "--non-interactive", "--no-progress"]
+    )
+
 
 def _symlink_vscode_config():
-    vscode_dir = os.path.join(POPCODE_ROOT, '.vscode')
+    vscode_dir = os.path.join(POPCODE_ROOT, ".vscode")
     if not os.path.exists(vscode_dir):
-        os.symlink(os.path.join('contrib', 'vscode'), vscode_dir)
-        gitignore_path = os.path.join(POPCODE_ROOT, '.git', 'info', 'exclude')
+        os.symlink(os.path.join("contrib", "vscode"), vscode_dir)
+        gitignore_path = os.path.join(POPCODE_ROOT, ".git", "info", "exclude")
         if not os.path.exists(os.path.dirname(gitignore_path)):
             os.mkdir(os.path.dirname(gitignore_path))
         needs_vscode_in_gitignore = True
         if os.path.exists(gitignore_path):
-            with open(gitignore_path, 'r') as gitignore_r:
-                needs_vscode_in_gitignore = not '.vscode' in gitignore_r
+            with open(gitignore_path, "r") as gitignore_r:
+                needs_vscode_in_gitignore = not ".vscode" in gitignore_r
         if needs_vscode_in_gitignore:
-            with open(gitignore_path, 'a') as gitignore_a:
-                gitignore_a.writelines(['/.vscode\n'])
+            with open(gitignore_path, "a") as gitignore_a:
+                gitignore_a.writelines(["/.vscode\n"])
+
 
 def _print_success_message():
-    yarn_path = os.path.join('tools', 'yarn.py')
-    print("""
+    yarn_path = os.path.join("tools", "yarn.py")
+    print(
+        """
 ================================================================================
 
 Your development environment is ready! To run your development server, type:
@@ -107,9 +122,15 @@ Your development environment is ready! To run your development server, type:
 To run tests in watch mode type:
 
   {yarn_path} run autotest
-""".format(yarn_path=yarn_path))
+""".format(
+            yarn_path=yarn_path
+        )
+    )
+
 
 def setup(skip_dependencies=False):
+    if "SKIP_POPCODE_SETUP" in os.environ:
+        return
     if _is_nodeenv_installed() and not _is_nodeenv_node_version_correct():
         shutil.rmtree(NODEENV_DIR)
     if not _is_nodeenv_installed():
@@ -120,6 +141,7 @@ def setup(skip_dependencies=False):
     if not skip_dependencies:
         _install_dependencies()
     _symlink_vscode_config()
+
 
 if __name__ == "__main__":
     setup()

--- a/tools/teardown.py
+++ b/tools/teardown.py
@@ -4,10 +4,12 @@ import shutil
 from util import POPCODE_ROOT, NODEENV_DIR
 from os import path
 
+
 def teardown():
     shutil.rmtree(NODEENV_DIR)
-    shutil.rmtree(path.join(POPCODE_ROOT, 'node_modules'))
-    shutil.rmtree(path.join(POPCODE_ROOT, 'bower_components'))
+    shutil.rmtree(path.join(POPCODE_ROOT, "node_modules"))
+    shutil.rmtree(path.join(POPCODE_ROOT, "bower_components"))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     teardown()

--- a/tools/yarn.py
+++ b/tools/yarn.py
@@ -5,16 +5,16 @@ from setup import setup
 from util import nodeenv_delegate
 
 YARN_DEPENDENCY_MANAGEMENT_COMMANDS = [
-    'add',
-    'install',
-    'link',
-    'remove',
-    'unlink',
-    'upgrade',
-    'upgrade-interactive'
+    "add",
+    "install",
+    "link",
+    "remove",
+    "unlink",
+    "upgrade",
+    "upgrade-interactive",
 ]
 
-if __name__ == '__main__':
-    command = next((arg for arg in sys.argv[1:] if not arg.startswith('-')), 'install')
+if __name__ == "__main__":
+    command = next((arg for arg in sys.argv[1:] if not arg.startswith("-")), "install")
     setup(skip_dependencies=(command in YARN_DEPENDENCY_MANAGEMENT_COMMANDS))
-    nodeenv_delegate('yarn')
+    nodeenv_delegate("yarn")


### PR DESCRIPTION
Running the setup script causes one of the node processes run by setup to capture the debugging session. Since it’s vanishingly unlikely that one would run the Jest debugger directly after pulling updates, we just skip the setup step when running the Jest process that needs to run the debugger.

Also applies Black formatting to all our Python setup scripts, sorry.