### PR TITLE
Enable sublime keymap from CodeMirror

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -13,6 +13,8 @@ import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/edit/matchbrackets';
 import 'codemirror/addon/lint/lint';
 import 'codemirror/addon/selection/active-line';
+import 'codemirror/addon/comment/comment';
+import 'codemirror/keymap/sublime';
 
 import {EditorLocation} from '../records';
 import bowser from '../services/bowser';
@@ -50,6 +52,7 @@ export default function Editor({
       lineWrapping: true,
       matchBrackets: true,
       styleActiveLine: true,
+      keyMap: 'sublime',
     }));
     editor.setSize('100%', '100%');
   }, []);


### PR DESCRIPTION
@paulproteus and I found that the commenting function called by Cmd-/ is one of several keyboard shortcuts included with the 'sublime' keymap of CodeMirror, so this commit just enables that whole shebang documented here: https://codemirror.net/demo/sublime.html 

Also imports the Comment addon from CodeMirror because it's called in the keymap to toggle comment.

Caveat: This may not include Windows-friendly commands, as the cmd button is specified in the keymap. 

Close #2276