### PR TITLE
Make multiple alerts queue, like blocking vanilla js alert()

### DIFF
--- a/src/previewSupport/overrideAlert.js
+++ b/src/previewSupport/overrideAlert.js
@@ -1,10 +1,23 @@
 import Swal from 'sweetalert2';
 
 export default function overrideAlert() {
+  let pendingAlerts = [];
+
   Object.defineProperties(window, {
     alert: {
-      value: message => {
-        Swal.fire({text: String(message)});
+      value: async message => {
+        if (pendingAlerts.length) {
+          pendingAlerts.push(message);
+          return;
+        }
+
+        pendingAlerts.push(message);
+
+        for (const pendingAlert of pendingAlerts) {
+          // eslint-disable-next-line no-await-in-loop
+          await Swal.fire({text: String(pendingAlert)});
+        }
+        pendingAlerts = [];
       },
       configurable: true,
     },


### PR DESCRIPTION
Currently if you have multiple alert calls, only the last one will be
seen:

```js
[1,2,3].forEach(alert); // shows a SweetAlert with 3
```

However in a standard browser, or the "popped out" document, it will
display first an alert with 1, then with 2, then 3.

A bit of personal backstory here: I learned how to program in part
watching [Simon Allardice's Foundations of
Programming](https://www.youtube.com/watch?v=LDPQ3TJtuDU&list=PLv-eQL7zVNdxfNVHmayusdXGRu0aJu5EQ) on Lynda, and the language-agnostic
course used javascript since everybody already has a browser and
`alert()` to show the result of values.

I think it's pretty useful to be able to do something like

```
let a = 3;
alert(a);
a = 5;
alert(a);
```

and this patch enables it.

You can do a similar thing with console.log, but all the results show up
at once, and they're hidden in the console.

This patch messy and untested, but I'm curious to see if there's any interest
in incorporating something like this.