### PR TITLE
set title width to fill available area and truncate any additional text

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -54,7 +54,7 @@ export default function Preview({
         <span className="preview__button preview__button_pop-out">
           <FontAwesomeIcon icon={faExternalLinkAlt} onClick={onPopOutProject} />
         </span>
-        {title}
+        <span className="preview__title-text">{title}</span>
         <span className="preview__button preview__button_toggle-visibility">
           <FontAwesomeIcon
             icon={faChevronDown}

--- a/src/css/application.css
+++ b/src/css/application.css
@@ -867,8 +867,12 @@ body {
   z-index: 2;
 }
 
-.preview__title {
-  text-align: center;
+.preview__title-text {
+  display: inline-block;
+  max-width: calc(100% - 75px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .preview__button {


### PR DESCRIPTION
In this commit the following changes are made:

- Eliminated an unused selector in css `.preview__title`
- Added a selector `.preview__title-text`
- Added rules to limit title text to no more than 100% width minus 75px for the three icons in the same row
- Truncated the title when there is not enough room to display the full text

Note: the title is still centered as the parent element has `text-align:center;`

<img width="463" alt="Screen Shot 2023-04-01 at 7 08 46 PM" src="https://user-images.githubusercontent.com/692461/229321719-1a47b624-6007-4a02-ac6c-6633afaf9b7f.png">
<img width="654" alt="Screen Shot 2023-04-01 at 7 08 39 PM" src="https://user-images.githubusercontent.com/692461/229321736-2145d76e-48cd-416b-bc5d-bff0bd0fe360.png">

