### PR TITLE
Don’t upgrade to Webpack 5

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -127,6 +127,10 @@
       "packageNames": ["webpack", "webpack-dev-middleware"]
     },
     {
+      "packageNames": ["webpack"],
+      "allowedVersions": "< 5.0"
+    },
+    {
       "packageNames": ["yarn"],
       "allowedVersions": "< 2.0"
     },


### PR DESCRIPTION
We rely on `script-ext-html-webpack-plugin` which doesn’t support Webpack 5 and [apparently never will](https://github.com/numical/script-ext-html-webpack-plugin#deprecation-warning). Webpack 4 is fine for now.